### PR TITLE
Add prerelease workflow for non-superseding npm publishes

### DIFF
--- a/.github/release-actions/build-pack-sign/action.yml
+++ b/.github/release-actions/build-pack-sign/action.yml
@@ -1,0 +1,54 @@
+name: Build, pack, and sign
+description: Install deps, build, npm pack, and sign the resulting tarball with cosign.
+
+inputs:
+  version:
+    description: Version string used to locate the packed tarball (e.g. 0.5.0 or 0.5.0-beta.1).
+    required: true
+
+outputs:
+  tarball:
+    description: Path to the packed npm tarball.
+    value: ${{ steps.paths.outputs.tarball }}
+  signature:
+    description: Path to the cosign signature bundle.
+    value: ${{ steps.paths.outputs.signature }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      with:
+        node-version: '24'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Build and pack
+      shell: bash
+      run: |
+        npm run build
+        npm pack
+
+    - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Resolve artifact paths
+      id: paths
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        TARBALL="bouncesecurity-aghast-${INPUT_VERSION}.tgz"
+        SIGNATURE="${TARBALL}.sigstore"
+        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+        echo "signature=$SIGNATURE" >> "$GITHUB_OUTPUT"
+
+    - name: Sign release artifact
+      shell: bash
+      env:
+        TARBALL: ${{ steps.paths.outputs.tarball }}
+        SIGNATURE: ${{ steps.paths.outputs.signature }}
+      run: cosign sign-blob --yes --bundle "$SIGNATURE" "$TARBALL"

--- a/.github/release-actions/wait-for-ci/action.yml
+++ b/.github/release-actions/wait-for-ci/action.yml
@@ -1,0 +1,46 @@
+name: Wait for CI
+description: Poll the CI workflow on HEAD and fail if it did not succeed within the timeout.
+
+runs:
+  using: composite
+  steps:
+    - name: Verify CI passed on current commit
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        SHA=$(git rev-parse HEAD)
+        echo "Checking CI status for $SHA"
+
+        MAX_WAIT=600  # 10 minutes
+        INTERVAL=15
+        ELAPSED=0
+
+        while true; do
+          RUN_JSON=$(gh run list --commit "$SHA" --workflow CI --json conclusion,status --jq '.[0] // empty')
+          if [ -z "$RUN_JSON" ]; then
+            echo "::error::No CI run found for commit $SHA. Ensure CI has run on main before releasing."
+            exit 1
+          fi
+
+          STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+          CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion // empty')
+
+          if [ "$STATUS" = "completed" ]; then
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "CI passed on $SHA"
+              break
+            else
+              echo "::error::CI did not pass on commit $SHA (conclusion: $CONCLUSION). Fix CI before releasing."
+              exit 1
+            fi
+          fi
+
+          if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+            echo "::error::Timed out waiting for CI on commit $SHA (status: $STATUS after ${ELAPSED}s)"
+            exit 1
+          fi
+          echo "CI is $STATUS on $SHA — waiting ${INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s elapsed)"
+          sleep "$INTERVAL"
+          ELAPSED=$((ELAPSED + INTERVAL))
+        done

--- a/.github/release-actions/wait-for-ci/action.yml
+++ b/.github/release-actions/wait-for-ci/action.yml
@@ -9,6 +9,10 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        # Resolve HEAD at the moment this step runs. Callers must invoke
+        # this action AFTER checkout and BEFORE any local commits (e.g. a
+        # version bump) so we verify CI on the commit that was actually
+        # fetched from the remote, not on a runner-local commit.
         SHA=$(git rev-parse HEAD)
         echo "Checking CI status for $SHA"
 

--- a/.github/scripts/update-version-refs.cjs
+++ b/.github/scripts/update-version-refs.cjs
@@ -1,8 +1,13 @@
 const fs = require('fs');
 
-const version = process.argv[2];
+const args = process.argv.slice(2);
+const flags = new Set(args.filter(a => a.startsWith('--')));
+const positional = args.filter(a => !a.startsWith('--'));
+const version = positional[0];
+const isPrerelease = flags.has('--prerelease');
+
 if (!version) {
-  console.error('Usage: node update-version-refs.cjs <version>');
+  console.error('Usage: node update-version-refs.cjs <version> [--prerelease]');
   process.exit(1);
 }
 
@@ -10,6 +15,21 @@ if (!version) {
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 pkg.version = version;
 fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+// Update package-lock.json version to match
+const lockPath = 'package-lock.json';
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+lock.version = version;
+if (lock.packages && lock.packages['']) {
+  lock.packages[''].version = version;
+}
+fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
+
+// Prereleases do not move the documented install command or the release.yml
+// input description — those both track the latest stable version.
+if (isPrerelease) {
+  process.exit(0);
+}
 
 // Update version references in docs
 for (const file of ['docs/getting-started.md']) {
@@ -20,15 +40,6 @@ for (const file of ['docs/getting-started.md']) {
   );
   fs.writeFileSync(file, content);
 }
-
-// Update package-lock.json version to match
-const lockPath = 'package-lock.json';
-const lock = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
-lock.version = version;
-if (lock.packages && lock.packages['']) {
-  lock.packages[''].version = version;
-}
-fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
 
 // Update release workflow description with next possible versions
 const [major, minor, patch] = version.split('.').map(Number);

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Prerelease version (e.g. 0.5.0-beta.1, 1.0.0-rc.2, 0.5.0-alpha.3)'
+        description: 'Prerelease version, counter >= 1 (e.g. 0.5.0-beta.1, 1.0.0-rc.2, 0.5.0-alpha.3)'
         required: true
         type: string
 
@@ -29,40 +29,41 @@ jobs:
         run: |
           # Project convention: x.y.z-<id>.<n>. Narrower than the full semver
           # grammar on purpose — the dist-tag is derived from <id>, so we
-          # require a single alphabetic identifier and a numeric counter.
-          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z][a-zA-Z0-9]*\.[0-9]+$'; then
-            echo "::error::Invalid prerelease version: '$INPUT_VERSION'. Must be x.y.z-<id>.<n> (e.g. 0.5.0-beta.1). For stable releases use the Release workflow."
+          # require a single alphabetic identifier. The counter <n> must
+          # start at 1 (0 is rejected) to match the documented convention
+          # and avoid accidentally publishing `@beta.0` when the first
+          # beta was intended to be `@beta.1`.
+          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z][a-zA-Z0-9]*\.[1-9][0-9]*$'; then
+            echo "::error::Invalid prerelease version: '$INPUT_VERSION'. Must be x.y.z-<id>.<n> with <n> >= 1 (e.g. 0.5.0-beta.1). For stable releases use the Release workflow."
             exit 1
           fi
 
           CURRENT_VERSION=$(node -p "require('./package.json').version")
 
