### PR TITLE
fix: use RELEASE_PAT for version bump push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Validate version input
         run: |


### PR DESCRIPTION
## Summary
- Use fine-grained PAT (`RELEASE_PAT`) for checkout in release workflow so version-bump commits can be pushed to `main` past branch protection
- `GITHUB_TOKEN` is still used for CI checks, GitHub Release creation, and npm publish (OIDC)

## Context
Branch protection requires PRs and status checks. `GITHUB_TOKEN` cannot bypass these when pushing the version-bump commit during releases. A fine-grained PAT scoped to `contents:write` on this repo only is used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)