### PR TITLE
fix: detect 'not logged in' and fail immediately

### DIFF
--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -196,6 +196,14 @@ export class ClaudeCodeProvider implements AIProvider {
               throw new FatalProviderError(`AI provider authentication failed (401): ${authErrorMatch}`);
             }
 
+            // Detect login required — fail immediately, unrecoverable without user action
+            const loginRequiredMatch = textChunks.find((t: string) =>
+              /not logged in/i.test(t),
+            );
+            if (loginRequiredMatch) {
+              throw new FatalProviderError(`AI provider not logged in: ${loginRequiredMatch}. Please authenticate before running scans.`);
+            }
+
             // Detect API errors surfaced as assistant text by the SDK
             const apiErrorMatch = textChunks.find((t: string) => t.includes('API Error:'));
             if (apiErrorMatch) {

--- a/tests/claude-code-provider.test.ts
+++ b/tests/claude-code-provider.test.ts
@@ -337,6 +337,29 @@ describe('ClaudeCodeProvider: fatal error handling (401 auth)', () => {
   });
 });
 
+describe('ClaudeCodeProvider: fatal error handling (not logged in)', () => {
+  it('throws FatalProviderError immediately on "Not logged in" message', async () => {
+    const messages = [
+      assistantMsg('Not logged in · Please run /login'),
+      // Should never reach these
+      assistantMsg('This should not be reached'),
+      successResult(),
+    ];
+
+    const provider = new ClaudeCodeProvider({ _queryFn: createFakeQueryFn(messages) });
+    await provider.initialize({ apiKey: 'test-key' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test prompt', '/tmp/repo'),
+      (err: Error) => {
+        assert.ok(err instanceof FatalProviderError, 'Should be FatalProviderError');
+        assert.match(err.message, /not logged in/i);
+        return true;
+      },
+    );
+  });
+});
+
 describe('ClaudeCodeProvider: enableDebug', () => {
   it('enableDebug method exists and does not throw', async () => {
     const provider = new ClaudeCodeProvider({ _queryFn: createFakeQueryFn([successResult()]) });


### PR DESCRIPTION
## Summary

- Detect "Not logged in" messages from the Claude Code SDK and throw `FatalProviderError` immediately, preventing infinite loops when the session is unauthenticated
- Add unit test for the new detection

Fixes #14

## Test plan

- [x] New unit test: `throws FatalProviderError immediately on "Not logged in" message`
- [x] All existing tests pass (487 pass, 0 fail)
- [ ] Manual test: run aghast with an unauthenticated session and verify it exits with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)