### PR TITLE
Add hono dependency, bump to 4.12.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "dotenv": "^17.3.1",
+        "hono": "^4.12.14",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.4"
       },
@@ -2261,9 +2262,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "dotenv": "^17.3.1",
+    "hono": "^4.12.14",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4"
   },


### PR DESCRIPTION
## Summary
- Adds `hono` as a project dependency (web framework for future API/server features)
- Bumps hono version to 4.12.14

## Test plan
- [x] All tests pass (593 pass, 0 fail)
- [x] `npm install` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)