### PR TITLE
Gracefully skip unknown discovery types, add example 5 video walkthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   check-ci-skip:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    continue-on-error: true
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      pull-requests: read
     steps:
       - name: Check if merged PR already passed CI
         id: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       contents: read
       checks: read
       pull-requests: read
+      actions: read
     steps:
       - name: Check if merged PR already passed CI
         id: check

--- a/docs/trying-it-out.md
+++ b/docs/trying-it-out.md
@@ -303,6 +303,8 @@ FAIL with ~3 issues: the AI should confirm the true positive findings (unescaped
 
 ### Example 5: Various Security Vulnerabilities (targeted check, OpenAnt discovery, general vulnerability analysis)
 
+[Click for a video walkthrough of running this example.](https://youtu.be/pALxeunbH7s)
+
 #### Check type
 
 `targeted` with `openant` discovery. Runs `openant parse` on the target repo to extract code units, then has the AI independently analyze each unit for security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,6 +1149,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1353,6 +1354,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1730,6 +1732,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1935,6 +1938,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2286,6 +2290,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2727,6 +2732,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3137,6 +3143,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3253,6 +3260,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -16,6 +16,7 @@ import type {
   CheckDefinition,
 } from './types.js';
 import { getCheckType, getValidCheckTypes } from './check-types.js';
+import { getRegisteredDiscoveries } from './discovery.js';
 
 // --- Layer 1: Check Registry ---
 
@@ -162,12 +163,13 @@ export async function loadCheckDefinition(checkFolderPath: string): Promise<Chec
     if (ct.concurrency !== undefined && (typeof ct.concurrency !== 'number' || ct.concurrency <= 0 || !Number.isInteger(ct.concurrency))) {
       throw new Error(`Check definition "${defPath}": "checkTarget.concurrency" must be a positive integer`);
     }
-    // Validate discovery field for targeted/static types
+    // Validate discovery field is present for targeted/static types (actual type
+    // validation happens in validateCheck, after repo filtering, so unknown
+    // discovery types don't crash the entire scan for unrelated checks)
     if (ct.type === 'targeted' || ct.type === 'static') {
-      const validDiscoveries = ct.type === 'targeted' ? ['semgrep', 'openant', 'sarif'] : ['semgrep'];
-      if (typeof ct.discovery !== 'string' || !validDiscoveries.includes(ct.discovery)) {
+      if (typeof ct.discovery !== 'string' || ct.discovery.trim() === '') {
         throw new Error(
-          `Check definition "${defPath}": "checkTarget.discovery" is required for type "${ct.type}" and must be one of: ${validDiscoveries.join(', ')}`,
+          `Check definition "${defPath}": "checkTarget.discovery" is required for type "${ct.type}"`,
         );
       }
     }
@@ -385,6 +387,18 @@ export async function validateCheck(
 
   if (!check.id || typeof check.id !== 'string' || check.id.trim() === '') {
     errors.push('Check is missing a valid "id" field');
+  }
+
+  // Validate discovery type is registered (checked here, after repo filtering,
+  // so unknown discovery types in unrelated checks don't crash the scan).
+  // Only validates when discoveries have been registered (skips in unit tests
+  // where scan-runner.ts hasn't been imported).
+  const discovery = check.checkTarget?.discovery;
+  if (discovery) {
+    const registered = getRegisteredDiscoveries();
+    if (registered.length > 0 && !registered.includes(discovery)) {
+      errors.push(`Unknown discovery type "${discovery}". Available: ${registered.join(', ')}`);
+    }
   }
 
   // Built-in analysis modes provide their own prompt template — no instructionsFile needed

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -39,6 +39,7 @@ export const sarifVerifyMissingConfigDir = resolve(testDir, 'fixtures', 'cli-con
 export const perCheckModelConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'per-check-model');
 export const openantCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'openant-check');
 export const mixedDiscoveryConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'mixed-discovery');
+export const unknownDiscoveryConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'unknown-discovery');
 
 // SARIF fixtures
 export const cli3TargetsSarif = resolve(testDir, 'fixtures', 'sarif', 'cli-3-targets.sarif');

--- a/tests/cli-unknown-discovery.test.ts
+++ b/tests/cli-unknown-discovery.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for graceful handling of unknown discovery types.
+ *
+ * A check with an unrecognized discovery type should be skipped
+ * (not crash the scan) when it matches the target repository.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fixtureRepo,
+  unknownDiscoveryConfigDir,
+  createScopedHelpers,
+} from './cli-test-helpers.js';
+
+describe('CLI: unknown discovery type handling', () => {
+  const { runCLI, cleanupOutput, readResults } = createScopedHelpers('unknown-discovery');
+  afterEach(cleanupOutput);
+
+  it('skips check with unknown discovery type instead of crashing', async () => {
+    const { exitCode, stdout, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', unknownDiscoveryConfigDir],
+    );
+
+    assert.equal(exitCode, 0, `Expected exit 0, got ${exitCode}. stderr: ${stderr}`);
+    const combined = stdout + stderr;
+    assert.ok(
+      combined.includes('Skipping invalid check'),
+      'Should log that the check was skipped',
+    );
+    assert.ok(
+      combined.includes('Unknown discovery type'),
+      'Should mention the unknown discovery type',
+    );
+
+    // Scan should complete with 0 checks (the only check was skipped)
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks.length, 0, 'No checks should have run');
+  });
+});

