### PR TITLE
fix: use commit SHAs for scorecard workflow actions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
+      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
@@ -31,6 +31,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+      - uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Fix scorecard action SHA pinning — annotated git tags have a tag object SHA that differs from the commit SHA
- The scorecard webapp rejects tag object SHAs as "imposter commits"
- Dereferenced `ossf/scorecard-action@v2.4.1` and `github/codeql-action@v3` to their actual commit SHAs

## Context
Error on main CI after PR #55:
```
imposter commit: ea651e62978af7915d09fe2e282747c798bf2dab does not belong to ossf/scorecard-action
```

The `gh api` for annotated tags returns `"type": "tag"` — need to follow the chain to get `"type": "commit"`.

## Test plan
- [ ] Verify scorecard workflow succeeds on merge to main (no imposter commit error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)