### PR TITLE
ci: pin scorecard actions and scope token permissions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-approve:
     if: github.event.repository.name == 'aghast'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,22 +15,22 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.1
+      - uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pin all actions in `scorecard.yml` to commit SHAs (was using version tags)
- Move `pull-requests: write` in `auto-approve.yml` from top-level to job-level

## Context
The scorecard.dev backend (which runs a newer version than the local CLI) flagged:
- **Pinned-Dependencies (6/10)**: scorecard.yml actions not pinned by hash
- **Token-Permissions (0/10)**: auto-approve.yml had write permission at top-level

The remaining Token-Permissions warnings (`checks: write` in ci.yml test-results job, `contents: write` in release.yml) are necessary and already correctly scoped.

## Test plan
- [ ] Verify CI passes
- [ ] Verify auto-approve still works (permission moved to job level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)