--- a/tests/fixtures/cli-configs/unknown-discovery/checks-config.json
+++ b/tests/fixtures/cli-configs/unknown-discovery/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-unknown-disc",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/unknown-discovery/checks/aghast-unknown-disc/aghast-unknown-disc.json
+++ b/tests/fixtures/cli-configs/unknown-discovery/checks/aghast-unknown-disc/aghast-unknown-disc.json
@@ -1,0 +1,10 @@
+{
+  "id": "aghast-unknown-disc",
+  "name": "Check with unknown discovery type",
+  "severity": "high",
+  "checkTarget": {
+    "type": "targeted",
+    "discovery": "future-discovery-type",
+    "analysisMode": "false-positive-validation"
+  }
+}

--- a/tests/fixtures/cli-configs/unknown-discovery/prompts/false-positive-validation.md
+++ b/tests/fixtures/cli-configs/unknown-discovery/prompts/false-positive-validation.md
@@ -1,0 +1,56 @@
+GENERIC INSTRUCTIONS:
+
+You are performing a SPECIFIC security check as defined in the CHECK INSTRUCTIONS below.
+
+IMPORTANT:
+- Focus ONLY on what the CHECK INSTRUCTIONS ask you to validate
+- Do NOT perform general security testing or look for unrelated vulnerabilities
+- Do NOT report issues outside the scope of the specific check
+- Follow the CHECK INSTRUCTIONS exactly as written
+
+OUTPUT FORMAT:
+
+Return your findings in the following JSON format:
+
+{
+  "issues": [
+    {
+      "file": "relative/path/to/file.ts",
+      "startLine": 40,
+      "endLine": 45,
+      "description": "Detailed explanation (see requirements below)",
+      "dataFlow": [
+        { "file": "src/routes/handler.ts", "lineNumber": 12, "label": "User input received from request parameter" },
+        { "file": "src/services/query.ts", "lineNumber": 38, "label": "Input passed to SQL query without sanitization" }
+      ]
+    }
+  ]
+}
+
+DESCRIPTION FORMATTING REQUIREMENTS:
+
+Your description field MUST be detailed and well-structured:
+- Use markdown formatting with headings (## Heading), bullet points, code blocks
+- Use \n for line breaks to create structured, readable content
+- Include an "Attack Scenario" section demonstrating exploitation
+- Include a "Recommendation" section with specific remediation steps
+
+DATA FLOW REQUIREMENTS:
+
+When the issue involves data flowing through multiple locations (e.g., user input reaching a dangerous sink), include a "dataFlow" array. Each step represents a point in the call stack or data flow:
+- "file": relative path to the source file
+- "lineNumber": the line number at that step
+- "label": a short description of what happens at this point (e.g., "User input received", "Passed to database query")
+- Order steps from source (e.g., user input) to sink (e.g., SQL execution)
+- Omit "dataFlow" entirely if the issue is localized to a single location
+
+CRITICAL: Return ONLY valid JSON. No markdown code blocks, no explanations outside the JSON.
+
+If no issues found for this SPECIFIC check, return: {"issues": []}
+
+If a TARGET LOCATION section appears at the end of this prompt, you must analyze ONLY that specific code location.
+
+---
+
+CHECK INSTRUCTIONS:
+


### PR DESCRIPTION
## Summary

- **Fix:** Gracefully skip checks with unknown discovery types instead of failing hard, so configs authored against newer aghast versions degrade cleanly on older binaries.
- **Docs:** Add a YouTube video walkthrough link for Example 5 (OpenAnt general-vuln-discovery) in `docs/trying-it-out.md`.
- **CI:** Mark the `check-ci-skip` job as `continue-on-error` so a transient failure of that gate doesn't block the rest of the workflow.

## Test plan

- [x] `npm test` — all 641 tests pass (2 skipped)
- [x] New `tests/cli-unknown-discovery.test.ts` covers the unknown-discovery skip path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)