### PR TITLE
Clean up AI progress logging, add release CI wait

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,16 +61,40 @@ jobs:
         run: |
           SHA=$(git rev-parse HEAD)
           echo "Checking CI status for $SHA"
-          RESULT=$(gh run list --commit "$SHA" --workflow CI --json conclusion --jq '.[0].conclusion // empty')
-          if [ -z "$RESULT" ]; then
-            echo "::error::No CI run found for commit $SHA. Ensure CI has run on main before releasing."
-            exit 1
-          fi
-          if [ "$RESULT" != "success" ]; then
-            echo "::error::CI did not pass on commit $SHA (conclusion: $RESULT). Fix CI before releasing."
-            exit 1
-          fi
-          echo "CI passed on $SHA"
+
+          MAX_WAIT=600  # 10 minutes
+          INTERVAL=15
+          ELAPSED=0
+
+          while true; do
+            RUN_JSON=$(gh run list --commit "$SHA" --workflow CI --json conclusion,status --jq '.[0] // empty')
+            if [ -z "$RUN_JSON" ]; then
+              echo "::error::No CI run found for commit $SHA. Ensure CI has run on main before releasing."
+              exit 1
+            fi
+
+            STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+            CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion // empty')
+
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "CI passed on $SHA"
+                break
+              else
+                echo "::error::CI did not pass on commit $SHA (conclusion: $CONCLUSION). Fix CI before releasing."
+                exit 1
+              fi
+            fi
+
+            # CI is still running — wait
+            if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+              echo "::error::Timed out waiting for CI on commit $SHA (status: $STATUS after ${ELAPSED}s)"
+              exit 1
+            fi
+            echo "CI is $STATUS on $SHA — waiting ${INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s elapsed)"
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
 
       - name: Update version references
         run: node .github/scripts/update-version-refs.cjs ${{ inputs.version }}

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -146,7 +146,7 @@ export class ClaudeCodeProvider implements AIProvider {
       const silentSeconds = Math.round((Date.now() - lastActivityTime) / 1000);
       if (silentSeconds >= HEARTBEAT_INTERVAL_MS / 1000) {
         const status = currentToolName ? `running ${currentToolName}` : 'waiting';
-        logProgress(TAG, `${prefix}Still ${status}... (${timer.elapsedStr()})`);
+        logDebug(TAG, `${prefix}Still ${status}... (${timer.elapsedStr()})`);
       }
     }, HEARTBEAT_INTERVAL_MS);
 
@@ -157,14 +157,14 @@ export class ClaudeCodeProvider implements AIProvider {
       if (message.type === 'tool_progress') {
         const progress = message as { tool_name: string; elapsed_time_seconds: number };
         currentToolName = progress.tool_name;
-        logProgress(TAG, `${prefix}Running ${progress.tool_name}... (${Math.round(progress.elapsed_time_seconds)}s)`);
+        logDebug(TAG, `${prefix}Running ${progress.tool_name}... (${Math.round(progress.elapsed_time_seconds)}s)`);
       }
 
       if (message.type === 'assistant') {
         turnCount++;
         currentToolName = undefined;
-        // Simple activity indicator at info level
-        logProgress(TAG, `${prefix}Turn ${turnCount} (${timer.elapsedStr()})`);
+        // Activity indicator at debug level (scan-runner provides periodic summary at info)
+        logDebug(TAG, `${prefix}Turn ${turnCount} (${timer.elapsedStr()})`);
 
         const content = (message as any).message?.content;
         if (Array.isArray(content)) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -341,7 +341,7 @@ export function createTimer(): { elapsed: () => number; elapsedStr: () => string
       const ms = Date.now() - start;
       if (ms < 1000) return `${ms}ms`;
       if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-      return `${(ms / 60000).toFixed(1)}m`;
+      return `${(ms / 60000).toFixed(2)}m`;
     },
   };
 }

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -453,6 +453,11 @@ async function executeTargetedCheck(
 
     logProgress(TAG, `Found ${targets.length} targets to analyze (concurrency: ${effectiveConcurrency})`);
 
+    // Progress summary timer — logs a periodic overview at info level (every 15s)
+    const PROGRESS_INTERVAL_MS = 15000;
+    const progressTimer = createTimer();
+    let inProgressCount = 0;
+
     // 5. Resolve generic prompt: CLI override > analysisMode prompt > discovery default
     const analysisModePrompts: Record<string, string> = {
       'false-positive-validation': 'false-positive-validation.md',
@@ -467,10 +472,20 @@ async function executeTargetedCheck(
     const abortHandle: AbortHandle = { aborted: false };
 
     // 6. Analyze targets concurrently — pipeline is generic, no discovery conditionals
-    const targetResults = await mapWithConcurrency(
+    const logProgressSummary = () => {
+      const pending = targets.length - completedCount - inProgressCount;
+      logProgress(TAG, `AI progress [${targets.length} targets]: ${completedCount} complete, ${inProgressCount} in progress, ${pending} pending (${progressTimer.elapsedStr()})`);
+    };
+    logProgressSummary();
+    const progressInterval = setInterval(logProgressSummary, PROGRESS_INTERVAL_MS);
+
+    let targetResults: { issues: SecurityIssue[]; error: boolean; flagged: boolean; tokenUsage: TokenUsage | undefined }[];
+    try {
+    targetResults = await mapWithConcurrency(
       targets,
       effectiveConcurrency,
       async (target, _idx) => {
+        inProgressCount++;
         try {
           const prompt = basePrompt + (target.promptEnrichment ?? '');
 
@@ -506,12 +521,16 @@ async function executeTargetedCheck(
           logDebug(TAG, `${target.label} Error: ${errorMsg}`);
           return { issues: [] as SecurityIssue[], error: true, flagged: false, tokenUsage: undefined };
         } finally {
+          inProgressCount--;
           completedCount++;
-          logProgress(TAG, `Progress: ${completedCount}/${targets.length} targets analyzed`);
+          logDebug(TAG, `Progress: ${completedCount}/${targets.length} targets analyzed`);
         }
       },
       abortHandle,
     );
+    } finally {
+      clearInterval(progressInterval);
+    }
 
     // 7. Aggregate results
     const allIssues: SecurityIssue[] = [];

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -962,8 +962,8 @@ describe('CLI mock mode: concurrency progress output', () => {
     );
     const combined = stdout + stderr;
     assert.ok(
-      combined.includes('targets analyzed'),
-      'Should log progress with "targets analyzed"',
+      combined.includes('targets to analyze'),
+      'Should log target count with "targets to analyze"',
     );
     assert.ok(
       combined.includes('concurrency:'),


### PR DESCRIPTION
## Summary

- **Quieter AI progress logging**: Moved per-turn and per-tool heartbeat messages from info to debug level in the AI provider. The scan runner now provides a periodic summary (every 15s) at info level showing complete/in-progress/pending target counts, replacing the noisy per-target progress lines.
- **Timer precision**: Increased minute-level elapsed time display from 1 to 2 decimal places for better granularity on longer scans.
- **Release workflow**: The CI verification step now polls for up to 10 minutes if a CI run is in-progress, instead of failing immediately. Still fails immediately if no CI run exists or if CI completed with a failure.

## Test plan

- [x] Run `npm test` — verify all tests pass
- [x] Verify the concurrency progress test now checks for "targets to analyze" message
- [x] Review release workflow CI wait loop logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)