-          if [ "$INPUT_VERSION" = "$CURRENT_VERSION" ]; then
-            echo "::error::Version $INPUT_VERSION is the same as the current package.json version"
-            exit 1
-          fi
-
           # Base (x.y.z) of the prerelease must be strictly greater than the
-          # current stable version. Prevents tagging e.g. 0.3.0-beta.1 or
-          # 0.4.3-beta.1 when current stable is 0.4.3, which would place the
-          # prerelease semantically before/at an already-published release.
+          # current stable version. This also subsumes the prior exact-match
+          # check: INPUT == CURRENT would require CURRENT to contain a
+          # prerelease suffix (since INPUT is required to), but we strip any
+          # suffix from CURRENT below for robustness, so equal bases fail
+          # the strictly-greater test and are rejected here.
           BASE_VERSION="${INPUT_VERSION%%-*}"
+          CURRENT_BASE="${CURRENT_VERSION%%-*}"
           IS_GREATER=$(node -e "
             const [aMaj, aMin, aPat] = process.argv[1].split('.').map(Number);
             const [bMaj, bMin, bPat] = process.argv[2].split('.').map(Number);
             const gt = aMaj > bMaj || (aMaj === bMaj && aMin > bMin) || (aMaj === bMaj && aMin === bMin && aPat > bPat);
             console.log(gt ? 'yes' : 'no');
-          " "$BASE_VERSION" "$CURRENT_VERSION")
+          " "$BASE_VERSION" "$CURRENT_BASE")
           if [ "$IS_GREATER" != "yes" ]; then
-            echo "::error::Prerelease base $BASE_VERSION must be strictly greater than current stable $CURRENT_VERSION"
+            echo "::error::Prerelease base $BASE_VERSION must be strictly greater than current stable $CURRENT_BASE"
             exit 1
           fi
 
-          # Reject if the tag already exists on the remote. Re-checked
-          # immediately before `git push` below to narrow the race window.
-          git fetch --tags --quiet
-          if git rev-parse -q --verify "refs/tags/v$INPUT_VERSION" >/dev/null; then
-            echo "::error::Tag v$INPUT_VERSION already exists"
+          # Early-exit check against the remote for a nicer error than
+          # `git push` would give. The authoritative guard is `--atomic` on
+          # the push itself, which fails server-side if the tag exists.
+          if git ls-remote --exit-code --tags origin "refs/tags/v$INPUT_VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$INPUT_VERSION already exists on the remote"
             exit 1
           fi
 
@@ -85,25 +86,20 @@ jobs:
           git commit -m "chore: prerelease v$INPUT_VERSION"
           git tag "v$INPUT_VERSION"
 
-          # Re-check remote for the tag just before pushing, in case a
-          # concurrent workflow dispatch tagged the same version between
-          # the validation step and now.
-          git fetch --tags --quiet
-          if git ls-remote --exit-code --tags origin "refs/tags/v$INPUT_VERSION" >/dev/null 2>&1; then
-            echo "::error::Tag v$INPUT_VERSION appeared on remote between validation and push — aborting"
-            exit 1
-          fi
-
-          # Push the tag only — main is not modified.
-          git push origin "v$INPUT_VERSION"
+          # Push the tag only — main is not modified. `--atomic` makes the
+          # tag creation fail server-side if the ref already exists (e.g. a
+          # concurrent workflow dispatch tagged the same version), rather
+          # than silently diverging.
+          git push --atomic origin "v$INPUT_VERSION"
 
       - name: Extract npm dist-tag from version
         id: disttag
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # 0.5.0-beta.1 -> beta ; 1.0.0-rc.2 -> rc ; 0.5.0-alpha.3 -> alpha
-          TAG=$(echo "$INPUT_VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z][a-zA-Z0-9]*)\.[0-9]+$/\1/')
+          # 0.5.0-beta.1 -> beta ; 1.0.0-rc.2 -> rc ; 0.5.0-alpha.3 -> alpha.
+          # Counter pattern matches the validation regex (>= 1).
+          TAG=$(echo "$INPUT_VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z][a-zA-Z0-9]*)\.[1-9][0-9]*$/\1/')
           if [ -z "$TAG" ] || [ "$TAG" = "$INPUT_VERSION" ]; then
             echo "::error::Could not extract dist-tag from $INPUT_VERSION"
             exit 1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -41,11 +41,12 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./package.json').version")
 
           # Base (x.y.z) of the prerelease must be strictly greater than the
-          # current stable version. This also subsumes the prior exact-match
-          # check: INPUT == CURRENT would require CURRENT to contain a
-          # prerelease suffix (since INPUT is required to), but we strip any
-          # suffix from CURRENT below for robustness, so equal bases fail
-          # the strictly-greater test and are rejected here.
+          # current stable version. Equal bases are rejected, which also
+          # subsumes the INPUT == CURRENT check. In the normal flow
+          # CURRENT_VERSION is always a clean x.y.z (main only ever holds
+          # stable versions), so the suffix strip is a no-op — it's a
+          # no-cost safety net if package.json was manually edited to
+          # contain a prerelease string.
           BASE_VERSION="${INPUT_VERSION%%-*}"
           CURRENT_BASE="${CURRENT_VERSION%%-*}"
           IS_GREATER=$(node -e "
@@ -67,7 +68,7 @@ jobs:
             exit 1
           fi
 
-          echo "Publishing prerelease v$INPUT_VERSION (current stable: v$CURRENT_VERSION)"
+          echo "Publishing prerelease v$INPUT_VERSION (current stable: v$CURRENT_BASE)"
 
       - uses: ./.github/release-actions/wait-for-ci
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,103 @@
+name: Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Prerelease version (e.g. 0.5.0-beta.1, 1.0.0-rc.2, 0.5.0-alpha.3)'
+        required: true
+        type: string
+
+permissions: read-all
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Validate version input
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # Must match x.y.z-<identifier>.<n> format (semver prerelease)
+          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z][a-zA-Z0-9]*\.[0-9]+$'; then
+            echo "::error::Invalid prerelease version: '$INPUT_VERSION'. Must be x.y.z-<id>.<n> (e.g. 0.5.0-beta.1). For stable releases use the Release workflow."
+            exit 1
+          fi
+
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$INPUT_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "::error::Version $INPUT_VERSION is the same as the current package.json version"
+            exit 1
+          fi
+
+          # Reject if the tag already exists on the remote
+          git fetch --tags --quiet
+          if git rev-parse -q --verify "refs/tags/v$INPUT_VERSION" >/dev/null; then
+            echo "::error::Tag v$INPUT_VERSION already exists"
+            exit 1
+          fi
+
+          echo "Publishing prerelease v$INPUT_VERSION (current stable: v$CURRENT_VERSION)"
+
+      - uses: ./.github/release-actions/wait-for-ci
+
+      - name: Bump version (runner only)
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: node .github/scripts/update-version-refs.cjs "$INPUT_VERSION" --prerelease
+
+      - name: Create throwaway commit and push tag only
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: prerelease v$INPUT_VERSION"
+          git tag "v$INPUT_VERSION"
+          # Push the tag only — main is not modified.
+          git push origin "v$INPUT_VERSION"
+
+      - name: Extract npm dist-tag from version
+        id: disttag
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # 0.5.0-beta.1 -> beta ; 1.0.0-rc.2 -> rc ; 0.5.0-alpha.3 -> alpha
+          TAG=$(echo "$INPUT_VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z][a-zA-Z0-9]*)\.[0-9]+$/\1/')
+          if [ -z "$TAG" ] || [ "$TAG" = "$INPUT_VERSION" ]; then
+            echo "::error::Could not extract dist-tag from $INPUT_VERSION"
+            exit 1
+          fi
+          echo "Using npm dist-tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build, pack, and sign
+        uses: ./.github/release-actions/build-pack-sign
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Publish to npmjs
+        run: npm publish --access public --provenance --tag "${{ steps.disttag.outputs.tag }}"
+
+      - name: Create GitHub Release (prerelease)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "v$INPUT_VERSION" \
+            --title "v$INPUT_VERSION" \
+            --prerelease \
+            --generate-notes \
+            "bouncesecurity-aghast-${INPUT_VERSION}.tgz" \
+            "bouncesecurity-aghast-${INPUT_VERSION}.tgz.sigstore"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,9 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # Must match x.y.z-<identifier>.<n> format (semver prerelease)
+          # Project convention: x.y.z-<id>.<n>. Narrower than the full semver
+          # grammar on purpose — the dist-tag is derived from <id>, so we
+          # require a single alphabetic identifier and a numeric counter.
           if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z][a-zA-Z0-9]*\.[0-9]+$'; then
             echo "::error::Invalid prerelease version: '$INPUT_VERSION'. Must be x.y.z-<id>.<n> (e.g. 0.5.0-beta.1). For stable releases use the Release workflow."
             exit 1
@@ -40,7 +42,24 @@ jobs:
             exit 1
           fi
 
-          # Reject if the tag already exists on the remote
+          # Base (x.y.z) of the prerelease must be strictly greater than the
+          # current stable version. Prevents tagging e.g. 0.3.0-beta.1 or
+          # 0.4.3-beta.1 when current stable is 0.4.3, which would place the
+          # prerelease semantically before/at an already-published release.
+          BASE_VERSION="${INPUT_VERSION%%-*}"
+          IS_GREATER=$(node -e "
+            const [aMaj, aMin, aPat] = process.argv[1].split('.').map(Number);
+            const [bMaj, bMin, bPat] = process.argv[2].split('.').map(Number);
+            const gt = aMaj > bMaj || (aMaj === bMaj && aMin > bMin) || (aMaj === bMaj && aMin === bMin && aPat > bPat);
+            console.log(gt ? 'yes' : 'no');
+          " "$BASE_VERSION" "$CURRENT_VERSION")
+          if [ "$IS_GREATER" != "yes" ]; then
+            echo "::error::Prerelease base $BASE_VERSION must be strictly greater than current stable $CURRENT_VERSION"
+            exit 1
+          fi
+
+          # Reject if the tag already exists on the remote. Re-checked
+          # immediately before `git push` below to narrow the race window.
           git fetch --tags --quiet
           if git rev-parse -q --verify "refs/tags/v$INPUT_VERSION" >/dev/null; then
             echo "::error::Tag v$INPUT_VERSION already exists"
@@ -65,6 +84,16 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: prerelease v$INPUT_VERSION"
           git tag "v$INPUT_VERSION"
+
+          # Re-check remote for the tag just before pushing, in case a
+          # concurrent workflow dispatch tagged the same version between
+          # the validation step and now.
+          git fetch --tags --quiet
+          if git ls-remote --exit-code --tags origin "refs/tags/v$INPUT_VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$INPUT_VERSION appeared on remote between validation and push — aborting"
+            exit 1
+          fi
+
           # Push the tag only — main is not modified.
           git push origin "v$INPUT_VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,46 +56,7 @@ jobs:
 
           echo "Releasing v$INPUT_VERSION (current: v$CURRENT_VERSION)"
 
-      - name: Verify CI passed on current commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA=$(git rev-parse HEAD)
-          echo "Checking CI status for $SHA"
-
-          MAX_WAIT=600  # 10 minutes
-          INTERVAL=15
-          ELAPSED=0
-
-          while true; do
-            RUN_JSON=$(gh run list --commit "$SHA" --workflow CI --json conclusion,status --jq '.[0] // empty')
-            if [ -z "$RUN_JSON" ]; then
-              echo "::error::No CI run found for commit $SHA. Ensure CI has run on main before releasing."
-              exit 1
-            fi
-
-            STATUS=$(echo "$RUN_JSON" | jq -r '.status')
-            CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion // empty')
-
-            if [ "$STATUS" = "completed" ]; then
-              if [ "$CONCLUSION" = "success" ]; then
-                echo "CI passed on $SHA"
-                break
-              else
-                echo "::error::CI did not pass on commit $SHA (conclusion: $CONCLUSION). Fix CI before releasing."
-                exit 1
-              fi
-            fi
-
-            # CI is still running — wait
-            if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
-              echo "::error::Timed out waiting for CI on commit $SHA (status: $STATUS after ${ELAPSED}s)"
-              exit 1
-            fi
-            echo "CI is $STATUS on $SHA — waiting ${INTERVAL}s (${ELAPSED}s/${MAX_WAIT}s elapsed)"
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
+      - uses: ./.github/release-actions/wait-for-ci
 
       - name: Update version references
         env:
@@ -120,28 +81,13 @@ jobs:
           git tag "v$INPUT_VERSION"
           git push origin "v$INPUT_VERSION"
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Build, pack, and sign
+        uses: ./.github/release-actions/build-pack-sign
         with:
-          node-version: '24'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: npm ci
-
-      - name: Build and pack
-        run: |
-          npm run build
-          npm pack
+          version: ${{ inputs.version }}
 
       - name: Publish to npmjs
         run: npm publish --access public --provenance
-
-      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Sign release artifact
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: cosign sign-blob --yes --bundle "bouncesecurity-aghast-${INPUT_VERSION}.tgz.sigstore" "bouncesecurity-aghast-${INPUT_VERSION}.tgz"
 
       - name: Create GitHub Release
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 - `src/formatters/sarif-formatter.ts` — SARIF output formatter
 - `src/formatters/types.ts` — Formatter type definitions
 - `.github/workflows/release.yml` — Release workflow (version bump, README update, tag, build, GitHub release)
+- `.github/workflows/prerelease.yml` — Prerelease workflow (tag-only bump, publishes to npm under non-`latest` dist-tag derived from `<id>`)
+- `.github/release-actions/` — Composite actions shared by `release.yml` and `prerelease.yml` (CI-wait polling, build/pack/sign)
 - `eslint.config.js` — ESLint flat config (TypeScript + recommended rules)
 - `config/prompts/` — Generic prompt templates prepended to all check executions (selected via `--generic-prompt` or `AGHAST_GENERIC_PROMPT`); includes `false-positive-validation.md` and `general-vuln-discovery.md` used when `analysisMode` is set in check definitions
 - `docs/README.md` — Documentation index
@@ -173,6 +175,18 @@ Releases are created via the `release.yml` GitHub Actions workflow (triggered ma
 3. Creates git tag `v<version>`, builds, packs, publishes to GitHub Packages, creates GitHub Release with tarball
 
 Users install via `npm install -g @bouncesecurity/aghast@<version>` (requires `~/.npmrc` with `@bouncesecurity` scope config).
+
+### Prerelease Workflow
+
+Prereleases (betas, release candidates) are published via the `prerelease.yml` GitHub Actions workflow (also `workflow_dispatch`):
+
+1. Input a version in the form `x.y.z-<id>.<n>` (e.g. `0.5.0-beta.1`). Base `x.y.z` must be strictly greater than current stable; `<id>` must be alphabetic (`beta` / `rc` / `alpha`); `<n>` must be `>= 1`.
+2. Workflow bumps `package.json` / `package-lock.json` in the runner only — `main` is NOT modified, so subsequent stable `release.yml` runs still see the current stable as the base for their strictly-greater check.
+3. Creates and pushes only the tag `v<version>` (version-bump commit is reachable only through the tag). Uses `git push --atomic` so concurrent dispatches fail cleanly.
+4. Publishes to npm with `npm publish --tag <id>` — the default `latest` dist-tag is unchanged, so `npm install @bouncesecurity/aghast` keeps resolving to the stable release. Users opt in via `npm install @bouncesecurity/aghast@<id>`.
+5. GitHub Release is marked `--prerelease` so it doesn't appear as "Latest" on the releases page.
+
+Shared build/sign/CI-wait steps live in `.github/release-actions/` and are consumed by both workflows.
 
 ## Documentation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,6 +50,22 @@ Releases are created via the **Release** GitHub Actions workflow (`workflow_disp
 
 If a release fixes a disclosed security vulnerability, update the generated GitHub Release notes to explicitly call out the fix. Include the CVE ID when one has been assigned.
 
+## Prereleases
+
+Prereleases (betas, release candidates) are published via the **Prerelease** GitHub Actions workflow (`workflow_dispatch`):
+
+1. Go to **Actions > Prerelease > Run workflow**
+2. Enter a prerelease version in the form `x.y.z-<id>.<n>` (e.g. `0.5.0-beta.1`, `1.0.0-rc.2`, `0.5.0-alpha.3`). The base `x.y.z` must be strictly greater than the current stable version; `<id>` must be alphabetic (`beta` / `rc` / `alpha`); `<n>` is a numeric counter starting at `1`.
+3. The workflow automatically:
+   - Bumps `package.json` and `package-lock.json` in the runner only — `main` is **not** modified, so subsequent stable releases via the Release workflow still see the current stable version as the base for the "strictly greater" check.
+   - Creates and pushes only the tag `v<version>` (the version-bump commit is reachable only through the tag).
+   - Builds, packs, signs, and publishes to npm with `--tag <id>` (e.g. `--tag beta`). The default `latest` dist-tag is unaffected, so `npm install @bouncesecurity/aghast` continues to resolve to the stable release.
+   - Creates a GitHub Release marked as **pre-release** so it doesn't appear as "Latest" on the releases page.
+
+Users opt into a prerelease explicitly with `npm install -g @bouncesecurity/aghast@<id>` (e.g. `@beta`).
+
+The two shared composite actions used by both `release.yml` and `prerelease.yml` live under `.github/release-actions/`.
+
 ---
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/prerelease.yml` — publishes to npm under a non-`latest` dist-tag (derived from the version identifier: `0.5.0-beta.1` → `beta`, `1.0.0-rc.2` → `rc`, etc.) so prereleases don't supersede the stable release for `npm install @bouncesecurity/aghast`.
- The version bump commits live only on a pushed tag — `main` is never modified — so subsequent stable releases still pass the strictly-greater version check in `release.yml`.
- Extracts shared CI-wait and build/pack/sign steps into composite actions under `.github/release-actions/` and updates `release.yml` to use them. Stable release behavior is unchanged.
- Extends `update-version-refs.cjs` with a `--prerelease` flag that skips the `docs/getting-started.md` install-command rewrite and the `release.yml` input-description rewrite.

## How to use

Trigger the new workflow via `workflow_dispatch` with a prerelease version like `0.5.0-beta.1`. After publishing:

- `npm install @bouncesecurity/aghast` → still installs the stable release (unchanged).
- `npm install @bouncesecurity/aghast@beta` → installs the prerelease.
- GitHub Releases page marks it as "Pre-release"; stable release still shows as "Latest".

## Test plan

- [ ] Dispatch `prerelease.yml` with a low-impact version (e.g. `0.4.4-beta.0`) and verify:
  - [ ] `main` has no new commits after the run
  - [ ] Tag `v0.4.4-beta.0` exists on origin
  - [ ] `npm view @bouncesecurity/aghast dist-tags` shows `latest: 0.4.3, beta: 0.4.4-beta.0`
  - [ ] `npm install -g @bouncesecurity/aghast` (no tag) still installs `0.4.3`
  - [ ] `npm install -g @bouncesecurity/aghast@beta` installs the prerelease
  - [ ] GitHub Releases marks it as "Pre-release"
- [ ] Dispatch `release.yml` with a stable version afterwards to confirm the composite-action refactor didn't regress the stable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)