### PR TITLE
Update package-lock.json during release version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,15 @@ jobs:
           done
 
       - name: Update version references
-        run: node .github/scripts/update-version-refs.cjs ${{ inputs.version }}
+        run: |
+          node .github/scripts/update-version-refs.cjs ${{ inputs.version }}
+          npm install --package-lock-only
 
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json docs/getting-started.md .github/workflows/release.yml
+          git add package.json package-lock.json docs/getting-started.md .github/workflows/release.yml
           git commit -m "chore: release v${{ inputs.version }}"
           git push
 


### PR DESCRIPTION
## Summary

- The release workflow updates `package.json` version but was not regenerating `package-lock.json`, causing the lock file to have a stale version after every release
- Added `npm install --package-lock-only` after the version update step
- Added `package-lock.json` to the staged files in the version bump commit

## Test plan

- [ ] Next release should show `package-lock.json` in the version bump commit
- [ ] `npm ci` should still work correctly in the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)