### PR TITLE
ci: fix token permissions and npm pinning for OpenSSF Scorecard

### DIFF
--- a/.github/scripts/update-version-refs.cjs
+++ b/.github/scripts/update-version-refs.cjs
@@ -21,6 +21,15 @@ for (const file of ['docs/getting-started.md']) {
   fs.writeFileSync(file, content);
 }
 
+// Update package-lock.json version to match
+const lockPath = 'package-lock.json';
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+lock.version = version;
+if (lock.packages && lock.packages['']) {
+  lock.packages[''].version = version;
+}
+fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
+
 // Update release workflow description with next possible versions
 const [major, minor, patch] = version.split('.').map(Number);
 const nextPatch = `${major}.${minor}.${patch + 1}`;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
       - name: Build and pack
         working-directory: aghast-install
         run: |
-          npm install
+          npm ci
           npm run build
           npm pack
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,15 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  actions: read
-  id-token: write
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,6 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           node .github/scripts/update-version-refs.cjs "$INPUT_VERSION"
-          npm install --package-lock-only --ignore-scripts
 
       - name: Commit version bump
         env:


### PR DESCRIPTION
## Summary
- Move release.yml write permissions from top-level to job-level, set top-level to `read-all`
- Replace `npm install` with `npm ci` in ci.yml build-and-install job
- Replace `npm install --package-lock-only` in release.yml with direct JSON lockfile update in `update-version-refs.cjs`

## Context
Three OpenSSF Scorecard alerts addressed:
- **Token-Permissions** (alert #3): `release.yml:12` had `contents: write` at top level — scorecard requires top-level to be read-only
- **Pinned-Dependencies** (alert #8): `ci.yml` used `npm install` — scorecard treats `npm ci` as pinned (verifies lockfile hashes)
- **Pinned-Dependencies** (alert #9): `release.yml` used `npm install --package-lock-only` — replaced with a direct JSON version update in the existing `update-version-refs.cjs` script, which is faster and avoids the npm command entirely

## Test plan
- [ ] Verify CI passes (build-and-install job still works with `npm ci`)
- [ ] On next release, verify `package-lock.json` version is correctly updated by the script
- [ ] Verify release workflow still has the permissions it needs at job level

🤖 Generated with [Claude Code](https://claude.com/claude-code)