### PR TITLE
docs: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/BounceSecurity/aghast/actions/workflows/ci.yml/badge.svg)](https://github.com/BounceSecurity/aghast/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/BounceSecurity/aghast/badge)](https://scorecard.dev/viewer/?uri=github.com/BounceSecurity/aghast)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12560/badge)](https://www.bestpractices.dev/projects/12560)
 [![By Bounce Security](https://img.shields.io/badge/By-Bounce_Security-f79421)](https://bouncesecurity.com/)
 
 > **Note**


### PR DESCRIPTION
## Summary
- Add OpenSSF Best Practices passing badge to README, alongside the existing Scorecard badge

## Test plan
- [x] Badge links to https://www.bestpractices.dev/projects/12560

🤖 Generated with [Claude Code](https://claude.com/claude-code)