### PR TITLE
Rename AGHAST_MOCK_OPENANT to AGHAST_OPENANT_DATASET

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `
 - GitHub Actions CI runs on push to main and all PRs
 - The CLI supports `AGHAST_MOCK_AI=true` to use a mock AI provider (no API key needed), or `AGHAST_MOCK_AI=<path>` to supply a custom response fixture file
 - `AGHAST_MOCK_SEMGREP=<path>` — Provide a SARIF file to use instead of running Semgrep (for testing targeted/static checks without Semgrep installed)
-- `AGHAST_MOCK_OPENANT=<path>` — Provide a JSON file to use instead of running OpenAnt (for testing targeted checks with openant discovery without OpenAnt installed)
+- `AGHAST_OPENANT_DATASET=<path>` — Provide a pre-generated OpenAnt dataset JSON file to use instead of invoking `openant parse`. Used for tests (so suites pass without OpenAnt installed) and supports production use cases like caching the dataset across runs or splitting OpenAnt into a separate CI job
 - `AGHAST_SKIP_SEMGREP_TESTS=true` — Skip real Semgrep integration tests (used in CI main job; Semgrep tests run in a separate CI job)
 - **When adding new functionality, always add CLI-level integration tests** in `tests/cli-mock-mode.test.ts` that spawn the real CLI process with `AGHAST_MOCK_AI=true`. These tests exercise the full pipeline (prompt building, response parsing, snippet extraction, issue enrichment, report generation) end-to-end. Include tests for PASS, FAIL, and ERROR scenarios as appropriate.
 
@@ -104,7 +104,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_LOCAL_CLAUDE` — Set to `true` to use local Claude instead of API
 - `AGHAST_MOCK_AI` — Enables mock AI provider. Set to `true` for default `{"issues":[]}` response, or set to a file path
 - `AGHAST_MOCK_SEMGREP` — Path to SARIF file for mock Semgrep output
-- `AGHAST_MOCK_OPENANT` — Path to JSON file for mock OpenAnt output
+- `AGHAST_OPENANT_DATASET` — Path to a pre-generated OpenAnt dataset JSON file (skips invoking `openant parse`)
 - `AGHAST_DEBUG_PRINTPROMPT` — Print full prompts (requires `--debug`)
 - `NO_COLOR` — Set to `1` to disable colored CLI output (standard; respected automatically by `picocolors`)
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -45,7 +45,7 @@ Run `aghast scan --help` for the full list of options.
 | `AGHAST_LOG_FILE` | Log file path (CLI `--log-file` takes precedence) |
 | `AGHAST_LOG_TYPE` | Log file handler type (CLI `--log-type` takes precedence) |
 | `AGHAST_MOCK_SEMGREP` | Path to a SARIF file to use instead of running Semgrep (for testing `semgrep` discovery without Semgrep installed) |
