### PR TITLE
docs: add community files for OpenSSF Best Practices badge

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+info@bouncesecurity.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to AGHAST
+
+Thank you for your interest in AGHAST! This document explains how you can contribute.
+
+## Bug Reports and Feature Requests
+
+We welcome bug reports and feature requests via [GitHub Issues](https://github.com/BounceSecurity/aghast/issues).
+
+When filing a bug report, please include:
+
+- The version of aghast you are using (`aghast --version`)
+- Your Node.js version (`node --version`)
+- Your operating system and version
+- Steps to reproduce the issue
+- Expected vs. actual behavior
+- Any relevant log output (use `--debug` for verbose output)
+
+For feature requests, describe the use case and why the feature would be valuable.
+
+## Pull Requests
+
+We are not currently accepting pull requests. If you have an idea for a change, please open an issue first to discuss it.
+
+## Security Vulnerabilities
+
+Please do **not** report security vulnerabilities via GitHub Issues. See our [Security Policy](SECURITY.md) for responsible disclosure instructions.
+
+## Development
+
+If you are working on aghast itself, see the [Development guide](docs/development.md) for setup, building, and testing instructions.
+
+### Testing Policy
+
+All new functionality must include tests. Specifically:
+
+- **CLI-level integration tests** in `tests/cli-mock-mode.test.ts` that spawn the real CLI process with `AGHAST_MOCK_AI=true`. These exercise the full pipeline end-to-end.
+- Include tests for **PASS**, **FAIL**, and **ERROR** scenarios as appropriate.
+- Tests use `node:test` and `node:assert` (Node.js built-in) — no external test frameworks.
+- The AI provider must be mocked/stubbed in all tests — tests must pass without `ANTHROPIC_API_KEY` set.
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
+### Coding Standards
+
+- TypeScript with strict mode enabled
+- ESLint enforced (`npm run lint`)
+- Error codes from `src/error-codes.ts` for all CLI error paths
+- Color output via `src/colors.ts` helpers, never raw ANSI codes
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## License
+
+By contributing to aghast, you agree that your contributions will be licensed under the [GNU Affero General Public License v3.0 or later](LICENSE).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Results are structured JSON (or SARIF) with per-check status and detailed issues
 
 ## Contributing
 
-We welcome bug reports and feature requests via [GitHub Issues](https://github.com/BounceSecurity/aghast/issues). We are not currently accepting pull requests.
+Use [GitHub Discussions](https://github.com/BounceSecurity/aghast/discussions) for questions and ideas, and [GitHub Issues](https://github.com/BounceSecurity/aghast/issues) for bug reports and feature requests. We are not currently accepting pull requests. See [CONTRIBUTING.md](CONTRIBUTING.md) for the current contribution policy.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,10 @@ Only the latest released version of aghast receives security updates.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in aghast, please report it responsibly by emailing **info@bouncesecurity.com**.
+If you discover a security vulnerability in aghast, please report it responsibly using one of the following private channels:
+
+- **GitHub Private Vulnerability Reporting** (preferred): Use the [Report a vulnerability](https://github.com/BounceSecurity/aghast/security/advisories/new) button on the Security tab of this repository.
+- **Email**: Send details to **info@bouncesecurity.com** if you are unable to use GitHub's reporting feature.
 
 Please include:
 
@@ -21,6 +24,12 @@ Please include:
 We will acknowledge your report within 5 business days and aim to provide a fix or mitigation plan within 30 days, depending on severity.
 
 Please do **not** open a public GitHub issue for security vulnerabilities.
+
+## Security Fix Release Notes
+
+When a release includes a fix for a disclosed vulnerability, the corresponding GitHub Release notes will explicitly identify the security fix.
+
+Where applicable, the release notes will include the assigned CVE ID and a short description of the issue that was fixed.
 
 ## Scope
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,11 +26,14 @@ npm run scan -- <repo-path> [options]
 npm run new-check -- [options]
 npm run build
 npm test
+npm run test:coverage  # Run the unit test suite with Node.js coverage enabled
 npm run test:ci        # Run tests with spec and JUnit reporters (for CI)
 npm run test:semgrep   # Run real Semgrep integration tests (requires Semgrep installed)
 npm run lint
 npm run lint:fix       # Run ESLint with auto-fix
 ```
+
+`npm run test:coverage` uses Node.js built-in test coverage support (`--experimental-test-coverage`) so contributors can measure coverage without adding a separate coverage toolchain.
 
 ## Releasing
 
@@ -44,6 +47,8 @@ Releases are created via the **Release** GitHub Actions workflow (`workflow_disp
    - Builds and packs a tarball
    - Publishes to npmjs registry
    - Creates a GitHub Release with the tarball attached
+
+If a release fixes a disclosed security vulnerability, update the generated GitHub Release notes to explicitly call out the fix. Include the CVE ID when one has been assigned.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "tsc",
     "build": "tsc",
     "test": "node --import tsx --test tests/*.test.ts",
+    "test:coverage": "node --experimental-test-coverage --import tsx --test tests/*.test.ts",
     "test:ci": "node --import tsx --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml tests/*.test.ts",
     "test:semgrep": "node --import tsx --test tests/semgrep-integration.itest.ts",
     "test:openant": "node --import tsx --test tests/openant-integration.itest.ts",


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with bug reporting guidance, PR policy, testing policy, and coding standards
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- Update `SECURITY.md`: add GitHub Private Vulnerability Reporting as preferred channel, add security fix release notes policy
- Update `README.md` contributing section to reference Discussions and CONTRIBUTING.md
- Add `test:coverage` npm script using Node.js built-in coverage
- Document coverage script and vuln disclosure in release notes in `docs/development.md`

Closes gaps identified against the [OpenSSF Best Practices Passing criteria](https://www.bestpractices.dev/en/criteria/0).

## Test plan
- [x] Verify `npm run test:coverage` produces coverage output
- [x] Verify all links in CONTRIBUTING.md and SECURITY.md resolve correctly
- [x] Verify GitHub Discussions link in README works

🤖 Generated with [Claude Code](https://claude.com/claude-code)