### PR TITLE
Add fuzz tests, harden CI workflows, fix URL normalization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,10 +9,11 @@ permissions:
 
 jobs:
   auto-approve:
+    if: github.event.repository.name == 'aghast'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.pulls.createReview({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,15 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -41,13 +40,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ github.event.repository.name == 'aghast' && fromJSON('["windows-latest","ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
         node-version: ['20', '22', '24']
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -60,13 +59,14 @@ jobs:
           # Shard 1: cli-mock-mode-2 (~35s CI, env-var tests)
           # Shard 2: cli-mock-mode (~40s CI, CLI integration tests)
           # Shard 3: cli-subcommands + everything else (~30s CI)
+          # Shard 4: fuzz tests (~47s Windows, ~16s macOS)
           # New test files land in shard 3 automatically.
-          case ${{ matrix.shard }} in
+          case $SHARD in
             1) files=(tests/cli-mock-mode-2.test.ts) ;;
             2) files=(tests/cli-mock-mode.test.ts) ;;
             3)
               all=($(printf '%s\n' tests/*.test.ts | sort))
-              heavy=(tests/cli-mock-mode-2.test.ts tests/cli-mock-mode.test.ts)
+              heavy=(tests/cli-mock-mode-2.test.ts tests/cli-mock-mode.test.ts tests/fuzz.test.ts)
               files=()
               for f in "${all[@]}"; do
                 skip=false
@@ -76,8 +76,9 @@ jobs:
                 if [[ "$skip" == "false" ]]; then files+=("$f"); fi
               done
               ;;
+            4) files=(tests/fuzz.test.ts) ;;
           esac
-          echo "Shard ${{ matrix.shard }}/3: running ${#files[@]} test files"
+          echo "Shard $SHARD/4: running ${#files[@]} test files"
           printf '  %s\n' "${files[@]}"
           node --import tsx --test \
             --test-reporter=spec --test-reporter-destination=stdout \
@@ -85,9 +86,10 @@ jobs:
             "${files[@]}"
         env:
           AGHAST_SKIP_SEMGREP_TESTS: 'true'
+          SHARD: ${{ matrix.shard }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results-${{ matrix.os }}-node-${{ matrix.node-version }}-shard-${{ matrix.shard }}
@@ -99,9 +101,11 @@ jobs:
     if: always()
     steps:
       - name: Check test matrix result
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "Test matrix failed: ${{ needs.test.result }}"
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "Test matrix failed: $TEST_RESULT"
             exit 1
           fi
 
@@ -111,25 +115,30 @@ jobs:
     if: always()
     steps:
       - name: Check build-and-install matrix result
+        env:
+          BUILD_RESULT: ${{ needs.build-and-install.result }}
         run: |
-          if [ "${{ needs.build-and-install.result }}" != "success" ]; then
-            echo "Build-and-install matrix failed: ${{ needs.build-and-install.result }}"
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "Build-and-install matrix failed: $BUILD_RESULT"
             exit 1
           fi
 
   test-results:
+    permissions:
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     needs: test
     if: always()
 
     steps:
       - name: Download all test results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-results-*
 
       - name: Publish test results
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           report_paths: '**/test-results.xml'
           check_name: Test Results
@@ -145,9 +154,9 @@ jobs:
         os: ${{ github.event.repository.name == 'aghast' && fromJSON('["windows-latest","ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -156,7 +165,7 @@ jobs:
 
       - run: echo semgrep > requirements.txt
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -175,20 +184,20 @@ jobs:
         os: ${{ github.event.repository.name == 'aghast' && fromJSON('["windows-latest","ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
 
       - run: npm ci
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25'
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -221,20 +230,16 @@ jobs:
         node-version: ['20', '22', '24']
 
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: aghast-install
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Verify the package builds, packs, and installs correctly.
-      # This mirrors the release workflow: build → pack → install tarball.
-      - name: Clone repo
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git clone --depth=1 --branch "${{ github.head_ref || github.ref_name }}" "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "${{ runner.temp }}/aghast-install"
-
       - name: Build and pack
-        working-directory: ${{ runner.temp }}/aghast-install
+        working-directory: aghast-install
         run: |
           npm install
           npm run build
@@ -242,7 +247,7 @@ jobs:
 
       - name: Install from tarball
         shell: bash
-        run: npm install -g "${{ runner.temp }}"/aghast-install/bouncesecurity-aghast-*.tgz
+        run: npm install -g ./aghast-install/bouncesecurity-aghast-*.tgz
 
       - name: Verify CLI works
         run: |
@@ -254,8 +259,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: low

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^25.5.0",
         "@types/picomatch": "^4.0.2",
         "eslint": "^10.0.3",
+        "fast-check": "^4.6.0",
         "tsx": "^4.21.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.57.1"
@@ -32,9 +33,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.105",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.105.tgz",
-      "integrity": "sha512-gPn7UEX6WrnIqCclNzfER6Of0mQ1ruxcNe0jrVXR9kOG09qFfaGzd6hy2qr3envCAB/dACkS7UDJoCm4/jg5Dg==",
+      "version": "0.2.110",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.110.tgz",
+      "integrity": "sha512-pS7QlPcJwQU8a87F8qChKlmnjddt3smUi6X7WvSluD0kzt72jphCe30QmKKXPJnjW3SVHu12cu6SLzfYQrWwHg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -1148,6 +1149,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1352,6 +1354,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1729,6 +1732,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1934,6 +1938,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1988,6 +1993,29 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2262,6 +2290,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2703,6 +2732,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2751,6 +2781,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -3096,6 +3143,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3212,6 +3260,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^25.5.0",
     "@types/picomatch": "^4.0.2",
     "eslint": "^10.0.3",
+    "fast-check": "^4.6.0",
     "tsx": "^4.21.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.57.1"

--- a/src/repository-analyzer.ts
+++ b/src/repository-analyzer.ts
@@ -148,16 +148,23 @@ export function sanitizeUrl(url: string): string {
  */
 export function normalizeUrl(url: string): string {
   let normalized = url;
+  let prev: string;
 
-  // Remove trailing .git suffix
-  if (normalized.endsWith('.git')) {
-    normalized = normalized.slice(0, -4);
-  }
+  // Loop until stable: handles cases like ".git/" where stripping
+  // slashes reveals a new .git suffix (or vice versa).
+  do {
+    prev = normalized;
 
-  // Remove trailing slashes
-  while (normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1);
-  }
+    // Remove trailing .git suffix
+    if (normalized.endsWith('.git')) {
+      normalized = normalized.slice(0, -4);
+    }
+
+    // Remove trailing slashes
+    while (normalized.endsWith('/')) {
+      normalized = normalized.slice(0, -1);
+    }
+  } while (normalized !== prev);
 
   return normalized;
 }
@@ -207,8 +214,10 @@ export function parseGitUrl(url: string): { org: string; repo: string } | undefi
  * 3. Convert to lowercase
  */
 export function normalizeRepoPath(repoPathOrUrl: string): string {
-  let normalized = normalizeUrl(repoPathOrUrl);
-  normalized = normalized.replace(/\\/g, '/');
+  // Replace backslashes before normalizeUrl so trailing-slash stripping
+  // catches forward slashes introduced by this replacement.
+  let normalized = repoPathOrUrl.replace(/\\/g, '/');
+  normalized = normalizeUrl(normalized);
   normalized = normalized.toLowerCase();
   return normalized;
 }

--- a/tests/fuzz.test.ts
+++ b/tests/fuzz.test.ts
@@ -1,0 +1,834 @@
+/**
+ * Property-based fuzz tests using fast-check.
+ *
+ * Tests 20 functions across 4 tiers for robustness, security invariants,
+ * and algebraic properties. Satisfies the OpenSSF Scorecard Fuzzing check.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fc from 'fast-check';
+import { resolve, sep, join } from 'node:path';
+
+import { parseAIResponse } from '../src/response-parser.js';
+import { parseSARIF, deduplicateTargets, limitTargets } from '../src/sarif-parser.js';
+import {
+  sanitizeUrl,
+  normalizeUrl,
+  parseGitUrl,
+  normalizeRepoPath,
+} from '../src/repository-analyzer.js';
+import {
+  checkMatchesRepository,
+  filterChecksForRepository,
+  parseCheckMarkdown,
+  filterApplicablePaths,
+  filterExcludedPaths,
+  filterCheckPaths,
+} from '../src/check-library.js';
+import { isPathWithinRepository } from '../src/snippet-extractor.js';
+import { formatError, formatFatalError } from '../src/error-codes.js';
+import type { ErrorCode } from '../src/error-codes.js';
+import { isValidLogLevel } from '../src/logging.js';
+import { filterUnits, formatUnitPromptSection } from '../src/openant-loader.js';
+import type { OpenAntUnit } from '../src/openant-loader.js';
+import type { SecurityCheck, CheckTarget, OpenAntFilterConfig } from '../src/types.js';
+
+// --- Shared Arbitraries ---
+
+const checkTargetArb: fc.Arbitrary<CheckTarget> = fc.record({
+  file: fc.string({ minLength: 1 }),
+  startLine: fc.nat({ max: 10000 }),
+  endLine: fc.nat({ max: 10000 }),
+  message: fc.string(),
+  snippet: fc.option(fc.string(), { nil: undefined }),
+});
+
+const aiIssueArb = fc.record({
+  file: fc.string(),
+  startLine: fc.integer(),
+  endLine: fc.integer(),
+  description: fc.string(),
+  dataFlow: fc.option(
+    fc.array(
+      fc.record({
+        file: fc.string(),
+        lineNumber: fc.integer(),
+        label: fc.string(),
+      }),
+    ),
+    { nil: undefined },
+  ),
+});
+
+const checkResponseArb = fc.record({
+  issues: fc.array(aiIssueArb),
+  flagged: fc.option(fc.boolean(), { nil: undefined }),
+  summary: fc.option(fc.string(), { nil: undefined }),
+  analysisNotes: fc.option(fc.string(), { nil: undefined }),
+});
+
+const securityCheckArb: fc.Arbitrary<SecurityCheck> = fc.record({
+  id: fc.string({ minLength: 1 }),
+  name: fc.string(),
+  repositories: fc.array(fc.string()),
+  enabled: fc.option(fc.boolean(), { nil: undefined }),
+  applicablePaths: fc.option(fc.array(fc.string()), { nil: undefined }),
+  excludedPaths: fc.option(fc.array(fc.string()), { nil: undefined }),
+});
+
+const openAntUnitArb: fc.Arbitrary<OpenAntUnit> = fc.record({
+  id: fc.string({ minLength: 1 }),
+  unit_type: fc.string({ minLength: 1 }),
+  code: fc.record({
+    primary_code: fc.string(),
+    primary_origin: fc.record({
+      file_path: fc.string({ minLength: 1 }),
+      start_line: fc.nat({ max: 10000 }).map((n) => n + 1),
+      end_line: fc.nat({ max: 10000 }).map((n) => n + 1),
+      function_name: fc.string({ minLength: 1 }),
+      class_name: fc.option(fc.string(), { nil: null }),
+      enhanced: fc.boolean(),
+      files_included: fc.array(fc.string()),
+      original_length: fc.nat(),
+      enhanced_length: fc.nat(),
+    }),
+    dependencies: fc.constant([]),
+    dependency_metadata: fc.record({
+      depth: fc.nat(),
+      total_upstream: fc.nat(),
+      total_downstream: fc.nat(),
+      direct_calls: fc.nat(),
+      direct_callers: fc.nat(),
+    }),
+  }),
+  ground_truth: fc.record({ status: fc.string() }),
+  metadata: fc.record({
+    decorators: fc.array(fc.string()),
+    is_async: fc.boolean(),
+    parameters: fc.array(fc.string()),
+    docstring: fc.option(fc.string(), { nil: null }),
+    direct_calls: fc.array(fc.string()),
+    direct_callers: fc.array(fc.string()),
+  }),
+  reachable: fc.boolean(),
+  is_entry_point: fc.boolean(),
+  entry_point_reason: fc.string(),
+  agent_context: fc.option(
+    fc.record({
+      include_functions: fc.array(fc.record({ id: fc.string(), reason: fc.string() })),
+      usage_context: fc.string(),
+      security_classification: fc.string(),
+      classification_reasoning: fc.string(),
+      confidence: fc.double({ min: 0, max: 1, noNaN: true }),
+      agent_metadata: fc.record({
+        iterations: fc.nat(),
+        total_tokens: fc.nat(),
+      }),
+      reachability: fc.record({
+        is_entry_point: fc.boolean(),
+        reachable_from_entry: fc.boolean(),
+        entry_point_path: fc.array(fc.string()),
+      }),
+    }),
+    { nil: undefined },
+  ),
+});
+
+const openAntFilterArb: fc.Arbitrary<OpenAntFilterConfig> = fc.record({
+  unitTypes: fc.option(fc.array(fc.string()), { nil: undefined }),
+  excludeUnitTypes: fc.option(fc.array(fc.string()), { nil: undefined }),
+  securityClassifications: fc.option(fc.array(fc.string()), { nil: undefined }),
+  reachableOnly: fc.option(fc.boolean(), { nil: undefined }),
+  entryPointsOnly: fc.option(fc.boolean(), { nil: undefined }),
+  minConfidence: fc.option(fc.double({ min: 0, max: 1, noNaN: true }), { nil: undefined }),
+});
+
+const errorCodeArb: fc.Arbitrary<ErrorCode> = fc.record({
+  code: fc.string({ minLength: 1 }),
+  label: fc.string(),
+});
+
+// =========================================================================
+// Tier 1: External Input Parsers (Security-Critical)
+// =========================================================================
+
+describe('fuzz: external input parsers', () => {
+  describe('parseAIResponse', () => {
+    it('never crashes on arbitrary strings', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = parseAIResponse(input);
+          assert.ok(result === undefined || (typeof result === 'object' && Array.isArray(result.issues)));
+        }),
+      );
+    });
+
+    it('never crashes on arbitrary JSON', () => {
+      fc.assert(
+        fc.property(fc.json(), (input) => {
+          const result = parseAIResponse(input);
+          assert.ok(result === undefined || (typeof result === 'object' && Array.isArray(result.issues)));
+        }),
+      );
+    });
+
+    it('valid results have required fields', () => {
+      fc.assert(
+        fc.property(checkResponseArb, (response) => {
+          const raw = JSON.stringify(response);
+          const result = parseAIResponse(raw);
+          if (result !== undefined) {
+            assert.ok(Array.isArray(result.issues));
+            for (const issue of result.issues) {
+              assert.equal(typeof issue.file, 'string');
+              assert.equal(typeof issue.startLine, 'number');
+              assert.equal(typeof issue.endLine, 'number');
+              assert.equal(typeof issue.description, 'string');
+            }
+          }
+        }),
+      );
+    });
+
+    it('idempotent on valid output', () => {
+      fc.assert(
+        fc.property(checkResponseArb, (response) => {
+          const raw = JSON.stringify(response);
+          const first = parseAIResponse(raw);
+          if (first !== undefined) {
+            const second = parseAIResponse(JSON.stringify(first));
+            assert.deepStrictEqual(second, first);
+          }
+        }),
+      );
+    });
+  });
+
+  describe('parseSARIF', () => {
+    it('never crashes on arbitrary strings', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          try {
+            parseSARIF(input);
+          } catch (e) {
+            // Controlled errors (throws Error) are expected for invalid SARIF
+            assert.ok(e instanceof Error);
+          }
+        }),
+      );
+    });
+
+    it('valid output has required fields and startLine <= endLine', () => {
+      // Generate valid-ish SARIF documents
+      // Generate SARIF with startLine <= endLine (valid regions)
+      const regionArb = fc.nat({ max: 10000 }).chain((start) =>
+        fc.nat({ max: 10000 }).map((offset) => ({
+          startLine: start + 1,
+          endLine: start + offset + 1,
+        })),
+      );
+      const sarifArb = fc.record({
+        version: fc.constant('2.1.0'),
+        runs: fc.array(
+          fc.record({
+            results: fc.array(
+              fc.record({
+                message: fc.record({ text: fc.string() }),
+                locations: fc.array(
+                  fc.record({
+                    physicalLocation: fc.record({
+                      artifactLocation: fc.record({ uri: fc.string({ minLength: 1 }) }),
+                      region: regionArb,
+                    }),
+                  }),
+                ),
+              }),
+            ),
+          }),
+        ),
+      });
+
+      fc.assert(
+        fc.property(sarifArb, (doc) => {
+          const targets = parseSARIF(JSON.stringify(doc));
+          for (const target of targets) {
+            assert.equal(typeof target.file, 'string');
+            assert.equal(typeof target.startLine, 'number');
+            assert.equal(typeof target.endLine, 'number');
+            assert.equal(typeof target.message, 'string');
+            assert.ok(target.startLine <= target.endLine);
+          }
+        }),
+      );
+    });
+  });
+
+  describe('sanitizeUrl', () => {
+    it('never crashes on arbitrary strings', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = sanitizeUrl(input);
+          assert.equal(typeof result, 'string');
+        }),
+      );
+    });
+
+    it('never leaks credentials', () => {
+      // Use a unique password marker that won't appear in host/path
+      fc.assert(
+        fc.property(
+          fc.stringMatching(/^[a-z]{3,8}$/),
+          fc.stringMatching(/^[a-z]{3,8}$/),
+          (user, host) => {
+            const pass = 'S3CRET_P4SS';
+            const url = `https://${user}:${pass}@${host}.example.com/org/repo`;
+            const sanitized = sanitizeUrl(url);
+            assert.ok(!sanitized.includes(pass), `Sanitized URL should not contain password: ${sanitized}`);
+          },
+        ),
+      );
+    });
+
+    it('is idempotent', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const once = sanitizeUrl(input);
+          const twice = sanitizeUrl(once);
+          assert.equal(twice, once);
+        }),
+      );
+    });
+  });
+
+  describe('parseGitUrl', () => {
+    it('never crashes on arbitrary strings', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = parseGitUrl(input);
+          assert.ok(
+            result === undefined ||
+            (typeof result === 'object' &&
+              typeof result.org === 'string' &&
+              typeof result.repo === 'string'),
+          );
+        }),
+      );
+    });
+
+    it('valid results have non-empty org and repo', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = parseGitUrl(input);
+          if (result !== undefined) {
+            assert.ok(result.org.length > 0, 'org should be non-empty');
+            assert.ok(result.repo.length > 0, 'repo should be non-empty');
+          }
+        }),
+      );
+    });
+  });
+});
+
+// =========================================================================
+// Tier 2: Pure Data Transformations (Strong Algebraic Properties)
+// =========================================================================
+
+describe('fuzz: data transformations', () => {
+  describe('deduplicateTargets', () => {
+    it('output is subset of input', () => {
+      fc.assert(
+        fc.property(fc.array(checkTargetArb), (targets) => {
+          const result = deduplicateTargets(targets);
+          assert.ok(result.length <= targets.length);
+          for (const item of result) {
+            assert.ok(targets.some((t) =>
+              t.file === item.file &&
+              t.startLine === item.startLine &&
+              t.endLine === item.endLine,
+            ));
+          }
+        }),
+      );
+    });
+
+    it('is idempotent', () => {
+      fc.assert(
+        fc.property(fc.array(checkTargetArb), (targets) => {
+          const once = deduplicateTargets(targets);
+          const twice = deduplicateTargets(once);
+          assert.deepStrictEqual(twice, once);
+        }),
+      );
+    });
+
+    it('no duplicate keys in output', () => {
+      fc.assert(
+        fc.property(fc.array(checkTargetArb), (targets) => {
+          const result = deduplicateTargets(targets);
+          const keys = result.map((t) => `${t.file}:${t.startLine}:${t.endLine}`);
+          assert.equal(keys.length, new Set(keys).size);
+        }),
+      );
+    });
+  });
+
+  describe('limitTargets', () => {
+    it('respects maxTargets bound', () => {
+      fc.assert(
+        fc.property(fc.array(checkTargetArb), fc.nat({ max: 100 }), (targets, max) => {
+          const result = limitTargets(targets, max);
+          assert.ok(result.length <= max);
+          assert.ok(result.length <= targets.length);
+        }),
+      );
+    });
+
+    it('preserves input order (prefix)', () => {
+      fc.assert(
+        fc.property(fc.array(checkTargetArb), fc.nat({ max: 100 }), (targets, max) => {
+          const result = limitTargets(targets, max);
+          for (let i = 0; i < result.length; i++) {
+            assert.deepStrictEqual(result[i], targets[i]);
+          }
+        }),
+      );
+    });
+  });
+
+  describe('normalizeUrl', () => {
+    it('never ends with .git or slash', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = normalizeUrl(input);
+          assert.ok(!result.endsWith('.git'), `should not end with .git: ${result}`);
+          assert.ok(!result.endsWith('/'), `should not end with /: ${result}`);
+        }),
+      );
+    });
+
+    it('is idempotent', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const once = normalizeUrl(input);
+          const twice = normalizeUrl(once);
+          assert.equal(twice, once);
+        }),
+      );
+    });
+  });
+
+  describe('normalizeRepoPath', () => {
+    it('output is lowercase with no backslashes', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const result = normalizeRepoPath(input);
+          assert.equal(result, result.toLowerCase());
+          assert.ok(!result.includes('\\'), `should not contain backslashes: ${result}`);
+        }),
+      );
+    });
+
+    it('is idempotent', () => {
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const once = normalizeRepoPath(input);
+          const twice = normalizeRepoPath(once);
+          assert.equal(twice, once);
+        }),
+      );
+    });
+  });
+
+  describe('filterApplicablePaths', () => {
+    it('empty patterns returns all files', () => {
+      fc.assert(
+        fc.property(fc.array(fc.string()), (files) => {
+          assert.deepStrictEqual(filterApplicablePaths(files, undefined), files);
+          assert.deepStrictEqual(filterApplicablePaths(files, []), files);
+        }),
+      );
+    });
+
+    it('result is a subsequence of input', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.stringMatching(/^[a-z0-9/.]+$/), { maxLength: 20 }),
+          fc.array(fc.stringMatching(/^[a-z0-9*/.]+$/), { minLength: 1, maxLength: 3 }),
+          (files, patterns) => {
+            const result = filterApplicablePaths(files, patterns);
+            assert.ok(result.length <= files.length);
+            let lastIdx = -1;
+            for (const r of result) {
+              const idx = files.indexOf(r, lastIdx + 1);
+              assert.ok(idx > lastIdx, 'result should be a subsequence');
+              lastIdx = idx;
+            }
+          },
+        ),
+      );
+    });
+  });
+
+  describe('filterExcludedPaths', () => {
+    it('empty patterns returns all files', () => {
+      fc.assert(
+        fc.property(fc.array(fc.string()), (files) => {
+          assert.deepStrictEqual(filterExcludedPaths(files, undefined), files);
+          assert.deepStrictEqual(filterExcludedPaths(files, []), files);
+        }),
+      );
+    });
+
+    it('result is a subsequence of input', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.stringMatching(/^[a-z0-9/.]+$/), { maxLength: 20 }),
+          fc.array(fc.stringMatching(/^[a-z0-9*/.]+$/), { minLength: 1, maxLength: 3 }),
+          (files, patterns) => {
+            const result = filterExcludedPaths(files, patterns);
+            assert.ok(result.length <= files.length);
+            let lastIdx = -1;
+            for (const r of result) {
+              const idx = files.indexOf(r, lastIdx + 1);
+              assert.ok(idx > lastIdx, 'result should be a subsequence');
+              lastIdx = idx;
+            }
+          },
+        ),
+      );
+    });
+  });
+
+  describe('filterCheckPaths', () => {
+    it('equals compose of applicable + excluded filters', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.stringMatching(/^[a-z0-9/.]+$/), { maxLength: 20 }),
+          fc.option(fc.array(fc.stringMatching(/^[a-z0-9*/.]+$/), { maxLength: 3 }), { nil: undefined }),
+          fc.option(fc.array(fc.stringMatching(/^[a-z0-9*/.]+$/), { maxLength: 3 }), { nil: undefined }),
+          (files, applicablePaths, excludedPaths) => {
+            const check: SecurityCheck = {
+              id: 'test',
+              name: 'Test',
+              repositories: [],
+              applicablePaths,
+              excludedPaths,
+            };
+            const composed = filterExcludedPaths(
+              filterApplicablePaths(files, applicablePaths),
+              excludedPaths,
+            );
+            const direct = filterCheckPaths(files, check);
+            assert.deepStrictEqual(direct, composed);
+          },
+        ),
+      );
+    });
+  });
+
+  describe('filterChecksForRepository', () => {
+    it('no disabled checks in output', () => {
+      fc.assert(
+        fc.property(fc.array(securityCheckArb), fc.string(), (checks, url) => {
+          const result = filterChecksForRepository(checks, url);
+          for (const check of result) {
+            assert.notEqual(check.enabled, false);
+          }
+        }),
+      );
+    });
+
+    it('is idempotent', () => {
+      fc.assert(
+        fc.property(fc.array(securityCheckArb), fc.string(), (checks, url) => {
+          const once = filterChecksForRepository(checks, url);
+          const twice = filterChecksForRepository(once, url);
+          assert.deepStrictEqual(twice, once);
+        }),
+      );
+    });
+  });
+});
+
+// =========================================================================
+// Tier 3: Security-Sensitive Functions
+// =========================================================================
+
+describe('fuzz: security functions', () => {
+  describe('isPathWithinRepository', () => {
+    it('never crashes on arbitrary paths', () => {
+      fc.assert(
+        fc.property(fc.string(), fc.string(), (repo, path) => {
+          const result = isPathWithinRepository(repo, path);
+          assert.equal(typeof result, 'boolean');
+        }),
+      );
+    });
+
+    it('returns true for genuine child paths', () => {
+      fc.assert(
+        fc.property(
+          fc.stringMatching(/^[a-zA-Z0-9_-]+$/),
+          fc.array(fc.stringMatching(/^[a-zA-Z0-9_-]+$/), { minLength: 1, maxLength: 5 }),
+          (base, segments) => {
+            const repoPath = resolve('/', base);
+            const childPath = join(repoPath, ...segments);
+            const result = isPathWithinRepository(repoPath, childPath);
+            assert.ok(result, `${childPath} should be within ${repoPath}`);
+          },
+        ),
+      );
+    });
+
+    it('rejects path traversal escapes', () => {
+      fc.assert(
+        fc.property(
+          fc.stringMatching(/^[a-zA-Z0-9_-]+$/),
+          fc.array(fc.constant('..'), { minLength: 2, maxLength: 5 }),
+          fc.stringMatching(/^[a-zA-Z0-9_-]+$/),
+          (base, ups, target) => {
+            const repoPath = resolve('/', base);
+            const escapePath = join(repoPath, ...ups, target);
+            const result = isPathWithinRepository(repoPath, escapePath);
+            // The resolved escape path should not be within the repo
+            const resolvedEscape = resolve(escapePath);
+            const resolvedRepo = resolve(repoPath) + sep;
+            if (!resolvedEscape.startsWith(resolvedRepo)) {
+              assert.equal(result, false, `${escapePath} should not be within ${repoPath}`);
+            }
+          },
+        ),
+      );
+    });
+  });
+
+  describe('checkMatchesRepository', () => {
+    it('empty repositories always matches', () => {
+      fc.assert(
+        fc.property(fc.string(), (url) => {
+          const check: SecurityCheck = {
+            id: 'test',
+            name: 'Test',
+            repositories: [],
+          };
+          assert.equal(checkMatchesRepository(check, url), true);
+        }),
+      );
+    });
+
+    it('never crashes on arbitrary URLs', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.string()),
+          fc.string(),
+          (repos, url) => {
+            const check: SecurityCheck = {
+              id: 'test',
+              name: 'Test',
+              repositories: repos,
+            };
+            const result = checkMatchesRepository(check, url);
+            assert.equal(typeof result, 'boolean');
+          },
+        ),
+      );
+    });
+  });
+});
+
+// =========================================================================
+// Tier 4: Formatting & Validation (Robustness)
+// =========================================================================
+
+describe('fuzz: formatting and validation', () => {
+  describe('parseCheckMarkdown', () => {
+    it('never crashes on arbitrary markdown', () => {
+      fc.assert(
+        fc.property(fc.string(), fc.string(), (id, markdown) => {
+          const result = parseCheckMarkdown(id, markdown);
+          assert.ok(typeof result === 'object');
+        }),
+      );
+    });
+
+    it('preserves id and content', () => {
+      fc.assert(
+        fc.property(fc.string(), fc.string(), (id, markdown) => {
+          const result = parseCheckMarkdown(id, markdown);
+          assert.equal(result.id, id);
+          assert.equal(result.content, markdown);
+        }),
+      );
+    });
+
+    it('fallback name on missing heading', () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.string().filter((s) => !s.match(/^###\s+.+$/m)),
+          (id, markdown) => {
+            const result = parseCheckMarkdown(id, markdown);
+            assert.equal(result.name, 'Unknown Check');
+          },
+        ),
+      );
+    });
+  });
+
+  describe('formatError', () => {
+    it('output contains code and message', () => {
+      fc.assert(
+        fc.property(errorCodeArb, fc.string(), (code, message) => {
+          const result = formatError(code, message);
+          assert.ok(result.startsWith('Error ['), `should start with "Error [": ${result}`);
+          assert.ok(result.includes(code.code), `should contain error code: ${result}`);
+          assert.ok(result.includes(message), `should contain message: ${result}`);
+        }),
+      );
+    });
+  });
+
+  describe('formatFatalError', () => {
+    it('output contains E9001 and version', () => {
+      fc.assert(
+        fc.property(fc.string(), fc.string(), (message, version) => {
+          const result = formatFatalError(message, version);
+          assert.ok(result.includes('E9001'), `should contain E9001: ${result}`);
+          assert.ok(result.includes(version), `should contain version: ${result}`);
+        }),
+      );
+    });
+
+    it('output contains URL-encoded issue link', () => {
+      fc.assert(
+        fc.property(fc.string(), fc.string(), (message, version) => {
+          const result = formatFatalError(message, version);
+          assert.ok(
+            result.includes('github.com/BounceSecurity/aghast/issues/new'),
+            `should contain issue link: ${result}`,
+          );
+        }),
+      );
+    });
+  });
+
+  describe('isValidLogLevel', () => {
+    it('true only for valid levels', () => {
+      const validLevels = ['error', 'warn', 'info', 'debug', 'trace'];
+      for (const level of validLevels) {
+        assert.equal(isValidLogLevel(level), true, `${level} should be valid`);
+      }
+    });
+
+    it('false for all other strings including case variations', () => {
+      fc.assert(
+        fc.property(
+          fc.string().filter(
+            (s) => !['error', 'warn', 'info', 'debug', 'trace'].includes(s),
+          ),
+          (input) => {
+            assert.equal(isValidLogLevel(input), false, `"${input}" should be invalid`);
+          },
+        ),
+      );
+    });
+  });
+
+  describe('filterUnits', () => {
+    it('empty filters returns all units', () => {
+      fc.assert(
+        fc.property(fc.array(openAntUnitArb, { maxLength: 10 }), (units) => {
+          assert.deepStrictEqual(filterUnits(units, undefined), units);
+        }),
+      );
+    });
+
+    it('result is a subsequence of input', () => {
+      fc.assert(
+        fc.property(
+          fc.array(openAntUnitArb, { maxLength: 10 }),
+          openAntFilterArb,
+          (units, filters) => {
+            const result = filterUnits(units, filters);
+            assert.ok(result.length <= units.length);
+            for (const item of result) {
+              assert.ok(units.includes(item));
+            }
+          },
+        ),
+      );
+    });
+
+    it('reachableOnly returns only reachable units', () => {
+      fc.assert(
+        fc.property(fc.array(openAntUnitArb, { maxLength: 10 }), (units) => {
+          const result = filterUnits(units, { reachableOnly: true });
+          for (const unit of result) {
+            assert.equal(unit.reachable, true);
+          }
+        }),
+      );
+    });
+
+    it('entryPointsOnly returns only entry point units', () => {
+      fc.assert(
+        fc.property(fc.array(openAntUnitArb, { maxLength: 10 }), (units) => {
+          const result = filterUnits(units, { entryPointsOnly: true });
+          for (const unit of result) {
+            assert.equal(unit.is_entry_point, true);
+          }
+        }),
+      );
+    });
+
+    it('minConfidence filters correctly', () => {
+      fc.assert(
+        fc.property(
+          fc.array(openAntUnitArb, { maxLength: 10 }),
+          fc.double({ min: 0, max: 1, noNaN: true }),
+          (units, minConf) => {
+            const result = filterUnits(units, { minConfidence: minConf });
+            for (const unit of result) {
+              assert.ok(unit.agent_context !== undefined, 'filtered unit should have agent_context');
+              assert.ok(unit.agent_context.confidence >= minConf,
+                `confidence ${unit.agent_context.confidence} should be >= ${minConf}`);
+            }
+          },
+        ),
+      );
+    });
+  });
+
+  describe('formatUnitPromptSection', () => {
+    it('output contains file path and function name', () => {
+      fc.assert(
+        fc.property(openAntUnitArb, (unit) => {
+          const result = formatUnitPromptSection(unit);
+          const expectedPath = unit.code.primary_origin.file_path.replace(/\\/g, '/');
+          assert.ok(
+            result.includes(expectedPath),
+            `should contain file path "${expectedPath}": ${result}`,
+          );
+          assert.ok(
+            result.includes(unit.code.primary_origin.function_name),
+            `should contain function name: ${result}`,
+          );
+        }),
+      );
+    });
+
+    it('line numbers in output are >= 1', () => {
+      fc.assert(
+        fc.property(openAntUnitArb, (unit) => {
+          const result = formatUnitPromptSection(unit);
+          const lineMatch = result.match(/Lines:\s*(\d+)-(\d+)/);
+          if (lineMatch) {
+            assert.ok(parseInt(lineMatch[1]) >= 1, 'start line should be >= 1');
+            assert.ok(parseInt(lineMatch[2]) >= 1, 'end line should be >= 1');
+          }
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Fuzz tests**: Add property-based fuzz tests using `fast-check` for repository-analyzer, response-parser, snippet-extractor, check-library, and SARIF parser. New CI shard 4 runs these tests.
- **CI hardening**: Pin all GitHub Actions to commit SHAs to prevent supply chain attacks. Fix expression injection vulnerability by routing `${{ }}` expressions through environment variables instead of inline shell interpolation. Scope `checks: write` permission to only the `test-results` job that needs it.
- **URL normalization fix**: Fix `normalizeRepoPath` to handle edge cases where backslashes followed by `.git` suffixes weren't properly stripped, by normalizing backslashes before URL normalization and looping until stable.
- **Build-and-install simplification**: Replace manual `git clone` with `actions/checkout` in the build-and-install CI job.
- **Auto-approve guard**: Restrict auto-approve workflow to only run in the public `aghast` repo.

## Test plan

- [x] All existing tests pass after sync
- [ ] CI runs successfully on this PR (lint, test matrix, build-and-install, semgrep, dependency review)
- [ ] New fuzz tests pass on all OS/Node combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)