-| `AGHAST_MOCK_OPENANT` | Path to a dataset JSON file to use instead of running `openant parse` (for testing `openant` discovery without OpenAnt installed) |
+| `AGHAST_OPENANT_DATASET` | Path to a pre-generated OpenAnt dataset JSON file. When set, aghast uses this dataset directly instead of invoking `openant parse`. Useful for caching the dataset across multiple scans, splitting OpenAnt and aghast into separate CI jobs, running aghast where Python 3.11+ isn't available, or stubbing OpenAnt output in tests |
 | `NO_COLOR` | Set to `1` to disable colored CLI output ([standard](https://no-color.org/)) |
 
 ## Runtime Configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -499,7 +499,7 @@ export async function runScan(args: string[]): Promise<void> {
   }
 
   // ─── Conditional OpenAnt verification ───
-  if (needsOpenant && !process.env.AGHAST_MOCK_OPENANT) {
+  if (needsOpenant && !process.env.AGHAST_OPENANT_DATASET) {
     try {
       await verifyOpenAntInstalled();
     } catch (err) {

--- a/src/openant-runner.ts
+++ b/src/openant-runner.ts
@@ -22,10 +22,11 @@ function getOpenAntBinary(): string {
 /**
  * Verify that OpenAnt is installed and available on PATH.
  * Resolves if found, rejects with a user-friendly error if not.
- * Skips the check when AGHAST_MOCK_OPENANT is set.
+ * Skips the check when AGHAST_OPENANT_DATASET is set (the dataset is
+ * supplied directly, so there is no need to invoke OpenAnt).
  */
 export async function verifyOpenAntInstalled(): Promise<void> {
-  if (process.env.AGHAST_MOCK_OPENANT) return;
+  if (process.env.AGHAST_OPENANT_DATASET) return;
   const binary = getOpenAntBinary();
   return new Promise((resolve, reject) => {
     execFile(binary, ['--help'], (error) => {
@@ -42,7 +43,9 @@ export async function verifyOpenAntInstalled(): Promise<void> {
 
 /**
  * Execute `openant parse` and return the path to the generated dataset.json.
- * If AGHAST_MOCK_OPENANT env var is set, copies that file to a temp location instead.
+ * If AGHAST_OPENANT_DATASET env var is set, uses that file instead of invoking
+ * OpenAnt. Useful in CI pipelines that cache the dataset across runs, in
+ * environments without Python 3.11+, or for tests that stub the OpenAnt output.
  *
  * The caller is responsible for cleaning up the returned temp directory via
  * the cleanup function returned alongside the dataset path.
@@ -50,18 +53,18 @@ export async function verifyOpenAntInstalled(): Promise<void> {
 export async function runOpenAnt(
   repositoryPath: string,
 ): Promise<{ datasetPath: string; cleanup: () => Promise<void> }> {
-  const mockFile = process.env.AGHAST_MOCK_OPENANT;
-  if (mockFile) {
-    logDebug(TAG, `Mock mode: using dataset from ${mockFile}`);
+  const preloadedDataset = process.env.AGHAST_OPENANT_DATASET;
+  if (preloadedDataset) {
+    logDebug(TAG, `Using preloaded dataset from ${preloadedDataset}`);
     // Copy to temp dir so cleanup logic is consistent
-    const tmpDir = await mkdtemp(join(tmpdir(), 'aghast-openant-mock-'));
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aghast-openant-preloaded-'));
     const datasetPath = join(tmpDir, 'dataset.json');
-    await copyFile(mockFile, datasetPath);
+    await copyFile(preloadedDataset, datasetPath);
     return {
       datasetPath,
       cleanup: async () => {
         await rm(tmpDir, { recursive: true, force: true }).catch((err) => {
-          logDebug(TAG, `Failed to clean up mock temp directory ${tmpDir}: ${err}`);
+          logDebug(TAG, `Failed to clean up temp directory ${tmpDir}: ${err}`);
         });
       },
     };

--- a/tests/cli-openant.test.ts
+++ b/tests/cli-openant.test.ts
@@ -1,6 +1,6 @@
 /**
  * CLI integration tests for the openant discovery type.
- * Spawns the real CLI process with AGHAST_MOCK_AI=true and AGHAST_MOCK_OPENANT=<dataset>.
+ * Spawns the real CLI process with AGHAST_MOCK_AI=true and AGHAST_OPENANT_DATASET=<dataset>.
  */
 
 import { describe, it, before, after } from 'node:test';
@@ -42,7 +42,7 @@ describe('CLI: openant discovery type', () => {
 
   it('should PASS with default mock AI response (empty issues)', async () => {
     const result = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_OPENANT: openantDataset },
+      { AGHAST_MOCK_AI: 'true', AGHAST_OPENANT_DATASET: openantDataset },
       [
         fixtureRepo,
         '--config-dir', openantConfigDir,
@@ -62,7 +62,7 @@ describe('CLI: openant discovery type', () => {
 
   it('should FAIL when mock AI returns issues', async () => {
     const result = await runCLI(
-      { AGHAST_MOCK_AI: failFixtureRepo, AGHAST_MOCK_OPENANT: openantDataset },
+      { AGHAST_MOCK_AI: failFixtureRepo, AGHAST_OPENANT_DATASET: openantDataset },
       [
         fixtureRepo,
         '--config-dir', openantConfigDir,
@@ -103,7 +103,7 @@ describe('CLI: openant discovery type', () => {
 
   it('should PASS with base (non-enhanced) dataset', async () => {
     const result = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_OPENANT: openantBaseDataset },
+      { AGHAST_MOCK_AI: 'true', AGHAST_OPENANT_DATASET: openantBaseDataset },
       [
         fixtureRepo,
         '--config-dir', openantConfigDir,
@@ -122,7 +122,7 @@ describe('CLI: openant discovery type', () => {
 
   it('should include scan metadata in output', async () => {
     const result = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_OPENANT: openantDataset },
+      { AGHAST_MOCK_AI: 'true', AGHAST_OPENANT_DATASET: openantDataset },
       [
         fixtureRepo,
         '--config-dir', openantConfigDir,

--- a/tests/openant-integration.itest.ts
+++ b/tests/openant-integration.itest.ts
@@ -24,8 +24,8 @@ const skip = !!process.env.AGHAST_SKIP_OPENANT_TESTS || !opnInstalled;
 
 describe('OpenAnt integration tests', { skip }, () => {
   before(() => {
-    // Ensure AGHAST_MOCK_OPENANT is not set
-    delete process.env.AGHAST_MOCK_OPENANT;
+    // Ensure AGHAST_OPENANT_DATASET is not set
+    delete process.env.AGHAST_OPENANT_DATASET;
   });
 
   it('runOpenAnt parses test codebase and produces dataset.json', async () => {


### PR DESCRIPTION
## Summary

The `AGHAST_MOCK_OPENANT` env var is increasingly used outside of testing — callers cache the OpenAnt dataset between scans, split OpenAnt parsing into a separate CI job, or run `aghast` on hosts without Python 3.11+ available. The "MOCK" framing no longer fits any of those flows. The implementation just swaps in a supplied dataset instead of invoking `openant parse`; it doesn't mock anything.

This PR renames it to `AGHAST_OPENANT_DATASET` and updates the surrounding docs and code comments to describe it as a "preloaded dataset" rather than a mock.

- **`src/index.ts`, `src/openant-runner.ts`** — read the renamed env var; refresh comments / debug log messages.
- **`docs/scanning.md`, `CLAUDE.md`** — document the renamed var and expand the description to cover the non-testing use cases (cached datasets, split CI jobs, hosts without Python 3.11+).
- **`tests/cli-openant.test.ts`, `tests/openant-integration.itest.ts`** — update env var name and temp-dir prefix.

## Test plan

- [x] `npm test` — 641 pass, 2 skipped, 0 failed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)