### PR TITLE
Add CI gate jobs for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,30 @@ jobs:
           name: test-results-${{ matrix.os }}-node-${{ matrix.node-version }}-shard-${{ matrix.shard }}
           path: test-results.xml
 
+  test-gate:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check test matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Test matrix failed: ${{ needs.test.result }}"
+            exit 1
+          fi
+
+  build-and-install-gate:
+    runs-on: ubuntu-latest
+    needs: build-and-install
+    if: always()
+    steps:
+      - name: Check build-and-install matrix result
+        run: |
+          if [ "${{ needs.build-and-install.result }}" != "success" ]; then
+            echo "Build-and-install matrix failed: ${{ needs.build-and-install.result }}"
+            exit 1
+          fi
+
   test-results:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
## Summary
- Branch protection required checks named `test` and `build-and-install`, but matrix jobs report as `test (ubuntu-latest, 1, 20)` etc. — never matching exactly
- This caused "Waiting for status to be reported" on all PRs
- Adds `test-gate` and `build-and-install-gate` jobs that aggregate matrix results into a single check name
- Branch protection already updated to require `lint`, `test-gate`, `build-and-install-gate`

## Test plan
- [ ] Verify this PR's own checks show `test-gate` and `build-and-install-gate` as passing
- [ ] After merge, rebase other open PRs on main and confirm they no longer show "Waiting for status to be reported"

🤖 Generated with [Claude Code](https://claude.com/claude-code)