### PR TITLE
fix: remove AGHAST_LOCAL_CLAUDE hint from error messages

### DIFF
--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -73,7 +73,7 @@ export class ClaudeCodeProvider implements AIProvider {
       this.model = config.model;
     }
     if (!this.apiKey && !this.useLocalClaude) {
-      throw new Error('ANTHROPIC_API_KEY is required (or set AGHAST_LOCAL_CLAUDE=true to use your local Claude Code session)');
+      throw new Error('ANTHROPIC_API_KEY is required');
     }
     if (this.useLocalClaude) {
       logProgress(TAG, 'Using local Claude Code session for authentication');

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,7 +376,7 @@ export async function runScan(args: string[]): Promise<void> {
 
     // Validate ANTHROPIC_API_KEY (not needed when using mock or local Claude)
     if (!process.env.ANTHROPIC_API_KEY && process.env.AGHAST_LOCAL_CLAUDE !== 'true') {
-      console.error(formatError(ERROR_CODES.E3001, 'ANTHROPIC_API_KEY environment variable is required (or set AGHAST_LOCAL_CLAUDE=true)'));
+      console.error(formatError(ERROR_CODES.E3001, 'ANTHROPIC_API_KEY environment variable is required'));
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary
- Remove references to `AGHAST_LOCAL_CLAUDE` from user-facing error messages in `src/index.ts` and `src/claude-code-provider.ts`
- `AGHAST_LOCAL_CLAUDE` is an undocumented feature and should not be surfaced to users

## Test plan
- [x] All 486 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)