### PR TITLE
Fix openant test skip, add walkthrough link

### DIFF
--- a/docs/trying-it-out.md
+++ b/docs/trying-it-out.md
@@ -11,6 +11,8 @@ Once you've [installed aghast](getting-started.md), you can either [create your 
 
 ## Option A: Create your own check
 
+[Click for a video walkthrough of using the new-check CLI option.](https://youtu.be/5MNadDxwtKk)
+
 Use `aghast new-check` to scaffold a check tailored to your own codebase:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,6 +1147,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1351,6 +1352,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1728,6 +1730,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1933,6 +1936,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2261,6 +2265,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2702,6 +2707,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3095,6 +3101,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3211,6 +3218,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tests/cli-openant.test.ts
+++ b/tests/cli-openant.test.ts
@@ -7,6 +7,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 import {
   fixtureRepo,
   failFixtureRepo,
@@ -20,6 +21,16 @@ const openantDataset = resolve(testDir, 'fixtures', 'openant', 'dataset_enhanced
 const openantBaseDataset = resolve(testDir, 'fixtures', 'openant', 'dataset.json');
 
 const { runCLI, cleanupOutput, readResults } = createScopedHelpers('openant');
+
+function isOpenAntInstalled(): boolean {
+  const binary = process.platform === 'win32' ? 'openant.exe' : 'openant';
+  try {
+    execFileSync(binary, ['--help'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe('CLI: openant discovery type', () => {
   before(async () => {
@@ -73,7 +84,7 @@ describe('CLI: openant discovery type', () => {
     assert.equal(issues[0].checkName, 'OpenAnt Security Test');
   });
 
-  it('should exit with error when openant binary not found and no mock set', async () => {
+  it('should exit with error when openant binary not found and no mock set', { skip: isOpenAntInstalled() ? 'openant is installed locally' : undefined }, async () => {
     const result = await runCLI(
       { AGHAST_MOCK_AI: 'true' },
       [


### PR DESCRIPTION
## Summary
- Skip the openant binary-not-found test when openant is actually installed locally, preventing false test failures in dev environments
- Add video walkthrough link to the trying-it-out documentation page
- Update package-lock.json dependency metadata (peer flags)

## Test plan
- [x] All 592 tests pass (2 skipped as expected)
- [x] No unexpected file deletions or changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)