### PR TITLE
ci: sign release artifacts with Sigstore cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Publish to npmjs
         run: npm publish --access public --provenance
 
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Sign release artifact
+        run: cosign sign-blob --yes --bundle bouncesecurity-aghast-${{ inputs.version }}.tgz.bundle bouncesecurity-aghast-${{ inputs.version }}.tgz
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,4 +142,5 @@ jobs:
           gh release create "v${{ inputs.version }}" \
             --title "v${{ inputs.version }}" \
             --generate-notes \
-            bouncesecurity-aghast-${{ inputs.version }}.tgz
+            bouncesecurity-aghast-${{ inputs.version }}.tgz \
+            bouncesecurity-aghast-${{ inputs.version }}.tgz.bundle


### PR DESCRIPTION
## Summary
- Add keyless Sigstore cosign signing to the release workflow
- Produces a `.bundle` file attached to each GitHub Release alongside the `.tgz`
- Uses the existing `id-token: write` permission for OIDC-based keyless signing
- Fixes OpenSSF Scorecard **Signed-Releases** check (0 → 8+)

## How it works
The `sigstore/cosign-installer` action installs cosign, then `cosign sign-blob --yes --bundle` signs the tarball using the GitHub Actions OIDC identity (no keys to manage). The resulting `.bundle` file contains the signature and certificate chain that scorecard looks for.

## Test plan
- [ ] Verify CI passes (workflow syntax is valid)
- [ ] On next release, verify the `.bundle` file appears in the GitHub Release assets
- [ ] Verify `cosign verify-blob` works against the published artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)