### PR TITLE
Add --ignore-scripts to release lockfile update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Update version references
         run: |
           node .github/scripts/update-version-refs.cjs ${{ inputs.version }}
-          npm install --package-lock-only
+          npm install --package-lock-only --ignore-scripts
 
       - name: Commit version bump
         run: |


### PR DESCRIPTION
## Summary

- The previous release workflow fix (#32) added `npm install --package-lock-only` to update `package-lock.json` during version bumps
- This failed in CI because `npm install` triggers the `prepare` script (`tsc`), but `node_modules` doesn't exist yet at that point in the workflow
- Added `--ignore-scripts` flag to skip lifecycle scripts — we only need the lockfile updated, not a full build

## Test plan

- [ ] Release workflow should pass the "Update version references" step without tsc errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)