### PR TITLE
feat: show next possible versions in release workflow

### DIFF
--- a/.github/scripts/update-version-refs.cjs
+++ b/.github/scripts/update-version-refs.cjs
@@ -20,3 +20,15 @@ for (const file of ['docs/getting-started.md']) {
   );
   fs.writeFileSync(file, content);
 }
+
+// Update release workflow description with next possible versions
+const [major, minor, patch] = version.split('.').map(Number);
+const nextPatch = `${major}.${minor}.${patch + 1}`;
+const nextMinor = `${major}.${minor + 1}.0`;
+const nextMajor = `${major + 1}.0.0`;
+const releaseYml = fs.readFileSync('.github/workflows/release.yml', 'utf-8');
+const updatedYml = releaseYml.replace(
+  /description: 'Release version \(e\.g\. [^']+\)'/,
+  `description: 'Release version (e.g. ${nextPatch}, ${nextMinor}, ${nextMajor})'`
+);
+fs.writeFileSync('.github/workflows/release.yml', updatedYml);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 1.2.0)'
+        description: 'Release version (e.g. 0.0.11, 0.1.0, 1.0.0)'
         required: true
         type: string
 
@@ -79,7 +79,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json docs/getting-started.md
+          git add package.json docs/getting-started.md .github/workflows/release.yml
           git commit -m "chore: release v${{ inputs.version }}"
           git push
 


### PR DESCRIPTION
## Summary
- Release workflow description now shows next patch/minor/major versions (e.g. "0.0.12, 0.1.0, 1.0.0")
- `update-version-refs.cjs` automatically updates the description during each release
- Release workflow now commits `release.yml` alongside `package.json` and `docs/getting-started.md`

## Test plan
- [x] Tested `update-version-refs.cjs` locally — correctly computes next versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)