### PR TITLE
fix: improve scan log message and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ test-results.xml
 
 .vscode
 
-# External checks config (private repo cloned as subfolder)
+# Other repos (cloned as subfolders)
 checks-config/
+checks-config-public/
 
 # Test codebases (live in external repo)
 test-codebases/

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -627,7 +627,7 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
   const startTime = new Date();
   const version = await getVersion();
 
-  logProgress(TAG, `Starting multi-check scan ${scanId} (${checks.length} checks)`);
+  logProgress(TAG, `Starting scan ${scanId} (${checks.length} ${checks.length === 1 ? 'check' : 'checks'})`);
   logDebug(TAG, `Repository: ${repositoryPath}`);
 
   // Use pre-analyzed repository info if provided, otherwise analyze here


### PR DESCRIPTION
## Summary

- Fix misleading "Starting multi-check scan" log message — now says "Starting scan" with correct singular/plural ("1 check" vs "3 checks")
- Add `checks-config-public/` to `.gitignore`

## Test plan

- [ ] Run scan with single check, verify log says "1 check" not "multi-check scan"
- [ ] Run scan with multiple checks, verify log says "N checks"
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)