### PR TITLE
OpenCode agent provider, rename AI provider to agent provider, maxIssuesPerTarget cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  REGRESSION_TEST_MODEL: opencode/big-pickle
+
 permissions:
   contents: read
 
@@ -284,6 +287,92 @@ jobs:
 
       - name: Run OpenAnt integration tests
         run: npm run test:openant
+
+  opencode-integration:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ github.event.repository.name == 'aghast' && fromJSON('["windows-latest","ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install OpenCode CLI
+        run: npm install -g opencode-ai
+
+      - name: Run OpenCode integration tests (with retry)
+        run: npm run test:opencode || npm run test:opencode || npm run test:opencode
+        timeout-minutes: 10
+
+  regression-test-sarif:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install OpenCode CLI
+        run: npm install -g opencode-ai
+
+      - name: Clone public checks repo
+        run: git clone --depth=1 https://github.com/BounceSecurity/aghast-bounce-checks-public.git checks-config-public
+
+      - name: Run regression test (test-9, SARIF false-positive validation, with retry)
+        run: |
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-9-sast-false-positives --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-9-sast-false-positives --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-9-sast-false-positives --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }}
+        timeout-minutes: 20
+
+  regression-test-semgrep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install OpenCode CLI
+        run: npm install -g opencode-ai
+
+      - run: echo semgrep > requirements.txt
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Install Semgrep
+        run: pip install -r requirements.txt
+
+      - name: Clone public checks repo
+        run: git clone --depth=1 https://github.com/BounceSecurity/aghast-bounce-checks-public.git checks-config-public
+
+      - name: Run regression test (test-2, targeted Semgrep+AI, with retry)
+        run: |
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }}
+        timeout-minutes: 20
 
   build-and-install:
     needs: [check-ci-skip]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Six core components orchestrated by the Security Scanner:
 
 1. **Security Scanner** — Orchestrator that coordinates the scan workflow, executes checks, and aggregates results
 2. **Check Library** — Two-layer config: loads check registry from `checks-config.json` (Layer 1: id, repositories, enabled) and per-check definitions from `checks/<id>/<id>.json` (Layer 2: name, instructions, severity, checkTarget) within a config directory specified via `--config-dir`. Merges layers, filters by repository, loads markdown instructions from each check folder.
-3. **AI Provider** — Abstraction layer over LLM APIs (reference impl: Claude Code)
+3. **Agent Provider** — Abstraction layer over agent SDKs / harnesses that delegate to LLMs (reference impls: Claude Code, OpenCode)
 4. **Repository Analyzer** — Extracts Git metadata (remote URL, branch, commit) from target repos
 5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, OpenAnt, and SARIF providers find code locations for targeted/static checks
 6. **Report Generator** — Produces `security_checks_results.json` (or `.sarif`) conforming to the `ScanResults` schema
@@ -43,11 +43,11 @@ Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `
 ## Testing
 
 - All tests use `node:test` and `node:assert` — no external test dependencies
-- AI provider must be mocked/stubbed in all tests — never depend on live API access
+- Agent provider must be mocked/stubbed in all tests — never depend on live API access
 - Tests must pass without `ANTHROPIC_API_KEY` set
 - Test fixtures live alongside tests: sample configs, markdown checks, AI responses, SARIF output
 - GitHub Actions CI runs on push to main and all PRs
-- The CLI supports `AGHAST_MOCK_AI=true` to use a mock AI provider (no API key needed), or `AGHAST_MOCK_AI=<path>` to supply a custom response fixture file
+- The CLI supports `AGHAST_MOCK_AI=true` to use a mock agent provider (no API key needed), or `AGHAST_MOCK_AI=<path>` to supply a custom response fixture file
 - `AGHAST_MOCK_SEMGREP=<path>` — Provide a SARIF file to use instead of running Semgrep (for testing targeted/static checks without Semgrep installed)
 - `AGHAST_OPENANT_DATASET=<path>` — Provide a pre-generated OpenAnt dataset JSON file to use instead of invoking `openant parse`. Used for tests (so suites pass without OpenAnt installed) and supports production use cases like caching the dataset across runs or splitting OpenAnt into a separate CI job
 - `AGHAST_SKIP_SEMGREP_TESTS=true` — Skip real Semgrep integration tests (used in CI main job; Semgrep tests run in a separate CI job)
@@ -74,7 +74,7 @@ The unified entry point is `src/cli.ts` which routes to `runScan()` (from `src/i
 - `npm run build` — Compile TypeScript
 - `npm run lint` — Run ESLint on src/ and tests/
 - `npm run lint:fix` — Run ESLint with auto-fix on src/ and tests/
-- `npm run scan -- <repo-path> --config-dir <path> [--output <path>] [--output-format json|sarif] [--fail-on-check-failure] [--debug] [--log-level <level>] [--log-file <path>] [--log-type <type>] [--model <model>] [--ai-provider <name>] [--generic-prompt <file>] [--runtime-config <path>]` — Run checks (`--config-dir` required, default format: `json`, default output: `<repo-path>/security_checks_results.<ext>`, exit 1 on FAIL/ERROR with `--fail-on-check-failure`, `--debug` is shorthand for `--log-level debug`, `--log-file` writes all logs to a file at trace level). Discovery methods (Semgrep, OpenAnt, SARIF) are configured per-check via `checkTarget.discovery` in check definitions. Precedence: CLI flags > env vars > runtime config > defaults.
+- `npm run scan -- <repo-path> --config-dir <path> [--output <path>] [--output-format json|sarif] [--fail-on-check-failure] [--debug] [--log-level <level>] [--log-file <path>] [--log-type <type>] [--model <model>] [--agent-provider <name>] [--generic-prompt <file>] [--runtime-config <path>]` — Run checks (`--config-dir` required, default format: `json`, default output: `<repo-path>/security_checks_results.<ext>`, exit 1 on FAIL/ERROR with `--fail-on-check-failure`, `--debug` is shorthand for `--log-level debug`, `--log-file` writes all logs to a file at trace level). Discovery methods (Semgrep, OpenAnt, SARIF) are configured per-check via `checkTarget.discovery` in check definitions. Precedence: CLI flags > env vars > runtime config > defaults.
 - `npm run new-check -- --config-dir <path> [--id <id> --name <name> ...]` — Interactive CLI to scaffold a new check (creates check folder with `<id>.json`, `<id>.md`, optional `<id>.yaml` Semgrep rule + tests; appends to `checks-config.json`). Bootstraps config directory if it doesn't exist.
 - `npm run build-config -- --config-dir <path> [--non-interactive] [--provider <name>] [--model <id>] [--output-format json|sarif] [--log-level <level>] [--clear <field>] ...` — Build or edit `runtime-config.json`. Interactive when no value flags are given; non-interactive when `--non-interactive` is passed (or when all needed values come from flags). Loads existing config so omitted fields stay untouched. Models come from `provider.listModels()`: the Claude Code provider tries `@anthropic-ai/sdk` `models.list()` first when `ANTHROPIC_API_KEY` is set (full canonical list with display names), then falls back to `claude-agent-sdk` `supportedModels()` (curated 3 aliases — works with `AGHAST_LOCAL_CLAUDE=true`).
 
@@ -95,7 +95,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 
 ## Environment Variables
 
-- `ANTHROPIC_API_KEY` — Required for Claude Code AI provider (unless `AGHAST_LOCAL_CLAUDE=true`)
+- `ANTHROPIC_API_KEY` — Required for Claude Code agent provider (unless `AGHAST_LOCAL_CLAUDE=true`)
 - `AGHAST_CONFIG_DIR` — Default config directory (CLI `--config-dir` takes precedence)
 - `AGHAST_AI_MODEL` — AI model override (CLI `--model` takes precedence)
 - `AGHAST_GENERIC_PROMPT` — Generic prompt template filename (CLI `--generic-prompt` takes precedence)
@@ -104,7 +104,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_LOG_FILE` — Log file path (CLI `--log-file` takes precedence)
 - `AGHAST_LOG_TYPE` — Log file handler type (CLI `--log-type` takes precedence, default: `file`)
 - `AGHAST_LOCAL_CLAUDE` — Set to `true` to use local Claude instead of API
-- `AGHAST_MOCK_AI` — Enables mock AI provider. Set to `true` for default `{"issues":[]}` response, or set to a file path
+- `AGHAST_MOCK_AI` — Enables mock agent provider. Set to `true` for default `{"issues":[]}` response, or set to a file path
 - `AGHAST_MOCK_SEMGREP` — Path to SARIF file for mock Semgrep output
 - `AGHAST_OPENANT_DATASET` — Path to a pre-generated OpenAnt dataset JSON file (skips invoking `openant parse`)
 - `AGHAST_DEBUG_PRINTPROMPT` — Print full prompts (requires `--debug`)
@@ -125,7 +125,9 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 - `src/discoveries/semgrep-discovery.ts` — Semgrep discovery provider (runs Semgrep rules, parses SARIF output into targets)
 - `src/discoveries/openant-discovery.ts` — OpenAnt discovery provider (runs OpenAnt to extract code units with call graph context)
 - `src/discoveries/sarif-discovery.ts` — SARIF discovery provider (reads external SARIF files for AI validation)
-- `src/claude-code-provider.ts` — Claude Code AI provider implementation using `@anthropic-ai/claude-agent-sdk`
+- `src/claude-code-provider.ts` — Claude Code agent provider implementation using `@anthropic-ai/claude-agent-sdk`
+- `src/opencode-provider.ts` — OpenCode agent provider implementation using `@opencode-ai/sdk` (supports 75+ LLM providers)
+- `src/provider-utils.ts` — Shared provider utilities (OUTPUT_SCHEMA for structured output)
 - `src/prompt-template.ts` — Prompt builder (prepends generic instructions to check markdown)
 - `src/snippet-extractor.ts` — Code snippet extractor (extracts lines from source files for issue enrichment)
 - `src/sarif-parser.ts` — SARIF 2.1.0 parser (`parseSARIF`, `deduplicateTargets`, `limitTargets`)
@@ -163,7 +165,7 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 
 ## Conventions
 
-- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=AI provider, E4xxx=repository/target validation, E5xxx=Semgrep, E9xxx=internal/fatal.
+- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep, E9xxx=internal/fatal.
 - **Color output**: Use helpers from `src/colors.ts` for colored output, never raw ANSI codes. The `NO_COLOR` env var is respected automatically via `picocolors`.
 
 ## Development Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ All new functionality must include tests. Specifically:
 - **CLI-level integration tests** in `tests/cli-mock-mode.test.ts` that spawn the real CLI process with `AGHAST_MOCK_AI=true`. These exercise the full pipeline end-to-end.
 - Include tests for **PASS**, **FAIL**, and **ERROR** scenarios as appropriate.
 - Tests use `node:test` and `node:assert` (Node.js built-in) — no external test frameworks.
-- The AI provider must be mocked/stubbed in all tests — tests must pass without `ANTHROPIC_API_KEY` set.
+- The agent provider must be mocked/stubbed in all tests — tests must pass without `ANTHROPIC_API_KEY` set.
 
 Run the test suite with:
 

--- a/config/prompts/general-vuln-discovery.md
+++ b/config/prompts/general-vuln-discovery.md
@@ -18,13 +18,14 @@ For each code unit, ask yourself:
 - What can an attacker control? (request body, URL params, headers, query strings)
 - Where does that input end up? (database queries, HTTP requests, file operations, authorization decisions)
 - What guarantees does the code assume but not enforce? (atomicity, ownership, trust boundaries, data types)
-- Are multi-step operations safe if executed concurrently by multiple users?
+- Are multi-step operations safe if executed concurrently by multiple users? (check-then-act on shared state — stock, balances, quotas, uniqueness — without `FOR UPDATE`, transactions, or atomic conditional updates is a TOCTOU race)
+- Are security-sensitive values (password reset tokens, session IDs, API keys, CSRF tokens, invitation codes, one-time codes) generated with cryptographically secure randomness? `Math.random()`, `Date.now()`, timestamps, or PIDs are predictable and unsafe for anything that gates authentication or authorization.
 
 BEFORE REPORTING — VALIDATE EACH FINDING:
 
 Before including any issue in your response, you MUST be able to answer YES to all of these:
-1. Can I construct a specific HTTP request (or sequence of requests) that triggers this vulnerability?
-2. After the exploit, what specific harm has occurred? Name ONE of: unauthorized data accessed, unauthorized action performed, authentication/authorization bypassed, server made to contact an attacker-controlled or internal endpoint, arbitrary code/query executed. If the harm is only "bad data in a database" (wrong types, negative numbers) with no further security consequence in this codebase, it is NOT a finding.
+1. Can I construct a specific HTTP request (or sequence of requests) that triggers this vulnerability? For race conditions, two or more concurrent requests count as a valid "sequence" — you do not need a single-request exploit.
+2. After the exploit, what specific harm has occurred? Name ONE of: unauthorized data accessed, unauthorized action performed, authentication/authorization bypassed (including via predictable security tokens that gate auth, e.g. reset tokens generated from `Math.random()`), server made to contact an attacker-controlled or internal endpoint, arbitrary code/query executed, or financial/inventory state corrupted in a way an attacker can exploit for value (e.g. overselling limited stock, double-spending balance, bypassing quota). Pure data-quality bugs (wrong types, missing length checks) with no security or value consequence are NOT findings.
 3. Does the exploit work against THIS codebase as written — including all middleware, route registrations, and existing validation? Do not ignore protections that exist outside the function body (e.g., middleware applied at route registration time).
 
 If you cannot answer YES to all three, do not report the issue.
@@ -36,6 +37,9 @@ Only report vulnerabilities that meet ALL of these criteria:
 - The vulnerability leads to a concrete security impact (data breach, unauthorized access, privilege escalation, code execution, etc.)
 - The vulnerability exists in the code AS WRITTEN — do not speculate about missing features, future code, or how the code might be used differently
 - The impact is demonstrated end-to-end in THIS codebase — not dependent on hypothetical downstream consumers of stored data
+
+EXCEPTION — predictable security tokens:
+The "end-to-end demonstration" and "no hypothetical downstream consumer" rules above DO NOT apply when code generates a value with a predictable source (`Math.random()`, `Date.now()`, timestamps, counters, non-CSPRNG hashes) AND the value's name or surrounding context indicates it functions as a credential or capability (reset/recovery tokens, session IDs, API keys, OTPs, magic links, CSRF tokens, invitation codes, etc.). Naming and intent are sufficient evidence — you do not need to find the consumer in this codebase. Report at the generation site; treat the harm as "authentication/authorization bypassed via predictable token". This exception applies only to values whose purpose is to authenticate a user, authorise an action, or establish a recoverable session — NOT to identifiers used purely for logging, tracing, or UI rendering, even if their names contain "token", "id", or "key".
 
 Do NOT report:
 - Missing input validation that has no security impact (e.g., missing length checks, type checks, or negative number checks unless they lead to a specific exploit like bypassing authorization)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ my-checks/
       aghast-sqli.yaml        # Semgrep rule (for checks with semgrep discovery)
       tests/                  # Semgrep rule test files
         aghast-sqli.py        # .py, .js, or .ts based on --language
-  runtime-config.json          # (Optional) AI provider & reporting overrides
+  runtime-config.json          # (Optional) Agent provider & reporting overrides
 ```
 
 Use `aghast new-check --config-dir <path>` to bootstrap this structure. If the directory doesn't exist, it will be created automatically.
@@ -164,6 +164,7 @@ Each check folder contains a JSON definition file with the check's metadata.
 | `checkTarget.sarifFile` | `string`                 | Yes***** | Path to SARIF file relative to target repository (*****only for `sarif` discovery) |
 | `checkTarget.maxTargets` | `number`               | No       | Limit number of targets/units to analyze |
 | `checkTarget.concurrency` | `number`              | No       | Max parallel AI analyses for targeted checks (default: 5) |
+| `checkTarget.maxIssuesPerTarget` | `number`       | No       | Cap on issues returned per target. When set, only the first N entries of the AI's `issues` array are kept (excess dropped with a debug log). Use for checks whose prompt expects a single combined issue per target and where the model occasionally splits or duplicates findings. Omit for unlimited. |
 | `checkTarget.openant` | `object`                  | No       | OpenAnt unit filter config (only for `openant` discovery). See below |
 | `checkTarget.openant.unitTypes` | `string[]`       | No       | Include only these unit types (e.g. `["function", "method"]`) |
 | `checkTarget.openant.excludeUnitTypes` | `string[]` | No      | Exclude these unit types (e.g. `["test", "dunder_method"]`) |
@@ -219,7 +220,7 @@ What this check looks for and why it matters.
 | `PASS` | No issues found. The code meets the check requirements |
 | `FAIL` | Issues found. The code does not meet the check requirements |
 | `FLAG` | AI is uncertain. Human review is recommended |
-| `ERROR` | The check could not be completed (e.g. AI provider error) |
+| `ERROR` | The check could not be completed (e.g. agent provider error) |
 
 When multiple targets are analyzed, the overall status is the worst: FAIL > FLAG > ERROR > PASS.
 
@@ -239,7 +240,7 @@ An optional `runtime-config.json` file in the config directory (or specified via
 
 ```json
 {
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "model": "claude-sonnet-4-20250514"
   },
@@ -259,8 +260,8 @@ An optional `runtime-config.json` file in the config directory (or specified via
 
 | Field                           | Type       | Default | Description |
 |---------------------------------|------------|---------|-------------|
-| `aiProvider.name`               | `string`   | `claude-code` | AI provider name |
-| `aiProvider.model`              | `string`   | (provider default) | Model ID override |
+| `agentProvider.name`            | `string`   | `claude-code` | Agent provider name (`claude-code` or `opencode`) |
+| `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/big-pickle`) |
 | `reporting.outputDirectory`     | `string`   | (target repo) | Directory for result files |
 | `reporting.outputFormat`        | `string`   | `json` | Output format: `json` or `sarif` |
 | `logging.logFile`               | `string`   | (none) | Path to log file. When set, all log output is written to this file |

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,16 +24,23 @@ During development, you can use the npm scripts directly:
 ```bash
 npm run scan -- <repo-path> [options]
 npm run new-check -- [options]
+npm run build-config -- --config-dir <path> [options]  # Build or edit runtime-config.json
 npm run build
 npm test
 npm run test:coverage  # Run the unit test suite with Node.js coverage enabled
 npm run test:ci        # Run tests with spec and JUnit reporters (for CI)
 npm run test:semgrep   # Run real Semgrep integration tests (requires Semgrep installed)
+npm run test:openant   # Run real OpenAnt integration tests (requires OpenAnt + Python 3.11+)
+npm run test:opencode  # Run real OpenCode integration tests (requires OpenCode installed)
 npm run lint
 npm run lint:fix       # Run ESLint with auto-fix
 ```
 
+`npm run build-config` is the CLI users normally invoke as `aghast build-config`. It interactively edits `runtime-config.json` or accepts flags for scripted use — see [Runtime Configuration](configuration.md#runtime-configuration) for the full schema and flag list.
+
 `npm run test:coverage` uses Node.js built-in test coverage support (`--experimental-test-coverage`) so contributors can measure coverage without adding a separate coverage toolchain.
+
+The three `test:<tool>` scripts run real integration tests against external binaries and are **not** part of the default `npm test` suite — they require those tools installed locally. CI runs them in dedicated jobs.
 
 ## Releasing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,11 @@ This guide walks you through installing aghast and setting up your environment.
 - **Node.js 20+**
 - **[Semgrep Community Edition](https://semgrep.dev/docs/getting-started/)** (LGPL-2.1) - only required if your checks use `semgrep` discovery
 - **[OpenAnt](https://github.com/knostic/OpenAnt)** + **Python 3.11+** + **Go** (for building) - only required if your checks use `openant` discovery
-- **Anthropic API key** - required for AI-based checks (`repository` and `targeted` types; not needed for `static` checks)
+- **An agent provider** - required for AI-based checks (`repository` and `targeted` types; not needed for `static` checks). Pick one:
+  - An **Anthropic API key** for the default `claude-code` provider, or
+  - **[OpenCode](https://opencode.ai)** installed and authenticated for the `opencode` provider, which delegates to any of the 75+ LLM providers OpenCode supports.
+
+  See [Scanning → Agent Providers](scanning.md#agent-providers) for the full comparison.
 
 ## 1. Install aghast
 
@@ -28,13 +32,40 @@ To uninstall:
 npm uninstall -g @bouncesecurity/aghast
 ```
 
-## 2. Set up your API key
+## 2. Set up an agent provider
+
+Required for `repository` and `targeted` checks. Skip this step entirely if you only plan to run `static` checks.
+
+**Option A — Claude Code (default)**
 
 ```bash
 export ANTHROPIC_API_KEY=your-api-key
 ```
 
-This is required for `repository` and `targeted` checks. You can skip this step if you only plan to run `static` checks.
+Claude Code is the default provider, so no flag is needed at scan time. To override the model, pass `--model <name>` per scan (see [Scanning](scanning.md)) or pin a default as shown below.
+
+**Option B — OpenCode**
+
+Install OpenCode from [https://opencode.ai](https://opencode.ai), then run `opencode` and use `/connect` to configure credentials for at least one LLM provider. Then pick either per-scan flags or a persistent default:
+
+```bash
+# Per-scan:
+aghast scan <repo-path> --config-dir <path> --agent-provider opencode --model opencode/big-pickle
+```
+
+**Pin defaults (applies to both options).** Use `aghast build-config` to write a `runtime-config.json` in your config directory so future scans use your chosen provider and model without any flags:
+
+```bash
+aghast build-config --config-dir <path>            # interactive (covers both options)
+
+# Option A — pin claude-code with a specific model:
+aghast build-config --config-dir <path> --provider claude-code --model sonnet --non-interactive
+
+# Option B — pin opencode with a specific model:
+aghast build-config --config-dir <path> --provider opencode --model opencode/big-pickle --non-interactive
+```
+
+See [Configuration Reference → Runtime Configuration](configuration.md#runtime-configuration) for the full schema.
 
 ## What's next
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -212,7 +212,7 @@ When a static rule alone can definitively answer the question. For example, "doe
 4. Each finding is mapped directly to a security issue. The description comes from the discovery method's output (e.g., the Semgrep rule's `message` field)
 5. Issues are enriched with code snippets and written to the output file
 
-This check type doesn't require an AI provider API key, making it fast and free to run.
+This check type doesn't require an agent provider API key, making it fast and free to run.
 
 ---
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -26,7 +26,7 @@ aghast scan <repo-path> --config-dir <path> [options]
 | `--log-file <path>` | Write all log output to a file (captures at `trace` level by default) |
 | `--log-type <type>` | Log file handler type (default: `file`). Pluggable; new types can be added |
 | `--model <model>` | AI model override (e.g. `claude-sonnet-4-20250514`) |
-| `--ai-provider <name>` | AI provider name (default: `claude-code`) |
+| `--agent-provider <name>` | Agent provider name (default: `claude-code`) |
 | `--generic-prompt <file>` | Generic prompt template filename |
 | `--runtime-config <path>` | Path to runtime config file. Useful for setting persistent defaults instead of repeating CLI flags |
 
@@ -47,6 +47,28 @@ Run `aghast scan --help` for the full list of options.
 | `AGHAST_MOCK_SEMGREP` | Path to a SARIF file to use instead of running Semgrep (for testing `semgrep` discovery without Semgrep installed) |
 | `AGHAST_OPENANT_DATASET` | Path to a pre-generated OpenAnt dataset JSON file. When set, aghast uses this dataset directly instead of invoking `openant parse`. Useful for caching the dataset across multiple scans, splitting OpenAnt and aghast into separate CI jobs, running aghast where Python 3.11+ isn't available, or stubbing OpenAnt output in tests |
 | `NO_COLOR` | Set to `1` to disable colored CLI output ([standard](https://no-color.org/)) |
+
+## Agent Providers
+
+aghast supports multiple agent providers via the `--agent-provider` flag or `agentProvider.name` in runtime config.
+
+| Provider | `--agent-provider` | `--model` format | Prerequisites |
+|----------|--------------------|------------------|---------------|
+| Claude Code (default) | `claude-code` | Model name (e.g. `haiku`, `sonnet`) | `ANTHROPIC_API_KEY` env var |
+| OpenCode | `opencode` | `providerID/modelID` (e.g. `opencode/big-pickle`, `cursor-acp/composer-2-fast`) | [OpenCode CLI](https://opencode.ai) installed and configured |
+
+### Using OpenCode
+
+The OpenCode provider delegates to any of the 75+ LLM providers supported by [OpenCode](https://opencode.ai). To use it:
+
+1. Install OpenCode: follow the instructions at https://opencode.ai
+2. Configure a provider: run `opencode` and use `/connect` to set up credentials
+3. Run a scan:
+   ```bash
+   aghast scan ./my-repo --config-dir ./checks --agent-provider opencode --model opencode/big-pickle
+   ```
+
+The default model is `opencode/big-pickle`. Use the `providerID/modelID` format to select any configured provider and model.
 
 ## Runtime Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+        "@opencode-ai/sdk": "^1.4.6",
         "dotenv": "^17.3.1",
-        "hono": "^4.12.14",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.4"
       },
@@ -865,6 +865,15 @@
         }
       }
     },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.6.tgz",
+      "integrity": "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -948,6 +957,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -1152,6 +1162,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1529,6 +1540,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1734,6 +1746,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2085,6 +2098,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2526,6 +2540,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2936,6 +2951,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3052,6 +3068,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:ci": "node --import tsx --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml tests/*.test.ts",
     "test:semgrep": "node --import tsx --test tests/semgrep-integration.itest.ts",
     "test:openant": "node --import tsx --test tests/openant-integration.itest.ts",
+    "test:opencode": "node --import tsx --test --test-force-exit tests/opencode-integration.itest.ts",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint --fix src/ tests/",
     "scan": "tsx src/cli.ts scan",
@@ -48,8 +49,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@opencode-ai/sdk": "^1.4.6",
     "dotenv": "^17.3.1",
-    "hono": "^4.12.14",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4"
   },

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -21,8 +21,8 @@ import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { loadRuntimeConfig } from './runtime-config.js';
 import { createProviderByName, getProviderNames, DEFAULT_PROVIDER_NAME } from './provider-registry.js';
 import { getAvailableFormats } from './formatters/index.js';
-import { getAvailableLogTypes, isValidLogLevel } from './logging.js';
-import { DEFAULT_AI_MODEL } from './types.js';
+import { getAvailableLogTypes, isValidLogLevel, getLogLevel, setLogLevel } from './logging.js';
+import { DEFAULT_MODEL } from './types.js';
 import type { RuntimeConfig, ProviderModelInfo } from './types.js';
 import {
   DEFAULT_OUTPUT_FORMAT,
@@ -36,7 +36,7 @@ import {
  *  Sourced from the same constants the scanner uses at runtime — no duplication. */
 const SCAN_DEFAULTS = {
   provider: DEFAULT_PROVIDER_NAME,
-  model: DEFAULT_AI_MODEL,
+  model: DEFAULT_MODEL,
   outputFormat: DEFAULT_OUTPUT_FORMAT,
   outputDirectory: '<repo-path>', // No constant — derived at runtime from the scanned repo path
   logLevel: DEFAULT_LOG_LEVEL,
@@ -139,7 +139,7 @@ Target file:
                                 are given)
 
 Field flags (any value provided here skips its prompt; closed lists are validated):
-  --provider <name>             AI provider name (e.g. claude-code)
+  --provider <name>             Agent provider name (e.g. claude-code)
   --model <id>                  Model ID. Must be one returned by the provider's
                                 listModels() (skip flag and use interactive mode to
                                 browse the live list).
@@ -198,8 +198,8 @@ function configToFlatDefaults(config: RuntimeConfig): {
   failOnCheckFailure?: boolean;
 } {
   return {
-    provider: config.aiProvider?.name,
-    model: config.aiProvider?.model,
+    provider: config.agentProvider?.name,
+    model: config.agentProvider?.model,
     outputFormat: config.reporting?.outputFormat,
     outputDirectory: config.reporting?.outputDirectory,
     logLevel: config.logging?.level,
@@ -225,9 +225,9 @@ interface BuiltValues {
 function buildConfig(values: BuiltValues): RuntimeConfig {
   const config: RuntimeConfig = {};
   if (values.provider !== undefined || values.model !== undefined) {
-    config.aiProvider = {};
-    if (values.provider !== undefined) config.aiProvider.name = values.provider;
-    if (values.model !== undefined) config.aiProvider.model = values.model;
+    config.agentProvider = {};
+    if (values.provider !== undefined) config.agentProvider.name = values.provider;
+    if (values.model !== undefined) config.agentProvider.model = values.model;
   }
   if (values.outputFormat !== undefined || values.outputDirectory !== undefined) {
     config.reporting = {};
@@ -247,16 +247,30 @@ function buildConfig(values: BuiltValues): RuntimeConfig {
 
 async function getProviderModels(providerName: string): Promise<readonly ProviderModelInfo[]> {
   const provider = createProviderByName(providerName);
-  // Honor the AIProvider contract — initialize() before any other method call.
-  // We intentionally pass an empty config so the provider falls back to env vars (e.g.
-  // ANTHROPIC_API_KEY). For providers like Claude Code that require either a key or
-  // AGHAST_LOCAL_CLAUDE=true, initialization may throw — let it propagate so callers
-  // can catch and degrade (e.g. fall back to free-text model entry).
-  await provider.initialize({});
-  if (!provider.listModels) {
-    return [];
+  // Silence provider progress logs ("Starting OpenCode server...", etc.) during the
+  // throwaway init/teardown used to fetch the model list. The user is in an interactive
+  // picker and doesn't need to see transient server lifecycle noise. Errors still surface
+  // via thrown exceptions, which the caller catches and reports.
+  const savedLevel = getLogLevel();
+  setLogLevel('silent');
+  try {
+    // Honor the AgentProvider contract — initialize() before any other method call.
+    // We intentionally pass an empty config so the provider falls back to env vars (e.g.
+    // ANTHROPIC_API_KEY). For providers like Claude Code that require either a key or
+    // AGHAST_LOCAL_CLAUDE=true, initialization may throw — let it propagate so callers
+    // can catch and degrade (e.g. fall back to free-text model entry).
+    await provider.initialize({});
+    if (!provider.listModels) {
+      return [];
+    }
+    return await provider.listModels();
+  } finally {
+    // Providers that start subprocesses/servers (e.g. OpenCode) must be cleaned up,
+    // or the process leaks resources until Node exits. cleanup() is documented to be
+    // safe on partially-initialized providers. No-op for providers without cleanup.
+    await provider.cleanup?.();
+    setLogLevel(savedLevel);
   }
-  return await provider.listModels();
 }
 
 /** Memoising fetcher — call once per (providerName, run) and re-use the result.
@@ -489,7 +503,7 @@ export async function runBuildConfig(args: string[]): Promise<void> {
     try {
       const providers = getProviderNames();
       if (flags.provider === undefined) {
-        result.provider = await helpers.askChoice('AI provider', providers, result.provider, SCAN_DEFAULTS.provider);
+        result.provider = await helpers.askChoice('Agent provider', providers, result.provider, SCAN_DEFAULTS.provider);
       }
 
       // Resolve provider for model listing — fall back to default only for the SDK call,

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -163,6 +163,9 @@ export async function loadCheckDefinition(checkFolderPath: string): Promise<Chec
     if (ct.concurrency !== undefined && (typeof ct.concurrency !== 'number' || ct.concurrency <= 0 || !Number.isInteger(ct.concurrency))) {
       throw new Error(`Check definition "${defPath}": "checkTarget.concurrency" must be a positive integer`);
     }
+    if (ct.maxIssuesPerTarget !== undefined && (typeof ct.maxIssuesPerTarget !== 'number' || ct.maxIssuesPerTarget < 1 || !Number.isInteger(ct.maxIssuesPerTarget))) {
+      throw new Error(`Check definition "${defPath}": "checkTarget.maxIssuesPerTarget" must be a positive integer`);
+    }
     // Validate discovery field is present for targeted/static types (actual type
     // validation happens in validateCheck, after repo filtering, so unknown
     // discovery types don't crash the entire scan for unrelated checks)
@@ -521,7 +524,7 @@ export async function loadCheckDetails(
 // --- Path Filtering ---
 // Note: These path filtering functions are implemented and tested but not yet
 // wired into the scan execution path. They will be integrated in a future
-// iteration when the AI provider interface supports scoped file lists.
+// iteration when the agent provider interface supports scoped file lists.
 
 /**
  * Filter files to those matching applicablePaths globs.

--- a/src/check-types.ts
+++ b/src/check-types.ts
@@ -13,7 +13,7 @@
 export interface CheckTypeDescriptor {
   /** The string value used in check definitions. */
   readonly type: string;
-  /** Whether the check requires an AI provider. */
+  /** Whether the check requires AI analysis. */
   readonly needsAI: boolean;
   /** Whether the check requires an instructions markdown file. */
   readonly needsInstructions: boolean;

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -1,14 +1,15 @@
 /**
- * Claude Code AI provider implementation.
+ * Claude Code agent provider implementation.
  * Uses @anthropic-ai/claude-agent-sdk per spec Section 6.2 / Appendix C.8.
  */
 
-import type { AIProvider, AIResponse, ProviderConfig, CheckResponse, ProviderModelInfo, TokenUsage } from './types.js';
-import { DEFAULT_AI_MODEL, FatalProviderError } from './types.js';
-// import { parseAIResponse } from './response-parser.js';
+import type { AgentProvider, AgentResponse, ProviderConfig, CheckResponse, ProviderModelInfo, TokenUsage } from './types.js';
+import { DEFAULT_MODEL, FatalProviderError } from './types.js';
+// import { parseAgentResponse } from './response-parser.js';
 import { logProgress, logDebug, logDebugFull, createTimer } from './logging.js';
+import { OUTPUT_SCHEMA } from './provider-utils.js';
 
-const TAG = 'ai-provider';
+const TAG = 'agent-provider';
 
 /** Hit the Anthropic API /v1/models endpoint (full canonical model list). */
 async function listModelsViaApiKey(apiKey: string): Promise<readonly ProviderModelInfo[]> {
@@ -70,46 +71,10 @@ export type QueryFn = (params: {
   options: Record<string, unknown>;
 }) => AsyncIterable<Record<string, unknown>>;
 
-// JSON schema for structured output (matches spec Section 4.4)
-const OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    issues: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          file: { type: 'string' },
-          startLine: { type: 'integer' },
-          endLine: { type: 'integer' },
-          description: { type: 'string' },
-          dataFlow: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                file: { type: 'string' },
-                lineNumber: { type: 'integer' },
-                label: { type: 'string' },
-              },
-              required: ['file', 'lineNumber', 'label'],
-              additionalProperties: false,
-            },
-          },
-        },
-        required: ['file', 'startLine', 'endLine', 'description'],
-        additionalProperties: false,
-      },
-    },
-  },
-  required: ['issues'],
-  additionalProperties: false,
-} as const;
-
-export class ClaudeCodeProvider implements AIProvider {
+export class ClaudeCodeProvider implements AgentProvider {
   private apiKey: string | undefined;
   private useLocalClaude: boolean = false;
-  private model: string = DEFAULT_AI_MODEL;
+  private model: string = DEFAULT_MODEL;
   private _queryFn: QueryFn | undefined;
   private debugEnabled: boolean = false;
 
@@ -117,10 +82,16 @@ export class ClaudeCodeProvider implements AIProvider {
     this._queryFn = options?._queryFn;
   }
 
+  checkPrerequisites(): void {
+    if (!process.env.ANTHROPIC_API_KEY && process.env.AGHAST_LOCAL_CLAUDE !== 'true') {
+      throw new Error('ANTHROPIC_API_KEY environment variable is required');
+    }
+  }
+
   async initialize(config: ProviderConfig): Promise<void> {
     this.useLocalClaude = process.env.AGHAST_LOCAL_CLAUDE === 'true';
     this.apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    // Model selection priority: config.model (from AGHAST_AI_MODEL env or runtime config) > DEFAULT_AI_MODEL
+    // Model selection priority: config.model (from AGHAST_AI_MODEL env or runtime config) > DEFAULT_MODEL
     if (config.model) {
       this.model = config.model;
     }
@@ -166,7 +137,7 @@ export class ClaudeCodeProvider implements AIProvider {
     repositoryPath: string,
     logPrefix?: string,
     options?: { maxTurns?: number },
-  ): Promise<AIResponse> {
+  ): Promise<AgentResponse> {
     const queryFn = this._queryFn ?? (await import('@anthropic-ai/claude-agent-sdk')).query;
     const timer = createTimer();
     const prefix = logPrefix ? `${logPrefix} ` : '';
@@ -263,7 +234,7 @@ export class ClaudeCodeProvider implements AIProvider {
               /you've hit your limit|API Error:\s*429|rate.?limit.?exceeded/i.test(t),
             );
             if (rateLimitMatch) {
-              throw new FatalProviderError(`AI provider rate limit reached: ${rateLimitMatch}`);
+              throw new FatalProviderError(`Agent provider rate limit reached: ${rateLimitMatch}`);
             }
 
             // Detect authentication errors (401) — fail immediately, unrecoverable
@@ -271,7 +242,7 @@ export class ClaudeCodeProvider implements AIProvider {
               /API Error:\s*401/i.test(t),
             );
             if (authErrorMatch) {
-              throw new FatalProviderError(`AI provider authentication failed (401): ${authErrorMatch}`);
+              throw new FatalProviderError(`Agent provider authentication failed (401): ${authErrorMatch}`);
             }
 
             // Detect login required — fail immediately, unrecoverable without user action
@@ -279,7 +250,7 @@ export class ClaudeCodeProvider implements AIProvider {
               /not logged in/i.test(t),
             );
             if (loginRequiredMatch) {
-              throw new FatalProviderError(`AI provider not logged in: ${loginRequiredMatch}. Please authenticate before running scans.`);
+              throw new FatalProviderError(`Agent provider not logged in: ${loginRequiredMatch}. Please authenticate before running scans.`);
             }
 
             // Detect API errors surfaced as assistant text by the SDK
@@ -287,7 +258,7 @@ export class ClaudeCodeProvider implements AIProvider {
             if (apiErrorMatch) {
               consecutiveApiErrors++;
               if (consecutiveApiErrors >= MAX_API_ERROR_RETRIES) {
-                throw new Error(`AI provider API error (after ${MAX_API_ERROR_RETRIES} attempts): ${apiErrorMatch}`);
+                throw new Error(`Agent provider API error (after ${MAX_API_ERROR_RETRIES} attempts): ${apiErrorMatch}`);
               }
             } else {
               consecutiveApiErrors = 0;
@@ -332,7 +303,7 @@ export class ClaudeCodeProvider implements AIProvider {
           logProgress(TAG, `${prefix}Completed in ${timer.elapsedStr()} (${turnCount} turns, ${toolCallCount} tool calls)`);
         } else {
           const errorResult = message as { subtype: string; errors?: string[] };
-          errorMessage = errorResult.errors?.join('; ') ?? `AI provider error: ${errorResult.subtype}`;
+          errorMessage = errorResult.errors?.join('; ') ?? `Agent provider error: ${errorResult.subtype}`;
           logProgress(TAG, `${prefix}Failed: ${errorResult.subtype} (${timer.elapsedStr()})`);
         }
       }
@@ -347,7 +318,7 @@ export class ClaudeCodeProvider implements AIProvider {
     }
 
     if (!resultText && !structuredOutput && !errorMessage) {
-      throw new Error('AI provider returned no result');
+      throw new Error('Agent provider returned no result');
     }
 
     logDebug(TAG, `${prefix}Result: ${resultText.length} chars`);
@@ -356,8 +327,8 @@ export class ClaudeCodeProvider implements AIProvider {
     }
 
     // Structured output from SDK is required - we enforce JSON schema output mode.
-    // The response parser (parseAIResponse) is kept in the codebase as a potential
-    // fallback for future use cases (e.g., alternative AI providers that don't support
+    // The response parser (parseAgentResponse) is kept in the codebase as a potential
+    // fallback for future use cases (e.g., alternative agent providers that don't support
     // structured output), but this provider always requires structured output.
     if (structuredOutput) {
       return { raw: resultText, parsed: structuredOutput, tokenUsage };
@@ -365,9 +336,9 @@ export class ClaudeCodeProvider implements AIProvider {
 
     // No fallback parsing - structured output is mandatory for this provider.
     // If needed in the future, uncomment:
-    // const parsed = parseAIResponse(resultText);
+    // const parsed = parseAgentResponse(resultText);
     // return { raw: resultText, parsed: parsed ?? undefined };
-    throw new Error('AI provider did not return structured output');
+    throw new Error('Agent provider did not return structured output');
   }
 
   async validateConfig(): Promise<boolean> {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,7 +6,7 @@
  * the scanner. Single source of truth — do not duplicate these literals elsewhere.
  *
  * (Provider and model defaults live alongside their respective registries:
- *  `DEFAULT_PROVIDER_NAME` in `provider-registry.ts`, `DEFAULT_AI_MODEL` in `types.ts`.)
+ *  `DEFAULT_PROVIDER_NAME` in `provider-registry.ts`, `DEFAULT_MODEL` in `types.ts`.)
  */
 
 /** Default output format for scan reports. */

--- a/src/discoveries/openant-discovery.ts
+++ b/src/discoveries/openant-discovery.ts
@@ -46,7 +46,7 @@ export const openantDiscovery: TargetDiscovery = {
           endLine: origin.end_line,
           label: `[unit ${idx + 1}/${units.length}]`,
           promptEnrichment: formatUnitPromptSection(unit),
-          aiOptions: { maxTurns: 20 },
+          agentOptions: { maxTurns: 20 },
         };
       });
     } finally {

--- a/src/discoveries/semgrep-discovery.ts
+++ b/src/discoveries/semgrep-discovery.ts
@@ -24,8 +24,16 @@ You are analyzing a specific code location:
 You MUST:
 - Analyze ONLY this specific target location — do not search for or report issues at other locations
 - You may read other files to understand context (e.g., imports, type definitions, data flow), but only report issues for this target
-- If the code at this location is not vulnerable, return {"issues": []}
+- If the code at this location is not vulnerable, return {"issues": []} — do not "spend" the target by reporting an issue you noticed somewhere else in the file
 - Do NOT scan the broader repository for other instances of this vulnerability pattern
+
+REPORTING RULES (strict — these prevent cross-target hallucinations):
+- Each reported issue's "file"/"startLine"/"endLine" MUST point at this target's range above, OR at a line inside a function this target directly/transitively calls. They must NOT point at a sibling location (e.g. another function, another route handler, another class) that simply happens to live in the same file. If that sibling is genuinely vulnerable, it has its own target run — leave it alone here.
+
+DESCRIPTION OPENING (mandatory output contract):
+- Your description's first heading MUST identify the entry point this target represents — its function name, route path+verb, class method, or equivalent — exactly as it appears in the source. For example: a route handler → "## Missing X in DELETE /:id"; a function → "## Missing X in processPayment".
+- The rest of the description must then describe THAT specific symbol's vulnerability — not a sibling's. If, while writing, you find yourself describing a different route/function than the one you opened with, stop: you are hallucinating across targets. Discard the issue and return {"issues": []}.
+- If you noticed a real vulnerability while reading the file but it is in a sibling location, do NOT smuggle it into this target's report. That sibling has its own target run.
 `;
 }
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -26,8 +26,8 @@ export interface DiscoveredTarget {
   label: string;
   /** Extra context appended to prompt per target (e.g. call graph for openant, finding details for sarif). */
   promptEnrichment?: string;
-  /** Discovery-specific AI provider options (e.g. maxTurns for openant). */
-  aiOptions?: { maxTurns?: number };
+  /** Discovery-specific agent provider options (e.g. maxTurns for openant). */
+  agentOptions?: { maxTurns?: number };
   /** Message from the discovery tool (e.g. Semgrep finding description). */
   message?: string;
   /** Code snippet from the discovery tool (e.g. Semgrep snippet). */
@@ -106,4 +106,13 @@ export function getRegisteredDiscoveries(): string[] {
  */
 export function clearDiscoveryRegistry(): void {
   discoveryRegistry.clear();
+}
+
+/**
+ * Remove a single discovery by name. Returns true if the entry existed.
+ * Intended for tests that want to register a one-off discovery and clean
+ * it up without disturbing the standard registrations.
+ */
+export function unregisterDiscovery(name: string): boolean {
+  return discoveryRegistry.delete(name);
 }

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -4,7 +4,7 @@
  * Numbering scheme:
  *   E1xxx — CLI parsing (argument/flag/command errors)
  *   E2xxx — Configuration (config dir, checks, runtime config)
- *   E3xxx — AI provider
+ *   E3xxx — Agent provider
  *   E4xxx — Repository/target validation
  *   E5xxx — Semgrep
  *   E6xxx — OpenAnt
@@ -33,10 +33,15 @@ export const ERROR_CODES = {
   E2004: ec('E2004', 'Invalid check definition'),
   E2005: ec('E2005', 'Configuration error'),
 
-  // E3xxx — AI provider
+  // E3xxx — Agent provider
   E3001: ec('E3001', 'API key missing'),
-  E3002: ec('E3002', 'Unknown AI provider'),
+  E3002: ec('E3002', 'Unknown agent provider'),
+  // E3003 retains "AI" intentionally: it refers to the file containing the
+  // mocked AI/LLM response body, not the agent harness. Same rationale as
+  // AGHAST_MOCK_AI / AGHAST_AI_MODEL — the model and its output are AI
+  // concerns; only the provider/harness layer was renamed to "agent".
   E3003: ec('E3003', 'Mock AI response file not found'),
+  E3004: ec('E3004', 'OpenCode not installed'),
 
   // E4xxx — Repository/target validation
   E4001: ec('E4001', 'Repository path not found'),

--- a/src/formatters/types.ts
+++ b/src/formatters/types.ts
@@ -1,6 +1,6 @@
 /**
  * Output formatter interface for scan results.
- * Follows the AIProvider interface pattern from src/types.ts.
+ * Follows the AgentProvider interface pattern from src/types.ts.
  */
 
 import type { ScanResults } from '../types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,11 @@ import { analyzeRepository } from './repository-analyzer.js';
 import { loadRuntimeConfig } from './runtime-config.js';
 import { logProgress, logDebug, setLogLevel, createTimer, isValidLogLevel, initFileHandler, closeAllHandlers, getAvailableLogTypes } from './logging.js';
 import type { LogLevel } from './logging.js';
-import { MOCK_MODEL_NAME, DEFAULT_AI_MODEL, type AIProvider } from './types.js';
+import { MOCK_MODEL_NAME, DEFAULT_MODEL, type AgentProvider } from './types.js';
 import { getFormatter } from './formatters/index.js';
 import { verifySemgrepInstalled } from './semgrep-runner.js';
 import { verifyOpenAntInstalled } from './openant-runner.js';
-import { MockAIProvider } from './mock-ai-provider.js';
+import { MockAgentProvider } from './mock-agent-provider.js';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { DEFAULT_OUTPUT_FORMAT, DEFAULT_LOG_LEVEL, DEFAULT_LOG_TYPE } from './defaults.js';
 import { colorStatus } from './colors.js';
@@ -33,7 +33,7 @@ import { createRequire } from 'node:module';
 
 const TAG = 'aghast';
 
-async function createMockProvider(): Promise<AIProvider> {
+async function createMockProvider(): Promise<AgentProvider> {
   // AGHAST_MOCK_AI='true' → default empty response; AGHAST_MOCK_AI=<path> → read from that file
   const mockAiValue = process.env.AGHAST_MOCK_AI;
   let rawResponse = '{"issues": []}';
@@ -45,7 +45,7 @@ async function createMockProvider(): Promise<AIProvider> {
     }
   }
 
-  const provider = new MockAIProvider({ rawResponse });
+  const provider = new MockAgentProvider({ rawResponse });
   await provider.initialize({});
   return provider;
 }
@@ -73,7 +73,7 @@ General options:
   --log-type <type>          Log file handler type (default: file).
                              Available types: file
   --model <model>            AI model override (e.g. claude-sonnet-4-20250514)
-  --ai-provider <name>       AI provider name (default: claude-code)
+  --agent-provider <name>    Agent provider name (default: claude-code)
   --generic-prompt <file>    Generic prompt template filename in prompts/ dir
 
 Environment variables:
@@ -105,7 +105,7 @@ function parseArgs(args: string[]): {
   logType?: string;
   runtimeConfigPath?: string;
   model?: string;
-  aiProvider?: string;
+  agentProvider?: string;
   genericPrompt?: string;
 } {
   if (args.length < 1 || args[0] === '--help' || args[0] === '-h') {
@@ -128,7 +128,7 @@ function parseArgs(args: string[]): {
   let logType: string | undefined;
   let runtimeConfigPath: string | undefined;
   let model: string | undefined;
-  let aiProvider: string | undefined;
+  let agentProvider: string | undefined;
   let genericPrompt: string | undefined;
 
   for (let i = startIdx; i < args.length; i++) {
@@ -181,10 +181,10 @@ function parseArgs(args: string[]): {
         i++;
         break;
       }
-      case '--ai-provider': {
-        aiProvider = args[i + 1];
-        if (!aiProvider) {
-          console.error(formatError(ERROR_CODES.E1001, '--ai-provider requires a provider name argument'));
+      case '--agent-provider': {
+        agentProvider = args[i + 1];
+        if (!agentProvider) {
+          console.error(formatError(ERROR_CODES.E1001, '--agent-provider requires a provider name argument'));
           process.exit(1);
         }
         i++;
@@ -234,26 +234,26 @@ function parseArgs(args: string[]): {
   return {
     repositoryPath, configDir, outputPath, outputFormat,
     failOnCheckFailure, debug, logLevel, logFile, logType,
-    runtimeConfigPath, model, aiProvider, genericPrompt,
+    runtimeConfigPath, model, agentProvider, genericPrompt,
   };
 }
 
 async function createProvider(
   useMock: boolean,
-  aiProviderName: string,
+  agentProviderName: string,
   modelOverride?: string,
-): Promise<{ provider: AIProvider; modelName: string }> {
+): Promise<{ provider: AgentProvider; modelName: string }> {
   if (useMock) {
-    logProgress(TAG, `MOCK AI provider enabled via AGHAST_MOCK_AI=${process.env.AGHAST_MOCK_AI}`);
+    logProgress(TAG, `Mock provider enabled via AGHAST_MOCK_AI=${process.env.AGHAST_MOCK_AI}`);
     return { provider: await createMockProvider(), modelName: MOCK_MODEL_NAME };
   }
 
-  const provider = createProviderByName(aiProviderName);
+  const provider = createProviderByName(agentProviderName);
   await provider.initialize({
     apiKey: process.env.ANTHROPIC_API_KEY,
     model: modelOverride,
   });
-  const modelName = provider.getModelName?.() ?? DEFAULT_AI_MODEL;
+  const modelName = provider.getModelName?.() ?? DEFAULT_MODEL;
   return { provider, modelName };
 }
 
@@ -457,32 +457,35 @@ export async function runScan(args: string[]): Promise<void> {
   const needsSemgrep = checksWithDetails.some(c => c.check.checkTarget?.discovery === 'semgrep');
   const needsOpenant = checksWithDetails.some(c => c.check.checkTarget?.discovery === 'openant');
 
-  // ─── Conditional AI provider setup ───
-  const aiProviderName = parsed.aiProvider ?? runtimeConfig.aiProvider?.name ?? DEFAULT_PROVIDER_NAME;
+  // ─── Conditional agent provider setup ───
+  const agentProviderName = parsed.agentProvider ?? runtimeConfig.agentProvider?.name ?? DEFAULT_PROVIDER_NAME;
 
   if (needsAI && !useMock) {
-    // Validate AI provider name before checking credentials (config errors before auth errors)
-    if (!getProviderNames().includes(aiProviderName)) {
+    // Validate agent provider name before checking credentials (config errors before auth errors)
+    if (!getProviderNames().includes(agentProviderName)) {
       console.error(
-        formatError(ERROR_CODES.E3002, `Unknown AI provider "${aiProviderName}". Supported providers: ${getProviderNames().join(', ')}`),
+        formatError(ERROR_CODES.E3002, `Unknown agent provider "${agentProviderName}". Supported providers: ${getProviderNames().join(', ')}`),
       );
       process.exit(1);
     }
 
-    // Validate ANTHROPIC_API_KEY (not needed when using mock or local Claude)
-    if (!process.env.ANTHROPIC_API_KEY && process.env.AGHAST_LOCAL_CLAUDE !== 'true') {
-      console.error(formatError(ERROR_CODES.E3001, 'ANTHROPIC_API_KEY environment variable is required'));
+    // Validate provider-specific prerequisites (API keys, binaries, etc.)
+    try {
+      const tempProvider = createProviderByName(agentProviderName);
+      tempProvider.checkPrerequisites?.();
+    } catch (err) {
+      console.error(formatError(ERROR_CODES.E3001, err instanceof Error ? err.message : String(err)));
       process.exit(1);
     }
   }
 
   // Resolve model precedence: CLI --model > env AGHAST_AI_MODEL > runtime config > default
-  const modelOverride = parsed.model ?? process.env.AGHAST_AI_MODEL ?? runtimeConfig.aiProvider?.model;
+  const modelOverride = parsed.model ?? process.env.AGHAST_AI_MODEL ?? runtimeConfig.agentProvider?.model;
 
-  let provider: AIProvider | undefined;
+  let provider: AgentProvider | undefined;
   let modelName: string | undefined;
   if (needsAI) {
-    ({ provider, modelName } = await createProvider(useMock, aiProviderName, modelOverride));
+    ({ provider, modelName } = await createProvider(useMock, agentProviderName, modelOverride));
     if (resolvedLogLevel === 'debug' || resolvedLogLevel === 'trace') {
       provider.enableDebug?.();
     }
@@ -509,63 +512,70 @@ export async function runScan(args: string[]): Promise<void> {
     }
   }
 
-  const results = await runMultiScan({
-    repositoryPath: effectiveRepoPath,
-    checks: checksWithDetails,
-    aiProvider: provider,
-    aiModelName: needsAI ? modelName : undefined,
-    repositoryInfo: repoAnalysis?.repository,
-    aiProviderName: needsAI ? (useMock ? 'mock' : aiProviderName) : undefined,
-    configDir,
-    genericPrompt,
-  });
+  try {
+    const results = await runMultiScan({
+      repositoryPath: effectiveRepoPath,
+      checks: checksWithDetails,
+      agentProvider: provider,
+      modelName: needsAI ? modelName : undefined,
+      repositoryInfo: repoAnalysis?.repository,
+      agentProviderName: needsAI ? (useMock ? 'mock' : agentProviderName) : undefined,
+      configDir,
+      genericPrompt,
+    });
 
-  // Resolve output path: --output flag > runtime config dir > default
-  let resolvedOutputPath: string;
-  if (parsed.outputPath) {
-    resolvedOutputPath = parsed.outputPath;
-  } else if (runtimeConfig.reporting?.outputDirectory) {
-    const dir = resolve(runtimeConfig.reporting.outputDirectory);
-    resolvedOutputPath = resolve(dir, 'security_checks_results' + formatter.fileExtension);
-  } else {
-    resolvedOutputPath = resolve(effectiveRepoPath, 'security_checks_results' + formatter.fileExtension);
+    // Resolve output path: --output flag > runtime config dir > default
+    let resolvedOutputPath: string;
+    if (parsed.outputPath) {
+      resolvedOutputPath = parsed.outputPath;
+    } else if (runtimeConfig.reporting?.outputDirectory) {
+      const dir = resolve(runtimeConfig.reporting.outputDirectory);
+      resolvedOutputPath = resolve(dir, 'security_checks_results' + formatter.fileExtension);
+    } else {
+      resolvedOutputPath = resolve(effectiveRepoPath, 'security_checks_results' + formatter.fileExtension);
+    }
+    await mkdir(dirname(resolvedOutputPath), { recursive: true });
+    await writeFile(resolvedOutputPath, formatter.format(results), 'utf-8');
+
+    // Summary output
+    const statusIcon =
+      results.summary.failedChecks > 0
+        ? 'ISSUES DETECTED'
+        : results.summary.flaggedChecks > 0
+          ? 'REVIEW REQUIRED'
+          : results.summary.errorChecks > 0
+            ? 'SCAN ERROR'
+            : 'NO ISSUES DETECTED';
+
+    console.log('');
+    console.log('='.repeat(60));
+    console.log(`AGHAST Scan Complete: ${colorStatus(statusIcon)}`);
+    console.log('='.repeat(60));
+    console.log(`  Total checks:  ${results.summary.totalChecks}`);
+    console.log(`  Passed:        ${results.summary.passedChecks}`);
+    console.log(`  Failed:        ${results.summary.failedChecks}`);
+    console.log(`  Flagged:       ${results.summary.flaggedChecks}`);
+    console.log(`  Errors:        ${results.summary.errorChecks}`);
+    console.log(`  Total issues:  ${results.summary.totalIssues}`);
+    if (results.tokenUsage) {
+      console.log(`  Tokens:        ${results.tokenUsage.totalTokens.toLocaleString()} (in: ${results.tokenUsage.inputTokens.toLocaleString()}, out: ${results.tokenUsage.outputTokens.toLocaleString()})`);
+    }
+    console.log(`  Duration:      ${globalTimer.elapsedStr()}`);
+    console.log(`  Results:       ${resolvedOutputPath}`);
+    console.log('='.repeat(60));
+
+    // Exit code based on --fail-on-check-failure flag or runtime config (spec Section 9.3)
+    const failOnCheckFailure = parsed.failOnCheckFailure || runtimeConfig.failOnCheckFailure === true;
+    const shouldFail =
+      failOnCheckFailure && (results.summary.failedChecks > 0 || results.summary.errorChecks > 0);
+    await closeAllHandlers();
+    process.exit(shouldFail ? 1 : 0);
+  } finally {
+    // Clean up provider resources (e.g. OpenCode server process)
+    if (provider && 'cleanup' in provider && typeof provider.cleanup === 'function') {
+      await (provider.cleanup as () => Promise<void>)();
+    }
   }
-  await mkdir(dirname(resolvedOutputPath), { recursive: true });
-  await writeFile(resolvedOutputPath, formatter.format(results), 'utf-8');
-
-  // Summary output
-  const statusIcon =
-    results.summary.failedChecks > 0
-      ? 'ISSUES DETECTED'
-      : results.summary.flaggedChecks > 0
-        ? 'REVIEW REQUIRED'
-        : results.summary.errorChecks > 0
-          ? 'SCAN ERROR'
-          : 'NO ISSUES DETECTED';
-
-  console.log('');
-  console.log('='.repeat(60));
-  console.log(`AGHAST Scan Complete: ${colorStatus(statusIcon)}`);
-  console.log('='.repeat(60));
-  console.log(`  Total checks:  ${results.summary.totalChecks}`);
-  console.log(`  Passed:        ${results.summary.passedChecks}`);
-  console.log(`  Failed:        ${results.summary.failedChecks}`);
-  console.log(`  Flagged:       ${results.summary.flaggedChecks}`);
-  console.log(`  Errors:        ${results.summary.errorChecks}`);
-  console.log(`  Total issues:  ${results.summary.totalIssues}`);
-  if (results.tokenUsage) {
-    console.log(`  Tokens:        ${results.tokenUsage.totalTokens.toLocaleString()} (in: ${results.tokenUsage.inputTokens.toLocaleString()}, out: ${results.tokenUsage.outputTokens.toLocaleString()})`);
-  }
-  console.log(`  Duration:      ${globalTimer.elapsedStr()}`);
-  console.log(`  Results:       ${resolvedOutputPath}`);
-  console.log('='.repeat(60));
-
-  // Exit code based on --fail-on-check-failure flag or runtime config (spec Section 9.3)
-  const failOnCheckFailure = parsed.failOnCheckFailure || runtimeConfig.failOnCheckFailure === true;
-  const shouldFail =
-    failOnCheckFailure && (results.summary.failedChecks > 0 || results.summary.errorChecks > 0);
-  await closeAllHandlers();
-  process.exit(shouldFail ? 1 : 0);
 }
 
 // Auto-run when executed directly (npm run scan / tsx src/index.ts), but not when imported by cli.ts.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -88,19 +88,36 @@ export class ConsoleHandler implements LogHandler {
     if (entryPriority > this.priority) return;
 
     const levelTag = entry.level === 'info' ? '' : `[${entry.level}]`;
+    // Ensure message is always single-line
+    const message = entry.message.includes('\n')
+      ? `[base64] ${Buffer.from(entry.message, 'utf-8').toString('base64')}`
+      : entry.message;
+
     if (entry.data === undefined) {
-      console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}`);
+      console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}`);
     } else {
       const formatted = typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data);
-      // Truncate at debug level for console readability (matching legacy behavior)
+      const isMultiline = formatted.includes('\n');
       if (entry.level === 'debug') {
-        const truncated = formatted.length > 200 ? formatted.slice(0, 200) + '...' : formatted;
-        console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}: ${truncated}`);
+        // Truncate at debug level for console readability
+        if (isMultiline) {
+          const b64 = Buffer.from(formatted, 'utf-8').toString('base64');
+          console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}: [base64] ${b64}`);
+        } else {
+          const truncated = formatted.length > 200 ? formatted.slice(0, 200) + '...' : formatted;
+          console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}: ${truncated}`);
+        }
       } else if (entry.level === 'trace') {
-        // Trace: full data, newline-separated (matching legacy logDebugFull)
-        console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}:\n${formatted}`);
+        // Trace: always base64-encode data
+        const b64 = Buffer.from(formatted, 'utf-8').toString('base64');
+        console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}: [base64] ${b64}`);
       } else {
-        console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}: ${formatted}`);
+        if (isMultiline) {
+          const b64 = Buffer.from(formatted, 'utf-8').toString('base64');
+          console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}: [base64] ${b64}`);
+        } else {
+          console.log(`${entry.timestamp} [${entry.tag}]${levelTag} ${message}: ${formatted}`);
+        }
       }
     }
   }
@@ -140,11 +157,20 @@ export class FileHandler implements LogHandler {
 
     const levelTag = `[${entry.level}]`;
     let line: string;
+    const message = entry.message.includes('\n')
+      ? `[base64] ${Buffer.from(entry.message, 'utf-8').toString('base64')}`
+      : entry.message;
+
     if (entry.data === undefined) {
-      line = `${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}`;
+      line = `${entry.timestamp} [${entry.tag}]${levelTag} ${message}`;
     } else {
       const formatted = typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data);
-      line = `${entry.timestamp} [${entry.tag}]${levelTag} ${entry.message}: ${formatted}`;
+      if (entry.level === 'trace' || formatted.includes('\n')) {
+        const b64 = Buffer.from(formatted, 'utf-8').toString('base64');
+        line = `${entry.timestamp} [${entry.tag}]${levelTag} ${message}: [base64] ${b64}`;
+      } else {
+        line = `${entry.timestamp} [${entry.tag}]${levelTag} ${message}: ${formatted}`;
+      }
     }
     this.stream.write(line + '\n');
   }

--- a/src/mock-agent-provider.ts
+++ b/src/mock-agent-provider.ts
@@ -1,13 +1,13 @@
 /**
- * Lightweight mock AI provider for CLI `AGHAST_MOCK_AI` mode.
+ * Lightweight mock agent provider for CLI `AGHAST_MOCK_AI` mode.
  *
  * Returns a fixed raw response without calling any AI API.
  * This is shipped with the package (unlike the full test mock in tests/mocks/).
  */
 
-import type { AIProvider, AIResponse, ProviderConfig } from './types.js';
+import type { AgentProvider, AgentResponse, ProviderConfig } from './types.js';
 
-export class MockAIProvider implements AIProvider {
+export class MockAgentProvider implements AgentProvider {
   private rawResponse: string;
 
   constructor(options: { rawResponse: string }) {
@@ -23,7 +23,7 @@ export class MockAIProvider implements AIProvider {
     _repositoryPath: string,
     _logPrefix?: string,
     _options?: { maxTurns?: number },
-  ): Promise<AIResponse> {
+  ): Promise<AgentResponse> {
     return {
       raw: this.rawResponse,
       parsed: undefined,

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -17,7 +17,7 @@ import { stdin, stdout } from 'node:process';
 import { createRequire } from 'node:module';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { getCheckType, getValidCheckTypes } from './check-types.js';
-import { DEFAULT_AI_MODEL } from './types.js';
+import { DEFAULT_MODEL } from './types.js';
 
 const ID_PREFIX = 'aghast-';
 
@@ -218,7 +218,7 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
   // Phase 3: Severity, confidence, model, repositories
   result.severity = await askChoice('Severity', ['critical', 'high', 'medium', 'low', 'informational'], 'high', flags.severity);
   result.confidence = await askChoice('Confidence', ['high', 'medium', 'low'], 'medium', flags.confidence);
-  result.model = flags.model !== undefined ? flags.model : await askOptional(`AI model override (default: ${DEFAULT_AI_MODEL})`, undefined);
+  result.model = flags.model !== undefined ? flags.model : await askOptional(`AI model override (default: ${DEFAULT_MODEL})`, undefined);
   result.repositories = flags.repositories !== undefined ? flags.repositories : await askOptional('Repositories (comma-separated URLs, or empty for all)', undefined);
 
   // Phase 4: Instructions (only for check types/modes that need custom instructions)

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -1,0 +1,624 @@
+/**
+ * OpenCode agent provider implementation.
+ * Uses @opencode-ai/sdk v2 API to delegate to any LLM provider supported by OpenCode.
+ *
+ * Progress logging: at trace level, a 1-second poller fetches session messages to
+ * log tool calls and text parts in real-time while session.prompt() blocks.
+ */
+
+import { exec } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { rm as rmAsync } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { AgentProvider, AgentResponse, ProviderConfig, CheckResponse, ProviderModelInfo, TokenUsage } from './types.js';
+import { FatalProviderError } from './types.js';
+import { parseAgentResponse } from './response-parser.js';
+import { OUTPUT_SCHEMA } from './provider-utils.js';
+import { logProgress, logDebug, logDebugFull, createTimer, getLogLevel } from './logging.js';
+
+const execAsync = promisify(exec);
+
+const TAG = 'opencode-provider';
+const DEFAULT_OPENCODE_MODEL = 'opencode/big-pickle';
+const HEARTBEAT_INTERVAL_MS = 15000;
+const TRACE_POLL_MS = 1000;
+const CLOSE_TIMEOUT_MS = 5000;
+
+/**
+ * Parse a "providerID/modelID" string into its components.
+ * Falls back to the default if not provided.
+ */
+function parseModelString(model?: string): { providerID: string; modelID: string } {
+  const raw = model ?? DEFAULT_OPENCODE_MODEL;
+  const slashIdx = raw.indexOf('/');
+  if (slashIdx === -1) {
+    throw new Error(
+      `Invalid model format "${raw}" for opencode provider. Expected "providerID/modelID" (e.g. "anthropic/claude-sonnet-4-20250514").`,
+    );
+  }
+  return { providerID: raw.slice(0, slashIdx), modelID: raw.slice(slashIdx + 1) };
+}
+
+/** Verify that the opencode binary is installed and runnable. */
+function verifyOpenCodeInstalled(): Promise<void> {
+  // Use `exec` (single command string, always uses shell) instead of `execFile` with
+  // shell:true + args array. The latter triggers DEP0190 on Node 22+; the former does not.
+  // Shell is required on Windows to invoke opencode's .cmd wrapper — spawning .cmd
+  // directly is blocked by the CVE-2024-27980 mitigation. No user input is interpolated
+  // into the command, so there is no injection surface.
+  return new Promise((resolve, reject) => {
+    exec('opencode --version', (error, stdout, stderr) => {
+      if (error) {
+        // `exec` routes both "spawn failed" (binary not on PATH) and "ran but exited
+        // non-zero" (e.g. corrupt config, permission issue) through the same error
+        // callback. We can't tell the two apart reliably cross-platform, so the
+        // message has to cover both possibilities — otherwise a user with a broken
+        // install is sent on a wild goose chase reinstalling an already-present binary.
+        const detail = (stderr || stdout || error.message).toString().trim();
+        const suffix = detail ? ` Details: ${detail}` : '';
+        reject(new Error(
+          `OpenCode is required for the 'opencode' agent provider but \`opencode --version\` failed. ` +
+          `Either OpenCode is not installed (get it from https://opencode.ai) or the installed binary returned an error.${suffix}`,
+        ));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+// SDK client type alias
+type OpenCodeClient = InstanceType<(typeof import('@opencode-ai/sdk/v2'))['OpencodeClient']>;
+
+/** Options for constructor dependency injection (testing). */
+export interface OpenCodeProviderOptions {
+  /** Inject a mock client for testing. Skips server startup. */
+  _client?: OpenCodeClient;
+}
+
+export class OpenCodeProvider implements AgentProvider {
+  private providerID: string = '';
+  private modelID: string = '';
+  private _client: OpenCodeClient | undefined;
+  private _server: { url: string; close(): void } | undefined;
+  private debugEnabled: boolean = false;
+  private cleanedUp: boolean = false;
+  private signalHandler: (() => void) | undefined;
+  /** Refcount of project markers we created, keyed by absolute repositoryPath.
+   *  An entry exists ONLY when we created the marker — we never track pre-existing `.git`. */
+  private createdMarkers = new Map<string, number>();
+  /** FIFO async mutex serializing mutations to createdMarkers. Guards against races
+   *  between the N parallel executeCheck calls that share one repositoryPath. */
+  private markerMutex: Promise<void> = Promise.resolve();
+  /** Skip project-marker logic when a mock client was injected (tests use fake paths). */
+  private skipProjectMarker: boolean;
+
+  constructor(options?: OpenCodeProviderOptions) {
+    if (options?._client) {
+      this._client = options._client;
+    }
+    this.skipProjectMarker = !!options?._client;
+  }
+
+  checkPrerequisites(): void {
+    // OpenCode manages its own credentials — no env var prerequisites to check.
+  }
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    const parsed = parseModelString(config.model);
+    this.providerID = parsed.providerID;
+    this.modelID = parsed.modelID;
+
+    // Skip server startup if a mock client was injected via constructor
+    if (this._client) {
+      logDebug(TAG, 'Using injected client (test mode)');
+      await this.validateModel();
+      logDebug(TAG, `Provider initialized with model ${this.providerID}/${this.modelID}`);
+      return;
+    }
+
+    // Verify opencode binary is installed
+    await verifyOpenCodeInstalled();
+
+    const { createOpencode } = await import('@opencode-ai/sdk/v2');
+
+    logProgress(TAG, 'Starting OpenCode server...');
+    const opencode = await createOpencode({
+      port: 0,
+    });
+    this._client = opencode.client as OpenCodeClient;
+    this._server = opencode.server;
+    logProgress(TAG, `OpenCode server started at ${this._server!.url}`);
+
+    // Register signal handlers for cleanup on unexpected exit.
+    // SIGHUP catches terminal-window-close (sent as SIGHUP on Unix; Node maps
+    // Windows CTRL_CLOSE_EVENT to the same event) — critical for cleaning up the
+    // transient .git marker when a user closes their terminal mid-scan.
+    this.signalHandler = () => {
+      this.cleanupSync();
+      process.exit(1);
+    };
+    process.on('SIGINT', this.signalHandler);
+    process.on('SIGTERM', this.signalHandler);
+    process.on('SIGHUP', this.signalHandler);
+    if (process.platform === 'win32') {
+      process.on('SIGBREAK', this.signalHandler);
+    }
+
+    try {
+      await this.validateModel();
+    } catch (err) {
+      this.cleanupSync();
+      throw err;
+    }
+    logDebug(TAG, `Provider initialized with model ${this.providerID}/${this.modelID}`);
+  }
+
+  private async validateModel(): Promise<void> {
+    type ProviderInfo = { id: string; name: string; models?: Record<string, { name?: string }> };
+
+    const client = this._client!;
+    const result = await client.config.providers();
+    const data = result.data as { providers?: ProviderInfo[] } | undefined;
+    const providers = data?.providers ?? [];
+
+    const provider = providers.find(p => p.id === this.providerID);
+    if (!provider) {
+      const available = providers.map(p => p.id).join(', ') || '(none)';
+      throw new FatalProviderError(
+        `OpenCode provider "${this.providerID}" not found. Available providers: ${available}. Run 'opencode' and use /connect to configure providers.`,
+      );
+    }
+
+    const models = provider.models ? Object.keys(provider.models) : [];
+    if (models.length > 0 && !models.includes(this.modelID)) {
+      const available = models.map(m => `${this.providerID}/${m}`).join(', ');
+      throw new FatalProviderError(
+        `Model "${this.modelID}" not found for provider "${this.providerID}". Available models: ${available}`,
+      );
+    }
+  }
+
+  async listModels(): Promise<readonly ProviderModelInfo[]> {
+    type ProviderInfo = { id: string; name: string; models?: Record<string, { name?: string }> };
+
+    if (!this._client) {
+      throw new Error('OpenCode provider not initialized — call initialize() first');
+    }
+    const result = await this._client.config.providers();
+    const data = result.data as { providers?: ProviderInfo[] } | undefined;
+    const providers = data?.providers ?? [];
+
+    const out: ProviderModelInfo[] = [];
+    for (const provider of providers) {
+      const models = provider.models ?? {};
+      for (const [modelID, model] of Object.entries(models)) {
+        out.push({
+          id: `${provider.id}/${modelID}`,
+          label: model.name ?? modelID,
+          description: provider.name,
+        });
+      }
+    }
+    return out;
+  }
+
+  getModelName(): string {
+    return `${this.providerID}/${this.modelID}`;
+  }
+
+  setModel(model: string): void {
+    const parsed = parseModelString(model);
+    this.providerID = parsed.providerID;
+    this.modelID = parsed.modelID;
+  }
+
+  enableDebug(): void {
+    this.debugEnabled = true;
+  }
+
+  /** Run `fn` under an async FIFO mutex so refcount mutations and fs ops don't race. */
+  private async withMarkerLock<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.markerMutex;
+    let release!: () => void;
+    this.markerMutex = new Promise<void>((r) => { release = r; });
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /** Ensure `.git` exists at repositoryPath so OpenCode treats it as the project root.
+   *  No-op if a `.git` already exists (whether directory or file) — we never touch
+   *  pre-existing markers. If we create it, track it via refcount so concurrent
+   *  targets with the same path coordinate correctly. Non-fatal on failure:
+   *  falls through to whatever OpenCode does by default (walk up to parent repo),
+   *  which is what the user saw before this fix. */
+  private async ensureProjectMarker(repositoryPath: string): Promise<void> {
+    if (this.skipProjectMarker) return;
+    await this.withMarkerLock(async () => {
+      const existing = this.createdMarkers.get(repositoryPath);
+      if (existing !== undefined) {
+        this.createdMarkers.set(repositoryPath, existing + 1);
+        return;
+      }
+      if (existsSync(join(repositoryPath, '.git'))) {
+        // Pre-existing — not ours, no refcount. OpenCode will use this naturally.
+        return;
+      }
+      const gitPath = join(repositoryPath, '.git');
+      // Record BEFORE running git init. If SIGINT/SIGHUP fires while git init is
+      // running — or in the race window between init completing and the set() call
+      // — the sync cleanup handler iterates createdMarkers and rmSync's whatever's
+      // at gitPath. rmSync with { force: true } is lenient on ENOENT, so recording
+      // before a would-be-nonexistent path is safe.
+      this.createdMarkers.set(repositoryPath, 1);
+      try {
+        await execAsync('git init -q', { cwd: repositoryPath });
+        // Info-level: we are touching the user's filesystem. They should see it without --debug.
+        logProgress(
+          TAG,
+          `Created transient ${gitPath} so OpenCode treats this directory as its project root. ` +
+          `Will be removed when the scan finishes.`,
+        );
+      } catch (err) {
+        // Init failed — remove the phantom refcount so release doesn't try to rm a
+        // non-existent .git (harmless but produces a confusing warning log).
+        this.createdMarkers.delete(repositoryPath);
+        logProgress(
+          TAG,
+          `Warning: could not create project marker at ${gitPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `File reads may resolve against the nearest ancestor .git instead, which can cause ENOENT errors.`,
+        );
+      }
+    });
+  }
+
+  /** Release one reference to a project marker. When refcount hits zero, remove it.
+   *  Pre-existing (non-ours) markers are ignored. */
+  private async releaseProjectMarker(repositoryPath: string): Promise<void> {
+    if (this.skipProjectMarker) return;
+    await this.withMarkerLock(async () => {
+      const count = this.createdMarkers.get(repositoryPath);
+      if (count === undefined) return;
+      if (count > 1) {
+        this.createdMarkers.set(repositoryPath, count - 1);
+        return;
+      }
+      this.createdMarkers.delete(repositoryPath);
+      const gitPath = join(repositoryPath, '.git');
+      try {
+        await rmAsync(gitPath, { recursive: true, force: true });
+        // Removal is the symmetric cleanup — debug is fine, users don't need to see it at info.
+        logDebug(TAG, `Removed transient project marker at ${gitPath}`);
+      } catch (err) {
+        // Failure to remove leaves state on the filesystem — surface at info.
+        logProgress(
+          TAG,
+          `Warning: could not remove transient project marker at ${gitPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `You may need to remove it manually.`,
+        );
+      }
+    });
+  }
+
+  /** Synchronously wipe all markers we created. Used by signal handlers where
+   *  async cleanup is unsafe. Does NOT acquire the mutex — signal handlers run
+   *  between event loop ticks, so we observe a consistent map snapshot. */
+  private cleanupMarkersSync(): void {
+    for (const [path] of this.createdMarkers) {
+      try {
+        rmSync(join(path, '.git'), { recursive: true, force: true });
+      } catch {
+        // Best-effort in signal handler — process is about to exit anyway.
+      }
+    }
+    this.createdMarkers.clear();
+  }
+
+  async executeCheck(
+    instructions: string,
+    repositoryPath: string,
+    logPrefix?: string,
+    _options?: { maxTurns?: number },
+  ): Promise<AgentResponse> {
+    if (!this._client) {
+      throw new Error('OpenCode provider not initialized — call initialize() first');
+    }
+
+    // Ensure OpenCode treats repositoryPath as its project root. Without this, when
+    // repositoryPath is a subdirectory of some other git repo, OpenCode walks up to
+    // the ancestor .git and resolves all Read-tool paths relative to THAT directory,
+    // causing ENOENT for every target file. This creates a transient `.git` marker
+    // we remove when the scan finishes (refcounted across parallel targets).
+    await this.ensureProjectMarker(repositoryPath);
+    try {
+      return await this.executeCheckInner(instructions, repositoryPath, logPrefix);
+    } finally {
+      await this.releaseProjectMarker(repositoryPath);
+    }
+  }
+
+  private async executeCheckInner(
+    instructions: string,
+    repositoryPath: string,
+    logPrefix?: string,
+  ): Promise<AgentResponse> {
+    const client = this._client!;
+    const timer = createTimer();
+    const prefix = logPrefix ? `${logPrefix} ` : '';
+
+    // Create an isolated session for this check
+    logDebug(TAG, `${prefix}Creating session for check (cwd=${repositoryPath})`);
+    const sessionResult = await client.session.create({
+      title: 'aghast security check',
+      directory: repositoryPath,
+    });
+
+    const sessionId = sessionResult.data?.id;
+    if (!sessionId) {
+      throw new Error('Failed to create OpenCode session — no session ID returned');
+    }
+    logDebug(TAG, `${prefix}Session created: ${sessionId}`);
+
+    logDebug(TAG, `${prefix}Starting query: model=${this.providerID}/${this.modelID}, promptLen=${instructions.length}`);
+    if (this.debugEnabled) {
+      logDebugFull(TAG, `${prefix}Full prompt sent to AI`, instructions);
+    }
+
+    // At trace level, poll session messages every second for real-time progress.
+    // session.prompt() blocks, but setInterval callbacks run during the await.
+    let toolCallCount = 0;
+    let lastLoggedPartCount = 0;
+    let lastActivityTime = Date.now();
+    const logLevel = getLogLevel();
+    const isDebugOrTrace = logLevel === 'debug' || logLevel === 'trace';
+
+    const progressInterval = isDebugOrTrace ? setInterval(async () => {
+      try {
+        const messagesResult = await client.session.messages({
+          sessionID: sessionId,
+          directory: repositoryPath,
+        });
+        const messages = messagesResult.data ?? [];
+        const assistantMsg = [...messages].reverse().find(
+          (m: { info: { role: string } }) => m.info.role === 'assistant',
+        );
+        if (!assistantMsg) return;
+
+        const parts = assistantMsg.parts as Array<{
+          type: string; tool?: string; text?: string;
+          state?: {
+            status: string;
+            input?: Record<string, unknown>;
+            error?: string;
+            output?: string;
+          };
+        }>;
+        if (parts.length <= lastLoggedPartCount) return;
+
+        for (let i = lastLoggedPartCount; i < parts.length; i++) {
+          const part = parts[i];
+          lastActivityTime = Date.now();
+
+          if (part.type === 'tool') {
+            const state = part.state;
+            const toolName = part.tool ?? 'unknown';
+            const inputPreview = previewJSON(state?.input, 200);
+            if (state?.status === 'running') {
+              toolCallCount++;
+              logDebug(TAG, `${prefix}Tool[${toolCallCount}]: ${toolName} ${inputPreview} (${timer.elapsedStr()})`);
+            } else if (state?.status === 'completed') {
+              logDebug(TAG, `${prefix}Tool done: ${toolName} (${timer.elapsedStr()})`);
+            } else if (state?.status === 'error') {
+              // Tools can transition running → error between polls, so the "running" log
+              // line may never fire for this tool. Always include the input so the user
+              // can see what was being attempted, plus the error message from the SDK.
+              const errorMsg = state.error ?? '(no error message)';
+              const errorPreview = errorMsg.length > 300 ? errorMsg.slice(0, 300) + '...' : errorMsg;
+              logDebug(
+                TAG,
+                `${prefix}Tool error: ${toolName} ${inputPreview} → ${errorPreview} (${timer.elapsedStr()})`,
+              );
+            }
+          } else if (part.type === 'text' && part.text) {
+            const preview = part.text.length > 150 ? part.text.slice(0, 150) + '...' : part.text;
+            logDebug(TAG, `${prefix}Text: ${preview}`);
+          }
+        }
+        lastLoggedPartCount = parts.length;
+      } catch {
+        // Polling failure is non-fatal
+      }
+    }, TRACE_POLL_MS) : undefined;
+
+    // Heartbeat timer (all log levels)
+    const heartbeatInterval = setInterval(() => {
+      const silentSeconds = Math.round((Date.now() - lastActivityTime) / 1000);
+      if (silentSeconds >= HEARTBEAT_INTERVAL_MS / 1000) {
+        logDebug(TAG, `${prefix}Still waiting... (${timer.elapsedStr()})`);
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    let promptResult;
+    try {
+      promptResult = await client.session.prompt({
+        sessionID: sessionId,
+        model: { providerID: this.providerID, modelID: this.modelID },
+        parts: [{ type: 'text' as const, text: instructions }],
+        format: {
+          type: 'json_schema' as const,
+          schema: OUTPUT_SCHEMA,
+        },
+        directory: repositoryPath,
+      });
+    } finally {
+      if (progressInterval) clearInterval(progressInterval);
+      clearInterval(heartbeatInterval);
+    }
+
+    const info = promptResult.data?.info;
+    const parts = promptResult.data?.parts;
+
+    // Check for errors on the assistant message
+    if (info?.error) {
+      const err = info.error;
+      const errName = err.name;
+      const errMsg = 'data' in err && err.data && typeof err.data === 'object' && 'message' in err.data
+        ? String((err.data as { message: unknown }).message)
+        : errName;
+
+      // StructuredOutputError: model doesn't support JSON schema output.
+      // Fall through to text-based parsing instead of failing.
+      if (errName === 'StructuredOutputError') {
+        logDebug(TAG, `${prefix}Model does not support structured output — falling back to text parsing`);
+      } else {
+        if (errName === 'ProviderAuthError') {
+          throw new FatalProviderError(`OpenCode authentication failed: ${errMsg}. Run 'opencode' and use /connect to configure credentials.`);
+        }
+        if (errName === 'APIError' && /rate.?limit|429/i.test(errMsg)) {
+          throw new FatalProviderError(`OpenCode rate limit reached: ${errMsg}`);
+        }
+        throw new Error(`OpenCode AI error (${errName}): ${errMsg}`);
+      }
+    }
+
+    // Extract token usage
+    let tokenUsage: TokenUsage | undefined;
+    if (!info?.tokens) {
+      logDebug(TAG, `${prefix}Token usage not reported by provider`);
+    } else {
+      const tokens = info.tokens;
+      const inputTokens = tokens.input ?? 0;
+      const outputTokens = tokens.output ?? 0;
+      tokenUsage = { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens };
+      logDebug(TAG, `${prefix}Token usage: ${tokenUsage.inputTokens} in, ${tokenUsage.outputTokens} out`);
+    }
+
+    // Try structured output first (v2 API: info.structured)
+    if (info?.structured) {
+      const structuredOutput = info.structured as CheckResponse;
+      logDebug(TAG, `${prefix}Structured output: ${structuredOutput.issues?.length ?? 0} issues`);
+      logProgress(TAG, `${prefix}Completed in ${timer.elapsedStr()} (${toolCallCount} tool calls)`);
+      const rawText = extractTextFromParts(parts);
+      return { raw: rawText, parsed: structuredOutput, tokenUsage };
+    }
+
+    // Fallback: extract text from response parts and parse with response-parser
+    const rawText = extractTextFromParts(parts);
+    logDebug(TAG, `${prefix}No structured output — falling back to text parsing (${rawText.length} chars)`);
+
+    if (this.debugEnabled) {
+      logDebugFull(TAG, `${prefix}Full AI response`, rawText);
+    }
+
+    if (!rawText) {
+      throw new Error('OpenCode AI returned no text response');
+    }
+
+    const parsed = parseAgentResponse(rawText);
+    if (parsed) {
+      logDebug(TAG, `${prefix}Parsed ${parsed.issues.length} issues from text response`);
+    }
+
+    logProgress(TAG, `${prefix}Completed in ${timer.elapsedStr()} (${toolCallCount} tool calls)`);
+    return { raw: rawText, parsed: parsed ?? undefined, tokenUsage };
+  }
+
+  async validateConfig(): Promise<boolean> {
+    return !!this._client;
+  }
+
+  /** Synchronous cleanup for signal handlers (best-effort). */
+  private cleanupSync(): void {
+    if (this.cleanedUp) return;
+    this.cleanedUp = true;
+    // Remove signal handlers so cleanup() (called later via build-config's finally,
+    // or by a caller after initialize() throws) doesn't no-op and leave them installed.
+    if (this.signalHandler) {
+      process.removeListener('SIGINT', this.signalHandler);
+      process.removeListener('SIGTERM', this.signalHandler);
+      process.removeListener('SIGHUP', this.signalHandler);
+      if (process.platform === 'win32') {
+        process.removeListener('SIGBREAK', this.signalHandler);
+      }
+      this.signalHandler = undefined;
+    }
+    // Wipe any transient .git markers we created before exiting.
+    this.cleanupMarkersSync();
+    if (this._server) {
+      try {
+        this._server.close();
+      } catch {
+        // Best-effort in signal handler
+      }
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.cleanedUp) return;
+    this.cleanedUp = true;
+
+    // Remove signal handlers
+    if (this.signalHandler) {
+      process.removeListener('SIGINT', this.signalHandler);
+      process.removeListener('SIGTERM', this.signalHandler);
+      process.removeListener('SIGHUP', this.signalHandler);
+      if (process.platform === 'win32') {
+        process.removeListener('SIGBREAK', this.signalHandler);
+      }
+      this.signalHandler = undefined;
+    }
+
+    // Force-remove any markers still tracked (normally refcount already brought them
+    // to zero via releaseProjectMarker; this covers the case where executeCheck threw
+    // before reaching its finally block).
+    for (const [path] of this.createdMarkers) {
+      try {
+        await rmAsync(join(path, '.git'), { recursive: true, force: true });
+      } catch (err) {
+        logDebug(TAG, `Failed to remove marker at ${path} during cleanup: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    this.createdMarkers.clear();
+
+    if (this._server) {
+      logProgress(TAG, 'Stopping OpenCode server...');
+      try {
+        await Promise.race([
+          Promise.resolve(this._server.close()),
+          new Promise<void>((resolve) => setTimeout(() => {
+            logDebug(TAG, `Server close timed out after ${CLOSE_TIMEOUT_MS}ms`);
+            resolve();
+          }, CLOSE_TIMEOUT_MS)),
+        ]);
+      } catch (err) {
+        logDebug(TAG, `Error stopping OpenCode server: ${err}`);
+      }
+      this._server = undefined;
+      this._client = undefined;
+    }
+  }
+}
+
+/**
+ * Extract text content from an array of response parts.
+ */
+/** JSON-stringify a value and truncate to `maxLen` characters for log output. */
+function previewJSON(value: unknown, maxLen: number): string {
+  if (value === undefined) return '';
+  const str = JSON.stringify(value);
+  if (str === undefined) return '';
+  return str.length > maxLen ? str.slice(0, maxLen) + '...' : str;
+}
+
+function extractTextFromParts(parts: Array<{ type: string; text?: string }> | undefined): string {
+  if (!parts) return '';
+  return parts
+    .filter((p) => p.type === 'text' && typeof p.text === 'string')
+    .map((p) => p.text!)
+    .join('\n');
+}

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,15 +1,16 @@
 /**
- * AI Provider Registry.
+ * Agent Provider Registry.
  *
  * Allows providers to be registered by name and resolved at runtime.
- * Adding a new provider requires only implementing the AIProvider interface
+ * Adding a new provider requires only implementing the AgentProvider interface
  * and calling registerProvider.
  */
 
-import type { AIProvider } from './types.js';
+import type { AgentProvider } from './types.js';
 import { ClaudeCodeProvider } from './claude-code-provider.js';
+import { OpenCodeProvider } from './opencode-provider.js';
 
-export type ProviderFactory = () => AIProvider;
+export type ProviderFactory = () => AgentProvider;
 
 const registry = new Map<string, ProviderFactory>();
 
@@ -17,11 +18,11 @@ export function registerProvider(name: string, factory: ProviderFactory): void {
   registry.set(name, factory);
 }
 
-export function createProviderByName(name: string): AIProvider {
+export function createProviderByName(name: string): AgentProvider {
   const factory = registry.get(name);
   if (!factory) {
     throw new Error(
-      `Unknown AI provider "${name}". Supported providers: ${[...registry.keys()].join(', ')}`,
+      `Unknown agent provider "${name}". Supported providers: ${[...registry.keys()].join(', ')}`,
     );
   }
   return factory();
@@ -31,8 +32,9 @@ export function getProviderNames(): string[] {
   return [...registry.keys()];
 }
 
-/** Default provider name — used as fallback in CLI when AI_PROVIDER / runtime config not set. */
+/** Default provider name — used as fallback in CLI when agent provider / runtime config not set. */
 export const DEFAULT_PROVIDER_NAME = 'claude-code';
 
 // Register built-in providers
 registerProvider(DEFAULT_PROVIDER_NAME, () => new ClaudeCodeProvider());
+registerProvider('opencode', () => new OpenCodeProvider());

--- a/src/provider-utils.ts
+++ b/src/provider-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared utilities for agent providers.
+ */
+
+// JSON schema for structured output (matches spec Section 4.4).
+// Shared across providers to ensure consistent output format.
+export const OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          file: { type: 'string' },
+          startLine: { type: 'integer' },
+          endLine: { type: 'integer' },
+          description: { type: 'string' },
+          dataFlow: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                file: { type: 'string' },
+                lineNumber: { type: 'integer' },
+                label: { type: 'string' },
+              },
+              required: ['file', 'lineNumber', 'label'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['file', 'startLine', 'endLine', 'description'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['issues'],
+  additionalProperties: false,
+} as const;

--- a/src/response-parser.ts
+++ b/src/response-parser.ts
@@ -1,7 +1,8 @@
 /**
- * AI response parser.
- * Parses raw AI responses into CheckResponse format (spec Appendix A.3b).
- * Handles malformed JSON, missing fields, and edge cases.
+ * Response parser.
+ * Parses the raw text body of an agent provider's response into
+ * CheckResponse format (spec Appendix A.3b). Handles malformed JSON,
+ * missing fields, and edge cases.
  */
 
 import type { CheckResponse, AIIssue, DataFlowStep } from './types.js';
@@ -10,10 +11,11 @@ import { logDebug } from './logging.js';
 const TAG = 'parser';
 
 /**
- * Attempt to parse a raw AI response string into a CheckResponse.
- * Returns undefined if the response is not valid JSON or lacks the expected structure.
+ * Attempt to parse the raw text body of an agent provider's response
+ * into a CheckResponse. Returns undefined if the response is not valid
+ * JSON or lacks the expected structure.
  */
-export function parseAIResponse(raw: string): CheckResponse | undefined {
+export function parseAgentResponse(raw: string): CheckResponse | undefined {
   logDebug(TAG, `Parsing response: ${raw.length} chars`);
 
   const tryParse = (text: string): unknown => {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,6 +1,6 @@
 /**
  * Runtime configuration loader.
- * Loads runtime-config.json from the config directory to override AI provider and reporting settings.
+ * Loads runtime-config.json from the config directory to override agent provider and reporting settings.
  * Spec Section 8.1 & Appendix C.10.
  */
 
@@ -46,15 +46,21 @@ export async function loadRuntimeConfig(configDir?: string, explicitPath?: strin
   // Validate field types
   const obj = parsed as Record<string, unknown>;
   if (obj.aiProvider !== undefined) {
-    if (typeof obj.aiProvider !== 'object' || obj.aiProvider === null || Array.isArray(obj.aiProvider)) {
-      throw new Error(`Runtime config "${pathToLoad}": "aiProvider" must be an object`);
+    throw new Error(
+      `Runtime config "${pathToLoad}": "aiProvider" has been renamed to "agentProvider" in 0.5.0. ` +
+        `Update your runtime-config.json to use the new key.`,
+    );
+  }
+  if (obj.agentProvider !== undefined) {
+    if (typeof obj.agentProvider !== 'object' || obj.agentProvider === null || Array.isArray(obj.agentProvider)) {
+      throw new Error(`Runtime config "${pathToLoad}": "agentProvider" must be an object`);
     }
-    const ap = obj.aiProvider as Record<string, unknown>;
+    const ap = obj.agentProvider as Record<string, unknown>;
     if (ap.name !== undefined && typeof ap.name !== 'string') {
-      throw new Error(`Runtime config "${pathToLoad}": "aiProvider.name" must be a string`);
+      throw new Error(`Runtime config "${pathToLoad}": "agentProvider.name" must be a string`);
     }
     if (ap.model !== undefined && typeof ap.model !== 'string') {
-      throw new Error(`Runtime config "${pathToLoad}": "aiProvider.model" must be a string`);
+      throw new Error(`Runtime config "${pathToLoad}": "agentProvider.model" must be a string`);
     }
   }
   if (obj.reporting !== undefined) {

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -6,23 +6,24 @@
 
 import { readFile } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
-import { resolve, dirname } from 'node:path';
+import { resolve, relative, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildPrompt } from './prompt-template.js';
-import { parseAIResponse } from './response-parser.js';
+import { parseAgentResponse } from './response-parser.js';
 import { extractSnippet } from './snippet-extractor.js';
 import { analyzeRepository } from './repository-analyzer.js';
 import { logProgress, logDebug, createTimer } from './logging.js';
 import { CHECK_TYPE } from './check-types.js';
 import { getDiscovery, registerDiscovery } from './discovery.js';
+import { DEFAULT_PROVIDER_NAME } from './provider-registry.js';
 import { semgrepDiscovery } from './discoveries/semgrep-discovery.js';
 import { openantDiscovery } from './discoveries/openant-discovery.js';
 import { sarifDiscovery } from './discoveries/sarif-discovery.js';
 import type { DiscoveredTarget } from './discovery.js';
 import {
-  DEFAULT_AI_MODEL,
+  DEFAULT_MODEL,
   FatalProviderError,
-  type AIProvider,
+  type AgentProvider,
   type RepositoryInfo,
   type AIIssue,
   type SecurityIssue,
@@ -123,9 +124,9 @@ async function mapWithConcurrency<T, R>(
 export interface MultiScanOptions {
   repositoryPath: string;
   checks: Array<{ check: SecurityCheck; details: CheckDetails }>;
-  aiProvider?: AIProvider;
-  aiModelName?: string;
-  aiProviderName?: string;
+  agentProvider?: AgentProvider;
+  modelName?: string;
+  agentProviderName?: string;
   concurrency?: number;
   repositoryInfo?: RepositoryInfo;
   configDir?: string;
@@ -140,6 +141,57 @@ export function generateScanId(): string {
   const ts = now.toISOString().replace(/[-:T]/g, '').replace(/\..+/, '');
   const hash = randomBytes(3).toString('hex');
   return `scan-${ts}-${hash}`;
+}
+
+/**
+ * Normalize a file path to be relative to the repository root.
+ * Handles:
+ * - AI-generated paths that include the parent directory name(s) of the target repo
+ *   (e.g., "test-codebases/test-2-importantvalidations-easy/routes/execute.py" when
+ *   repo is at "checks-config/test-codebases/test-2-importantvalidations-easy")
+ * - Absolute paths: resolves and makes relative
+ * - Paths with repository prefix: strips the prefix
+ * - Relative paths: returns as-is with forward slashes
+ *
+ * This ensures consistent path formatting across all findings regardless
+ * of how the AI or discovery provider reported the path.
+ */
+function normalizeFilePath(filePath: string, repositoryPath: string): string {
+  const normalizedFile = filePath.replace(/\\/g, '/');
+
+  // If the path already looks relative and doesn't contain obvious parent refs,
+  // check if it starts with path segments that could be the parent of the repo.
+  // AI providers often return paths relative to a working directory that is
+  // different from the actual repository root, so we need to strip any
+  // prefix that leads to the repo path.
+  const normalizedRepo = resolve(repositoryPath);
+  const repoParts = normalizedRepo.replace(/\\/g, '/').split('/').filter(Boolean);
+
+  // Try stripping progressively longer trailing suffixes of the repo path from
+  // the front of the file path. AI providers often return paths relative to an
+  // ancestor directory, e.g. "test-codebases/test-2-easy/routes/run.py" when
+  // the repo is at "/abs/path/to/test-codebases/test-2-easy".
+  for (let i = 1; i <= repoParts.length; i++) {
+    const suffix = repoParts.slice(repoParts.length - i).join('/');
+    if (normalizedFile.startsWith(suffix + '/')) {
+      const candidate = normalizedFile.slice(suffix.length + 1);
+      const candidateResolved = resolve(normalizedRepo, candidate);
+      const candidateRelative = relative(normalizedRepo, candidateResolved).replace(/\\/g, '/');
+      if (!candidateRelative.startsWith('..')) {
+        return candidate;
+      }
+    }
+  }
+
+  // Fallback: resolve against repo and make relative
+  const resolved = resolve(normalizedRepo, normalizedFile);
+  const rel = relative(normalizedRepo, resolved).replace(/\\/g, '/');
+  if (!rel.startsWith('..')) {
+    return rel;
+  }
+
+  // Last resort: just normalize slashes
+  return normalizedFile;
 }
 
 // --- Single check execution helper ---
@@ -170,7 +222,7 @@ async function enrichIssue(
   const issue: SecurityIssue = {
     checkId,
     checkName,
-    file: aiIssue.file.replace(/\\/g, '/'),
+    file: normalizeFilePath(aiIssue.file, repositoryPath),
     startLine: aiIssue.startLine,
     endLine: aiIssue.endLine,
     description: aiIssue.description,
@@ -187,7 +239,7 @@ async function enrichIssue(
   if (aiIssue.dataFlow !== undefined) {
     issue.dataFlow = aiIssue.dataFlow.map((step) => ({
       ...step,
-      file: step.file.replace(/\\/g, '/'),
+      file: normalizeFilePath(step.file, repositoryPath),
     }));
   }
   return issue;
@@ -199,12 +251,12 @@ async function enrichIssue(
  */
 function applyPerCheckModel(
   check: SecurityCheck,
-  aiProvider: AIProvider | undefined,
+  agentProvider: AgentProvider | undefined,
   globalModelName: string | undefined,
 ): string | undefined {
-  if (!check.model || !aiProvider?.setModel) return undefined;
-  const previousModel = aiProvider.getModelName?.() ?? globalModelName;
-  aiProvider.setModel(check.model);
+  if (!check.model || !agentProvider?.setModel) return undefined;
+  const previousModel = agentProvider.getModelName?.() ?? globalModelName;
+  agentProvider.setModel(check.model);
   logProgress(TAG, `Using per-check model: ${check.model} (check: ${check.id})`);
   return previousModel;
 }
@@ -213,11 +265,11 @@ function applyPerCheckModel(
  * Restore the provider's model to the previous value after per-check override.
  */
 function restoreModel(
-  aiProvider: AIProvider | undefined,
+  agentProvider: AgentProvider | undefined,
   previousModel: string | undefined,
 ): void {
-  if (previousModel !== undefined && aiProvider?.setModel) {
-    aiProvider.setModel(previousModel);
+  if (previousModel !== undefined && agentProvider?.setModel) {
+    agentProvider.setModel(previousModel);
   }
 }
 
@@ -242,7 +294,7 @@ async function mapTargetToIssue(
   const issue: SecurityIssue = {
     checkId,
     checkName,
-    file: target.file.replace(/\\/g, '/'),
+    file: normalizeFilePath(target.file, repositoryPath),
     startLine: target.startLine,
     endLine: target.endLine,
     description: target.message || 'Static finding',
@@ -268,7 +320,7 @@ async function executeSingleCheck(
   checkName: string,
   checkInstructions: string,
   repositoryPath: string,
-  aiProvider: AIProvider | undefined,
+  agentProvider: AgentProvider | undefined,
   checkMetadata?: { severity?: string; confidence?: string },
   concurrency?: number,
   configDir?: string,
@@ -278,15 +330,15 @@ async function executeSingleCheck(
 
   // Route to targeted execution (discovery + AI analysis)
   if (check.checkTarget?.type === CHECK_TYPE.TARGETED) {
-    if (!aiProvider) {
-      throw new Error(`Check "${checkId}" requires an AI provider but none was configured`);
+    if (!agentProvider) {
+      throw new Error(`Check "${checkId}" requires an agent provider but none was configured`);
     }
     return executeTargetedCheck(
       check,
       checkName,
       checkInstructions,
       repositoryPath,
-      aiProvider,
+      agentProvider,
       checkMetadata,
       concurrency,
       configDir,
@@ -300,8 +352,8 @@ async function executeSingleCheck(
   }
 
   // Repository check (no discovery, AI analyzes whole repo)
-  if (!aiProvider) {
-    throw new Error(`Check "${checkId}" requires an AI provider but none was configured`);
+  if (!agentProvider) {
+    throw new Error(`Check "${checkId}" requires an agent provider but none was configured`);
   }
 
   logProgress(TAG, `Running check: ${checkName}`);
@@ -315,11 +367,11 @@ async function executeSingleCheck(
   const checkTimer = createTimer();
 
   try {
-    const aiResponse = await aiProvider.executeCheck(prompt, repositoryPath);
+    const agentResponse = await agentProvider.executeCheck(prompt, repositoryPath);
     const executionTime = checkTimer.elapsed();
 
-    logDebug(TAG, `AI response: ${aiResponse.raw.length} chars`);
-    const parsed = aiResponse.parsed ?? parseAIResponse(aiResponse.raw);
+    logDebug(TAG, `Agent response: ${agentResponse.raw.length} chars`);
+    const parsed = agentResponse.parsed ?? parseAgentResponse(agentResponse.raw);
 
     if (!parsed) {
       logProgress(TAG, 'Result: ERROR (malformed response)');
@@ -329,9 +381,9 @@ async function executeSingleCheck(
         status: 'ERROR',
         issuesFound: 0,
         executionTime,
-        error: 'AI provider returned malformed response',
-        rawAiResponse: aiResponse.raw,
-        tokenUsage: aiResponse.tokenUsage,
+        error: 'Agent provider returned malformed response',
+        rawAiResponse: agentResponse.raw,
+        tokenUsage: agentResponse.tokenUsage,
       };
     } else if (parsed.issues.length > 0) {
       logProgress(TAG, `Result: FAIL (${parsed.issues.length} issues)`);
@@ -348,7 +400,7 @@ async function executeSingleCheck(
         status: 'FAIL',
         issuesFound: issues.length,
         executionTime,
-        tokenUsage: aiResponse.tokenUsage,
+        tokenUsage: agentResponse.tokenUsage,
       };
     } else if (parsed.flagged) {
       logProgress(TAG, 'Result: FLAG (AI flagged for review)');
@@ -358,7 +410,7 @@ async function executeSingleCheck(
         status: 'FLAG',
         issuesFound: 0,
         executionTime,
-        tokenUsage: aiResponse.tokenUsage,
+        tokenUsage: agentResponse.tokenUsage,
       };
     } else {
       logProgress(TAG, 'Result: PASS');
@@ -368,7 +420,7 @@ async function executeSingleCheck(
         status: 'PASS',
         issuesFound: 0,
         executionTime,
-        tokenUsage: aiResponse.tokenUsage,
+        tokenUsage: agentResponse.tokenUsage,
       };
     }
   } catch (err) {
@@ -402,7 +454,7 @@ async function executeTargetedCheck(
   checkName: string,
   checkInstructions: string,
   repositoryPath: string,
-  aiProvider: AIProvider,
+  agentProvider: AgentProvider,
   checkMetadata?: { severity?: string; confidence?: string },
   optionsConcurrency?: number,
   configDir?: string,
@@ -490,26 +542,37 @@ async function executeTargetedCheck(
           const prompt = basePrompt + (target.promptEnrichment ?? '');
 
           logDebug(TAG, `${target.label} Analyzing: ${target.file}:${target.startLine}-${target.endLine}`);
-          const aiResponse = await aiProvider.executeCheck(
+          const agentResponse = await agentProvider.executeCheck(
             prompt,
             repositoryPath,
             target.label,
-            target.aiOptions,
+            target.agentOptions,
           );
 
-          const parsed = aiResponse.parsed ?? parseAIResponse(aiResponse.raw);
+          const parsed = agentResponse.parsed ?? parseAgentResponse(agentResponse.raw);
 
           if (!parsed) {
             logDebug(TAG, `${target.label} Returned malformed response`);
-            return { issues: [] as SecurityIssue[], error: true, flagged: false, tokenUsage: aiResponse.tokenUsage };
+            return { issues: [] as SecurityIssue[], error: true, flagged: false, tokenUsage: agentResponse.tokenUsage };
+          }
+
+          // Apply optional per-target issue cap (checkTarget.maxIssuesPerTarget).
+          // Useful for checks whose prompt expects one combined issue per target;
+          // most checks should leave it unset and allow unlimited issues per target.
+          const maxIssues = checkTarget.maxIssuesPerTarget;
+          const cappedIssues = typeof maxIssues === 'number' && maxIssues >= 0
+            ? parsed.issues.slice(0, maxIssues)
+            : parsed.issues;
+          if (cappedIssues.length < parsed.issues.length) {
+            logDebug(TAG, `${target.label} Capping ${parsed.issues.length} issues to ${maxIssues} (maxIssuesPerTarget)`);
           }
 
           const issues = await Promise.all(
-            parsed.issues.map((aiIssue) =>
+            cappedIssues.map((aiIssue) =>
               enrichIssue(aiIssue, checkId, checkName, repositoryPath, checkMetadata),
             ),
           );
-          return { issues, error: false, flagged: parsed.flagged === true, tokenUsage: aiResponse.tokenUsage };
+          return { issues, error: false, flagged: parsed.flagged === true, tokenUsage: agentResponse.tokenUsage };
         } catch (err) {
           // Fatal errors: signal abort and re-throw to stop other workers
           if (err instanceof FatalProviderError) {
@@ -683,7 +746,7 @@ async function executeStaticCheck(
  * Run multiple security checks and return aggregated ScanResults.
  */
 export async function runMultiScan(options: MultiScanOptions): Promise<ScanResults> {
-  const { repositoryPath, checks, aiProvider, aiModelName, aiProviderName, concurrency, configDir, genericPrompt } = options;
+  const { repositoryPath, checks, agentProvider, modelName, agentProviderName, concurrency, configDir, genericPrompt } = options;
   const scanTimer = createTimer();
   const scanId = generateScanId();
   const startTime = new Date();
@@ -706,7 +769,7 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
 
   // Track all models used during the scan
   const modelsUsed = new Set<string>();
-  if (aiModelName) modelsUsed.add(aiModelName);
+  if (modelName) modelsUsed.add(modelName);
 
   // Execute checks sequentially
   for (let ci = 0; ci < checks.length; ci++) {
@@ -717,7 +780,7 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
     };
 
     // Apply per-check model override if specified
-    const previousModel = applyPerCheckModel(check, aiProvider, aiModelName);
+    const previousModel = applyPerCheckModel(check, agentProvider, modelName);
     if (check.model) modelsUsed.add(check.model);
 
     try {
@@ -726,7 +789,7 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
         details.name,
         details.content,
         repositoryPath,
-        aiProvider,
+        agentProvider,
         checkMetadata,
         concurrency,
         configDir,
@@ -768,7 +831,7 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
       throw err;
     } finally {
       // Restore the global model after per-check override
-      restoreModel(aiProvider, previousModel);
+      restoreModel(agentProvider, previousModel);
     }
   }
 
@@ -800,8 +863,8 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
     executionTime,
     startTime: startTime.toISOString(),
     endTime: endTime.toISOString(),
-    aiProvider: aiProvider
-      ? { name: aiProviderName ?? 'claude-code', models: modelsUsed.size > 0 ? [...modelsUsed] : [DEFAULT_AI_MODEL] }
+    agentProvider: agentProvider
+      ? { name: agentProviderName ?? DEFAULT_PROVIDER_NAME, models: modelsUsed.size > 0 ? [...modelsUsed] : [DEFAULT_MODEL] }
       : { name: 'none', models: [] },
     tokenUsage: aggregateTokenUsage,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,9 @@
  * Based on SPECIFICATION.md Appendix A.
  */
 
-// --- Default AI Model ---
+// --- Default Model ---
 
-export const DEFAULT_AI_MODEL = 'haiku';
+export const DEFAULT_MODEL = 'haiku';
 export const MOCK_MODEL_NAME = 'mock';
 
 // --- Token Usage ---
@@ -76,6 +76,8 @@ export interface CheckTargetDefinition {
   sarifFile?: string;
   maxTargets?: number;
   concurrency?: number;
+  /** Cap on issues returned per target; omit for unlimited. See docs/configuration.md. */
+  maxIssuesPerTarget?: number;
   /** Analysis mode: determines the AI's approach to each target. */
   analysisMode?: 'custom' | 'false-positive-validation' | 'general-vuln-discovery';
   openant?: OpenAntFilterConfig;
@@ -115,7 +117,7 @@ export interface SecurityIssue {
   dataFlow?: DataFlowStep[];
 }
 
-// --- A.3b AI Check Response ---
+// --- A.3b Check Response ---
 
 export interface CheckResponse {
   issues: AIIssue[];
@@ -127,8 +129,8 @@ export interface CheckResponse {
 /** Raw issue as returned by the AI (before enrichment). */
 export interface AIIssue {
   file: string;
-  startLine: number; // Required - enforced via JSON schema in AI provider
-  endLine: number; // Required - enforced via JSON schema in AI provider
+  startLine: number; // Required - enforced via JSON schema in agent provider
+  endLine: number; // Required - enforced via JSON schema in agent provider
   description: string;
   dataFlow?: DataFlowStep[];
 }
@@ -143,6 +145,13 @@ export interface CheckExecutionSummary {
   executionTime: number;
   targetsAnalyzed?: number;
   error?: string;
+  /**
+   * Raw text body of the agent provider's response, included in ERROR results
+   * for debugging. Field name retains "AI" (rather than "Agent") because the
+   * stored content is the LLM's raw text output — same rationale as
+   * AGHAST_MOCK_AI / AGHAST_AI_MODEL: the model and its output are AI/LLM
+   * concerns, the harness around them is the agent.
+   */
   rawAiResponse?: string;
   tokenUsage?: TokenUsage;
 }
@@ -160,7 +169,7 @@ export interface ScanResults {
   executionTime: number;
   startTime: string;
   endTime: string;
-  aiProvider: {
+  agentProvider: {
     name: string;
     models: string[];
   };
@@ -188,7 +197,7 @@ export interface ScanSummary {
 // --- Runtime Configuration (spec Section 8.1) ---
 
 export interface RuntimeConfig {
-  aiProvider?: {
+  agentProvider?: {
     name?: string;
     model?: string;
   };
@@ -252,7 +261,7 @@ export interface CheckDetails {
   content: string;
 }
 
-// --- C.5 AI Provider Interface ---
+// --- C.5 Agent Provider Interface ---
 
 export interface ProviderConfig {
   apiKey?: string;
@@ -260,7 +269,7 @@ export interface ProviderConfig {
   [key: string]: unknown;
 }
 
-export interface AIResponse {
+export interface AgentResponse {
   raw: string;
   parsed?: CheckResponse;
   tokenUsage?: TokenUsage;
@@ -276,24 +285,31 @@ export interface ProviderModelInfo {
   description?: string;
 }
 
-export interface AIProvider {
+export interface AgentProvider {
   initialize(config: ProviderConfig): Promise<void>;
   executeCheck(
     instructions: string,
     repositoryPath: string,
     logPrefix?: string,
     options?: { maxTurns?: number },
-  ): Promise<AIResponse>;
+  ): Promise<AgentResponse>;
   validateConfig(): Promise<boolean>;
+  /**
+   * Check that required prerequisites (API keys, binaries, etc.) are available.
+   * Called before initialize() to give early feedback. Throws with a descriptive
+   * error message if a prerequisite is missing.
+   */
+  checkPrerequisites?(): void;
   getModelName?(): string;
   setModel?(model: string): void;
   enableDebug?(): void;
+  cleanup?(): Promise<void>;
   /** Closed list of models this provider accepts. Used by `aghast build-config`. */
   listModels?(): Promise<readonly ProviderModelInfo[]>;
 }
 
 /**
- * Error thrown by AI providers for unrecoverable failures (e.g. 401 auth, rate limits).
+ * Error thrown by agent providers for unrecoverable failures (e.g. 401 auth, rate limits).
  * When caught by the scan runner, this signals that the entire scan should abort —
  * no further checks or targets should be attempted.
  */

--- a/tests/build-config.test.ts
+++ b/tests/build-config.test.ts
@@ -95,7 +95,7 @@ describe('build-config CLI', () => {
     ]);
     assert.equal(exitCode, 0);
     const written = JSON.parse(await readFile(join(tempDir, 'runtime-config.json'), 'utf-8'));
-    assert.equal(written.aiProvider.name, 'claude-code');
+    assert.equal(written.agentProvider.name, 'claude-code');
     assert.equal(written.reporting.outputFormat, 'sarif');
     assert.equal(written.logging.level, 'debug');
     assert.equal(written.failOnCheckFailure, true);
@@ -104,7 +104,7 @@ describe('build-config CLI', () => {
   it('preserves untouched fields when editing existing config', async () => {
     const target = join(tempDir, 'runtime-config.json');
     await writeFile(target, JSON.stringify({
-      aiProvider: { name: 'claude-code', model: 'sonnet' },
+      agentProvider: { name: 'claude-code', model: 'sonnet' },
       reporting: { outputFormat: 'json', outputDirectory: '/tmp/out' },
       failOnCheckFailure: false,
     }), 'utf-8');
@@ -116,7 +116,7 @@ describe('build-config CLI', () => {
     ]);
     assert.equal(exitCode, 0);
     const written = JSON.parse(await readFile(target, 'utf-8'));
-    assert.equal(written.aiProvider.model, 'sonnet', 'model preserved');
+    assert.equal(written.agentProvider.model, 'sonnet', 'model preserved');
     assert.equal(written.reporting.outputDirectory, '/tmp/out', 'outputDirectory preserved');
     assert.equal(written.reporting.outputFormat, 'sarif', 'format updated');
     assert.equal(written.failOnCheckFailure, false, 'bool preserved');
@@ -125,7 +125,7 @@ describe('build-config CLI', () => {
   it('--clear removes a field from existing config', async () => {
     const target = join(tempDir, 'runtime-config.json');
     await writeFile(target, JSON.stringify({
-      aiProvider: { name: 'claude-code', model: 'sonnet' },
+      agentProvider: { name: 'claude-code', model: 'sonnet' },
       reporting: { outputDirectory: '/tmp/out', outputFormat: 'json' },
     }), 'utf-8');
 
@@ -137,8 +137,8 @@ describe('build-config CLI', () => {
     ]);
     assert.equal(exitCode, 0);
     const written = JSON.parse(await readFile(target, 'utf-8'));
-    assert.equal(written.aiProvider.name, 'claude-code');
-    assert.equal(written.aiProvider.model, undefined, 'model cleared');
+    assert.equal(written.agentProvider.name, 'claude-code');
+    assert.equal(written.agentProvider.model, undefined, 'model cleared');
     assert.equal(written.reporting.outputDirectory, undefined, 'outputDirectory cleared');
     assert.equal(written.reporting.outputFormat, 'json', 'format preserved');
   });
@@ -266,7 +266,7 @@ describe('build-config CLI', () => {
     // validation is skipped via warning. Either way the config is written correctly.
     const target = join(tempDir, 'runtime-config.json');
     await writeFile(target, JSON.stringify({
-      aiProvider: { name: 'claude-code', model: 'sonnet' },
+      agentProvider: { name: 'claude-code', model: 'sonnet' },
     }), 'utf-8');
 
     const { exitCode, stderr } = await runCLI([
@@ -279,8 +279,8 @@ describe('build-config CLI', () => {
     assert.ok(stderr.includes('skipped model validation'),
       `expected warning that model validation was skipped, got stderr: ${stderr}`);
     const written = JSON.parse(await readFile(target, 'utf-8'));
-    assert.equal(written.aiProvider?.name, undefined, 'provider cleared');
-    assert.equal(written.aiProvider?.model, 'sonnet', 'model preserved');
+    assert.equal(written.agentProvider?.name, undefined, 'provider cleared');
+    assert.equal(written.agentProvider?.model, 'sonnet', 'model preserved');
   });
 
   it('--model without --provider preserves the value (validation against default provider) (F14)', async () => {
@@ -297,7 +297,7 @@ describe('build-config CLI', () => {
     assert.ok(stderr.includes('skipped model validation'),
       `expected warning that model validation was skipped, got stderr: ${stderr}`);
     const written = JSON.parse(await readFile(join(tempDir, 'runtime-config.json'), 'utf-8'));
-    assert.equal(written.aiProvider?.model, 'sonnet');
+    assert.equal(written.agentProvider?.model, 'sonnet');
   });
 
   it('AGHAST_CONFIG_DIR env var resolves the target path when no flag is given (F15)', async () => {

--- a/tests/claude-code-provider.test.ts
+++ b/tests/claude-code-provider.test.ts
@@ -52,7 +52,7 @@ describe('ClaudeCodeProvider: API error handling', () => {
     await assert.rejects(
       () => provider.executeCheck('test prompt', '/tmp/repo'),
       (err: Error) => {
-        assert.match(err.message, /AI provider API error \(after 3 attempts\)/);
+        assert.match(err.message, /Agent provider API error \(after 3 attempts\)/);
         assert.match(err.message, /workspace limits reached/);
         return true;
       },
@@ -93,7 +93,7 @@ describe('ClaudeCodeProvider: API error handling', () => {
     await assert.rejects(
       () => provider.executeCheck('test prompt', '/tmp/repo'),
       (err: Error) => {
-        assert.match(err.message, /AI provider API error/);
+        assert.match(err.message, /Agent provider API error/);
         assert.match(err.message, /500 internal server error/);
         return true;
       },
@@ -342,7 +342,7 @@ describe('ClaudeCodeProvider: fatal error handling (401 auth)', () => {
       (err: Error) => {
         // Should be a regular Error (not FatalProviderError) since it's not a 401
         assert.ok(!(err instanceof FatalProviderError), 'Should NOT be FatalProviderError for 500');
-        assert.match(err.message, /AI provider API error \(after 3 attempts\)/);
+        assert.match(err.message, /Agent provider API error \(after 3 attempts\)/);
         assert.match(err.message, /500 internal server error/);
         return true;
       },

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for CLI mock AI provider mode (part 2).
+ * Integration tests for CLI mock agent provider mode (part 2).
  *
  * CLI flags, env vars, runtime config, ERROR/FLAG scenarios, debug mode,
  * and semgrep-only checks.
@@ -81,7 +81,7 @@ describe('CLI: --output flag', () => {
   });
 });
 
-describe('CLI: ANTHROPIC_API_KEY and --ai-provider flag', () => {
+describe('CLI: ANTHROPIC_API_KEY and --agent-provider flag', () => {
   afterEach(cleanupOutput);
 
   it('missing ANTHROPIC_API_KEY exits 1 with error message', async () => {
@@ -107,27 +107,27 @@ describe('CLI: ANTHROPIC_API_KEY and --ai-provider flag', () => {
     assert.ok(!stderr.includes('ANTHROPIC_API_KEY environment variable is required'));
   });
 
-  it('unknown --ai-provider exits 1 with error message', async () => {
+  it('unknown --agent-provider exits 1 with error message', async () => {
     const { exitCode, stderr } = await runCLI({
       AGHAST_MOCK_AI: undefined,
-    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--ai-provider', 'unknown-provider']);
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--agent-provider', 'unknown-provider']);
     assert.equal(exitCode, 1);
-    assert.ok(stderr.includes('Unknown AI provider'));
+    assert.ok(stderr.includes('Unknown agent provider'));
   });
 
-  it('unknown --ai-provider error message lists known providers from registry', async () => {
+  it('unknown --agent-provider error message lists known providers from registry', async () => {
     const { exitCode, stderr } = await runCLI({
       AGHAST_MOCK_AI: undefined,
-    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--ai-provider', 'unknown-provider']);
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--agent-provider', 'unknown-provider']);
     assert.equal(exitCode, 1);
-    assert.ok(stderr.includes('Unknown AI provider'), 'Should mention unknown provider');
+    assert.ok(stderr.includes('Unknown agent provider'), 'Should mention unknown provider');
     assert.ok(stderr.includes('claude-code'), 'Error should list claude-code as a valid option from registry');
   });
 
-  it('--ai-provider claude-code (explicit) with mock mode exits 0', async () => {
+  it('--agent-provider claude-code (explicit) with mock mode exits 0', async () => {
     const { exitCode } = await runCLI({
       AGHAST_MOCK_AI: 'true',
-    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--ai-provider', 'claude-code']);
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--agent-provider', 'claude-code']);
     assert.equal(exitCode, 0);
   });
 
@@ -475,16 +475,16 @@ describe('CLI mock mode: semgrep-only checks', () => {
     assert.ok(!combined.includes('Using model'), 'Semgrep-only scan should not log "Using model"');
   });
 
-  it('semgrep-only scan sets aiProvider.name to "none" in results', async () => {
+  it('semgrep-only scan sets agentProvider.name to "none" in results', async () => {
     await runCLI(
       { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
 
     const results = await readResults();
-    const aiProvider = results.aiProvider as Record<string, unknown>;
-    assert.equal(aiProvider.name, 'none', 'aiProvider.name should be "none" for semgrep-only scans');
-    assert.deepEqual(aiProvider.models, [], 'aiProvider.models should be empty for semgrep-only scans');
+    const agentProvider = results.agentProvider as Record<string, unknown>;
+    assert.equal(agentProvider.name, 'none', 'agentProvider.name should be "none" for semgrep-only scans');
+    assert.deepEqual(agentProvider.models, [], 'agentProvider.models should be empty for semgrep-only scans');
   });
 
   it('mixed scan (AI + semgrep-only) still logs "Using model"', async () => {
@@ -667,17 +667,17 @@ describe('CLI: per-check model override', () => {
     );
   });
 
-  it('per-check model appears in results aiProvider.models', async () => {
+  it('per-check model appears in results agentProvider.models', async () => {
     await runCLI(
       { AGHAST_MOCK_AI: 'true' },
       [fixtureRepo, '--config-dir', perCheckModelConfigDir],
     );
 
     const results = await readResults();
-    const aiProvider = results.aiProvider as { name: string; models: string[] };
+    const agentProvider = results.agentProvider as { name: string; models: string[] };
     assert.ok(
-      aiProvider.models.includes('claude-sonnet-4-6'),
-      `models array should include the per-check model, got: ${JSON.stringify(aiProvider.models)}`,
+      agentProvider.models.includes('claude-sonnet-4-6'),
+      `models array should include the per-check model, got: ${JSON.stringify(agentProvider.models)}`,
     );
   });
 

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -1,8 +1,8 @@
 /**
- * Integration tests for CLI mock AI provider mode (part 1).
+ * Integration tests for CLI mock agent provider mode (part 1).
  *
  * Spawns the actual CLI process with AGHAST_MOCK_AI=true to verify
- * the full pipeline end-to-end without a real AI provider.
+ * the full pipeline end-to-end without a real agent provider.
  * Exercises: config loading, check filtering, prompt building, response
  * parsing, snippet extraction, issue enrichment, report generation,
  * and CLI output.
@@ -27,6 +27,7 @@ import {
   disabledConfigDir,
   invalidConfigDir,
   multiTargetConfigDir,
+  multiTargetCappedConfigDir,
   mixedChecksConfigDir,
   semgrepOnlyConfigDir,
   cli3TargetsSarif,
@@ -73,7 +74,7 @@ describe('CLI mock mode: PASS scenarios', () => {
   it('stdout indicates mock provider is active', async () => {
     const { stdout, stderr } = await runCLI({ AGHAST_MOCK_AI: 'true' });
     const combined = stdout + stderr;
-    assert.ok(combined.includes('MOCK AI provider'), 'Should log mock provider message');
+    assert.ok(combined.includes('Mock provider'), 'Should log mock provider message');
   });
 
   it('stdout shows "Using model: mock"', async () => {
@@ -112,7 +113,7 @@ describe('CLI mock mode: ScanResults output structure', () => {
     assert.ok(results.summary, 'Should have summary');
     assert.ok(results.startTime, 'Should have startTime');
     assert.ok(results.endTime, 'Should have endTime');
-    assert.ok(results.aiProvider, 'Should have aiProvider');
+    assert.ok(results.agentProvider, 'Should have agentProvider');
     assert.equal(typeof results.executionTime, 'number', 'executionTime should be a number');
   });
 
@@ -131,12 +132,12 @@ describe('CLI mock mode: ScanResults output structure', () => {
     }
   });
 
-  it('aiProvider shows mock model', async () => {
+  it('agentProvider shows mock model', async () => {
     await runCLI({ AGHAST_MOCK_AI: 'true' });
     const results = await readResults();
-    const aiProvider = results.aiProvider as { name: string; models: string[] };
-    assert.equal(aiProvider.name, 'mock');
-    assert.ok(aiProvider.models.includes(MOCK_MODEL_NAME), `models should include "${MOCK_MODEL_NAME}"`);
+    const agentProvider = results.agentProvider as { name: string; models: string[] };
+    assert.equal(agentProvider.name, 'mock');
+    assert.ok(agentProvider.models.includes(MOCK_MODEL_NAME), `models should include "${MOCK_MODEL_NAME}"`);
   });
 
   it('repository info contains the fixture repo path', async () => {
@@ -831,6 +832,49 @@ describe('CLI mock mode: multi-target checks', () => {
       assert.equal(issue.checkId, 'aghast-mt-sqli');
       assert.equal(issue.checkName, 'SQL Injection Prevention');
     }
+  });
+
+  it('maxIssuesPerTarget: caps issues per target when set in checkTarget', async () => {
+    // Without cap, multiIssueFixture (2 issues per response) × 3 targets = 6 issues.
+    // With maxIssuesPerTarget: 1 in checkTarget, only the first issue per target
+    // is kept → 3 issues total.
+    const { exitCode } = await runCLI(
+      {
+        AGHAST_MOCK_AI: multiIssueFixture,
+        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+      },
+      [fixtureRepo, '--config-dir', multiTargetCappedConfigDir],
+    );
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    const checks = results.checks as Array<Record<string, unknown>>;
+
+    assert.equal(checks[0].targetsAnalyzed, 3);
+    assert.equal(issues.length, 3, 'Cap of 1 issue per target × 3 targets = 3 issues');
+
+    // The kept issue is the first entry of the AI response — multi-issue-fixture-repo.json's
+    // first issue describes "SQL injection" at lines 3-5.
+    for (const issue of issues) {
+      assert.match(issue.description as string, /SQL injection/i);
+    }
+  });
+
+  it('maxIssuesPerTarget unset (multi-target config): all issues per target are kept', async () => {
+    // Sanity check the inverse: same fixtures against the un-capped config should
+    // yield 6 issues (2 per target × 3 targets), confirming the cap is opt-in.
+    await runCLI(
+      {
+        AGHAST_MOCK_AI: multiIssueFixture,
+        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+      },
+      [fixtureRepo, '--config-dir', multiTargetConfigDir],
+    );
+
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 6, 'No cap = 2 issues × 3 targets = 6 issues');
   });
 
   it('empty SARIF: 0 targets → PASS, targetsAnalyzed: 0', async () => {

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -28,6 +28,7 @@ export const repoFilteredConfigDir = resolve(testDir, 'fixtures', 'cli-configs',
 export const disabledConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'with-disabled');
 export const invalidConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'invalid');
 export const multiTargetConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'multi-target');
+export const multiTargetCappedConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'multi-target-capped');
 export const mixedChecksConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'mixed-checks');
 export const flagCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'flag-check');
 export const mixedResultsConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'mixed-results');

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -5,6 +5,7 @@ import {
   registerDiscovery,
   getRegisteredDiscoveries,
   clearDiscoveryRegistry,
+  unregisterDiscovery,
 } from '../src/discovery.js';
 import type { TargetDiscovery } from '../src/discovery.js';
 
@@ -74,6 +75,24 @@ describe('Discovery registry', () => {
     assert.equal(getRegisteredDiscoveries().length, 1);
     clearDiscoveryRegistry();
     assert.equal(getRegisteredDiscoveries().length, 0);
+  });
+
+  it('unregisterDiscovery() removes a registered entry and returns true', () => {
+    registerDiscovery(stubDiscovery('temp'));
+    assert.equal(unregisterDiscovery('temp'), true);
+    assert.deepEqual(getRegisteredDiscoveries(), []);
+  });
+
+  it('unregisterDiscovery() returns false for an unknown name', () => {
+    assert.equal(unregisterDiscovery('does-not-exist'), false);
+  });
+
+  it('unregisterDiscovery() leaves other entries intact', () => {
+    registerDiscovery(stubDiscovery('keep-1'));
+    registerDiscovery(stubDiscovery('drop'));
+    registerDiscovery(stubDiscovery('keep-2'));
+    assert.equal(unregisterDiscovery('drop'), true);
+    assert.deepEqual(getRegisteredDiscoveries().sort(), ['keep-1', 'keep-2']);
   });
 });
 

--- a/tests/fixtures/cli-configs/multi-target-capped/checks-config.json
+++ b/tests/fixtures/cli-configs/multi-target-capped/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-mt-sqli",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/multi-target-capped/checks/aghast-mt-sqli/aghast-mt-sqli.json
+++ b/tests/fixtures/cli-configs/multi-target-capped/checks/aghast-mt-sqli/aghast-mt-sqli.json
@@ -1,0 +1,11 @@
+{
+  "id": "aghast-mt-sqli",
+  "name": "Multi-Target SQL Injection",
+  "instructionsFile": "aghast-mt-sqli.md",
+  "checkTarget": {
+    "type": "targeted",
+    "discovery": "semgrep",
+    "rules": "unused-in-mock.yaml",
+    "maxIssuesPerTarget": 1
+  }
+}

--- a/tests/fixtures/cli-configs/multi-target-capped/checks/aghast-mt-sqli/aghast-mt-sqli.md
+++ b/tests/fixtures/cli-configs/multi-target-capped/checks/aghast-mt-sqli/aghast-mt-sqli.md
@@ -1,0 +1,16 @@
+### SQL Injection Prevention
+
+#### Overview
+Validates that database queries use parameterized queries or prepared statements instead of string concatenation.
+
+#### What to Check
+1. Identify all database query execution points
+2. Check if user-supplied input is concatenated into SQL strings
+3. Verify parameterized queries or ORM methods are used
+
+#### Result
+- **PASS**: All database queries use parameterized queries or ORM methods
+- **FAIL**: Any database query uses string concatenation with user input
+
+#### Recommendation
+Replace string concatenation with parameterized queries. Use prepared statements or ORM query builders.

--- a/tests/fixtures/runtime-config/bad-types.json
+++ b/tests/fixtures/runtime-config/bad-types.json
@@ -1,3 +1,3 @@
 {
-  "aiProvider": "not-an-object"
+  "agentProvider": "not-an-object"
 }

--- a/tests/fixtures/runtime-config/valid-dir/runtime-config.json
+++ b/tests/fixtures/runtime-config/valid-dir/runtime-config.json
@@ -1,5 +1,5 @@
 {
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "model": "claude-opus-4-6"
   }

--- a/tests/fixtures/runtime-config/valid.json
+++ b/tests/fixtures/runtime-config/valid.json
@@ -1,5 +1,5 @@
 {
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "model": "claude-opus-4-6"
   }

--- a/tests/fixtures/scan-results/error-scan.json
+++ b/tests/fixtures/scan-results/error-scan.json
@@ -16,7 +16,7 @@
       "status": "ERROR",
       "issuesFound": 0,
       "executionTime": 500,
-      "error": "AI provider returned malformed response",
+      "error": "Agent provider returned malformed response",
       "rawAiResponse": "This is not valid JSON output"
     }
   ],
@@ -28,7 +28,7 @@
     "errorChecks": 1,
     "totalIssues": 0
   },
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "models": ["claude-sonnet-4-5-20250929"]
   },

--- a/tests/fixtures/scan-results/fail-scan.json
+++ b/tests/fixtures/scan-results/fail-scan.json
@@ -43,7 +43,7 @@
     "errorChecks": 0,
     "totalIssues": 1
   },
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "models": ["claude-sonnet-4-5-20250929"]
   },

--- a/tests/fixtures/scan-results/pass-scan.json
+++ b/tests/fixtures/scan-results/pass-scan.json
@@ -26,7 +26,7 @@
     "errorChecks": 0,
     "totalIssues": 0
   },
-  "aiProvider": {
+  "agentProvider": {
     "name": "claude-code",
     "models": ["claude-sonnet-4-5-20250929"]
   },

--- a/tests/fuzz.test.ts
+++ b/tests/fuzz.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import fc from 'fast-check';
 import { resolve, sep, join } from 'node:path';
 
-import { parseAIResponse } from '../src/response-parser.js';
+import { parseAgentResponse } from '../src/response-parser.js';
 import { parseSARIF, deduplicateTargets, limitTargets } from '../src/sarif-parser.js';
 import {
   sanitizeUrl,
@@ -154,11 +154,11 @@ const errorCodeArb: fc.Arbitrary<ErrorCode> = fc.record({
 // =========================================================================
 
 describe('fuzz: external input parsers', () => {
-  describe('parseAIResponse', () => {
+  describe('parseAgentResponse', () => {
     it('never crashes on arbitrary strings', () => {
       fc.assert(
         fc.property(fc.string(), (input) => {
-          const result = parseAIResponse(input);
+          const result = parseAgentResponse(input);
           assert.ok(result === undefined || (typeof result === 'object' && Array.isArray(result.issues)));
         }),
       );
@@ -167,7 +167,7 @@ describe('fuzz: external input parsers', () => {
     it('never crashes on arbitrary JSON', () => {
       fc.assert(
         fc.property(fc.json(), (input) => {
-          const result = parseAIResponse(input);
+          const result = parseAgentResponse(input);
           assert.ok(result === undefined || (typeof result === 'object' && Array.isArray(result.issues)));
         }),
       );
@@ -177,7 +177,7 @@ describe('fuzz: external input parsers', () => {
       fc.assert(
         fc.property(checkResponseArb, (response) => {
           const raw = JSON.stringify(response);
-          const result = parseAIResponse(raw);
+          const result = parseAgentResponse(raw);
           if (result !== undefined) {
             assert.ok(Array.isArray(result.issues));
             for (const issue of result.issues) {
@@ -195,9 +195,9 @@ describe('fuzz: external input parsers', () => {
       fc.assert(
         fc.property(checkResponseArb, (response) => {
           const raw = JSON.stringify(response);
-          const first = parseAIResponse(raw);
+          const first = parseAgentResponse(raw);
           if (first !== undefined) {
-            const second = parseAIResponse(JSON.stringify(first));
+            const second = parseAgentResponse(JSON.stringify(first));
             assert.deepStrictEqual(second, first);
           }
         }),

--- a/tests/json-formatter.test.ts
+++ b/tests/json-formatter.test.ts
@@ -14,7 +14,7 @@ const stubResults: ScanResults = {
   executionTime: 100,
   startTime: '2026-01-01T12:00:00.000Z',
   endTime: '2026-01-01T12:00:00.100Z',
-  aiProvider: { name: 'mock', models: ['mock'] },
+  agentProvider: { name: 'mock', models: ['mock'] },
 };
 
 describe('JsonFormatter', () => {

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -106,7 +106,7 @@ test('ConsoleHandler: truncates debug data at 200 chars', () => {
   }
 });
 
-test('ConsoleHandler: trace data is not truncated', () => {
+test('ConsoleHandler: trace data is base64-encoded', () => {
   const handler = new ConsoleHandler('trace');
   const logs: string[] = [];
   const origLog = console.log;
@@ -117,7 +117,12 @@ test('ConsoleHandler: trace data is not truncated', () => {
     handler.handle({ timestamp: '2025-01-01', level: 'trace', tag: 'test', message: 'data', data: longData });
 
     assert.equal(logs.length, 1);
-    assert.ok(logs[0].includes('y'.repeat(300)), 'Should contain full data');
+    assert.ok(logs[0].includes('[base64]'), 'Should contain base64 marker');
+    // Verify the base64 decodes back to original data
+    const b64Match = logs[0].match(/\[base64\] (.+)$/);
+    assert.ok(b64Match, 'Should have base64 content');
+    const decoded = Buffer.from(b64Match![1], 'base64').toString('utf-8');
+    assert.equal(decoded, longData, 'Decoded base64 should match original');
   } finally {
     console.log = origLog;
   }
@@ -424,7 +429,12 @@ test('logDebugFull dispatches as trace level', async () => {
     await closeAllHandlers();
     const content = await readFile(logPath, 'utf-8');
     assert.ok(content.includes('[trace]'));
-    assert.ok(content.includes('complete-string'));
+    assert.ok(content.includes('[base64]'), 'Trace data should be base64-encoded');
+    // Verify the base64 decodes back to original data
+    const b64Match = content.match(/\[base64\] (.+)/);
+    assert.ok(b64Match, 'Should have base64 content');
+    const decoded = Buffer.from(b64Match![1].trim(), 'base64').toString('utf-8');
+    assert.equal(decoded, 'complete-string');
   } finally {
     try { await unlink(logPath); } catch { /* ignore */ }
   }

--- a/tests/mock-agent-provider.test.ts
+++ b/tests/mock-agent-provider.test.ts
@@ -1,25 +1,25 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  MockAIProvider,
+  MockAgentProvider,
   createPassProvider,
   createFailProvider,
   createMalformedProvider,
   createTimeoutProvider,
   createAuthErrorProvider,
   createDelayedProvider,
-} from './mocks/mock-ai-provider.js';
+} from './mocks/mock-agent-provider.js';
 
-describe('MockAIProvider', () => {
-  it('implements AIProvider interface', async () => {
-    const provider = new MockAIProvider();
+describe('MockAgentProvider', () => {
+  it('implements AgentProvider interface', async () => {
+    const provider = new MockAgentProvider();
     assert.equal(typeof provider.initialize, 'function');
     assert.equal(typeof provider.executeCheck, 'function');
     assert.equal(typeof provider.validateConfig, 'function');
   });
 
   it('tracks initialization state', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     assert.equal(provider.initialized, false);
     await provider.initialize({ apiKey: 'test-key' });
     assert.equal(provider.initialized, true);
@@ -110,7 +110,7 @@ describe('factory: createDelayedProvider', () => {
   });
 });
 
-describe('MockAIProvider.setResponse', () => {
+describe('MockAgentProvider.setResponse', () => {
   it('changes response between calls', async () => {
     const provider = createPassProvider();
 
@@ -130,7 +130,7 @@ describe('MockAIProvider.setResponse', () => {
   });
 });
 
-describe('MockAIProvider.setRawResponse', () => {
+describe('MockAgentProvider.setRawResponse', () => {
   it('switches to raw mode', async () => {
     const provider = createPassProvider();
     provider.setRawResponse('garbage');
@@ -140,7 +140,7 @@ describe('MockAIProvider.setRawResponse', () => {
   });
 });
 
-describe('MockAIProvider.setError', () => {
+describe('MockAgentProvider.setError', () => {
   it('switches to error mode', async () => {
     const provider = createPassProvider();
     provider.setError(new Error('boom'));

--- a/tests/mocks/mock-agent-provider.ts
+++ b/tests/mocks/mock-agent-provider.ts
@@ -1,13 +1,13 @@
 /**
- * Mock AI Provider for testing.
+ * Mock Agent Provider for testing.
  *
- * Implements the AIProvider interface with configurable responses
+ * Implements the AgentProvider interface with configurable responses
  * for use in unit and integration tests. Never calls a real AI API.
  */
 
 import type {
-  AIProvider,
-  AIResponse,
+  AgentProvider,
+  AgentResponse,
   CheckResponse,
   ProviderConfig,
   TokenUsage,
@@ -25,14 +25,15 @@ export interface MockProviderOptions {
   delay?: number;
   /** Whether validateConfig should return true. */
   validConfig?: boolean;
-  /** Token usage to include in AIResponse. */
+  /** Token usage to include in AgentResponse. */
   tokenUsage?: TokenUsage;
 }
 
-export class MockAIProvider implements AIProvider {
+export class MockAgentProvider implements AgentProvider {
   public callHistory: Array<{
     instructions: string;
     repositoryPath: string;
+    options?: { maxTurns?: number };
   }> = [];
 
   public initialized = false;
@@ -57,8 +58,9 @@ export class MockAIProvider implements AIProvider {
     instructions: string,
     repositoryPath: string,
     _logPrefix?: string,
-  ): Promise<AIResponse> {
-    this.callHistory.push({ instructions, repositoryPath });
+    options?: { maxTurns?: number },
+  ): Promise<AgentResponse> {
+    this.callHistory.push({ instructions, repositoryPath, options });
 
     if (this.options.delay && this.options.delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.options.delay));
@@ -132,15 +134,15 @@ export class MockAIProvider implements AIProvider {
 // --- Pre-configured factory functions ---
 
 /** Provider that always returns PASS (no issues). */
-export function createPassProvider(): MockAIProvider {
-  return new MockAIProvider({
+export function createPassProvider(): MockAgentProvider {
+  return new MockAgentProvider({
     response: { issues: [] },
   });
 }
 
 /** Provider that returns FAIL with predefined issues. */
-export function createFailProvider(): MockAIProvider {
-  return new MockAIProvider({
+export function createFailProvider(): MockAgentProvider {
+  return new MockAgentProvider({
     response: {
       issues: [
         {
@@ -155,46 +157,46 @@ export function createFailProvider(): MockAIProvider {
 }
 
 /** Provider that returns malformed (non-JSON) response. */
-export function createMalformedProvider(): MockAIProvider {
-  return new MockAIProvider({
+export function createMalformedProvider(): MockAgentProvider {
+  return new MockAgentProvider({
     rawResponse: 'This is not valid JSON. The code looks fine to me.',
   });
 }
 
 /** Provider that throws a timeout error. */
-export function createTimeoutProvider(): MockAIProvider {
-  return new MockAIProvider({
-    error: new Error('AI provider request timed out after 60000ms'),
+export function createTimeoutProvider(): MockAgentProvider {
+  return new MockAgentProvider({
+    error: new Error('Agent provider request timed out after 60000ms'),
   });
 }
 
 /** Provider that throws an authentication error. */
-export function createAuthErrorProvider(): MockAIProvider {
-  return new MockAIProvider({
+export function createAuthErrorProvider(): MockAgentProvider {
+  return new MockAgentProvider({
     error: new Error('Invalid API key: authentication failed'),
     validConfig: false,
   });
 }
 
 /** Provider with configurable delay (for concurrency testing). */
-export function createDelayedProvider(delayMs: number): MockAIProvider {
-  return new MockAIProvider({
+export function createDelayedProvider(delayMs: number): MockAgentProvider {
+  return new MockAgentProvider({
     response: { issues: [] },
     delay: delayMs,
   });
 }
 
 /** Provider that always returns PASS with token usage. */
-export function createPassProviderWithTokens(tokenUsage?: TokenUsage): MockAIProvider {
-  return new MockAIProvider({
+export function createPassProviderWithTokens(tokenUsage?: TokenUsage): MockAgentProvider {
+  return new MockAgentProvider({
     response: { issues: [] },
     tokenUsage: tokenUsage ?? { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
   });
 }
 
 /** Provider that throws a FatalProviderError (unrecoverable, aborts scan). */
-export function createFatalErrorProvider(message?: string): MockAIProvider {
-  return new MockAIProvider({
-    error: new FatalProviderError(message ?? 'AI provider authentication failed (401)'),
+export function createFatalErrorProvider(message?: string): MockAgentProvider {
+  return new MockAgentProvider({
+    error: new FatalProviderError(message ?? 'Agent provider authentication failed (401)'),
   });
 }

--- a/tests/opencode-integration.itest.ts
+++ b/tests/opencode-integration.itest.ts
@@ -1,0 +1,97 @@
+/**
+ * Real OpenCode integration tests.
+ * These tests actually invoke the OpenCode SDK and send prompts to a real LLM.
+ * Uses opencode/big-pickle (free, no API key needed).
+ * Requires opencode CLI to be installed (npm install -g opencode-ai).
+ * Skip explicitly by setting AGHAST_SKIP_OPENCODE_TESTS=true.
+ */
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { OpenCodeProvider } from '../src/opencode-provider.js';
+import { FatalProviderError } from '../src/types.js';
+
+const skip = !!process.env.AGHAST_SKIP_OPENCODE_TESTS;
+
+if (skip) {
+  console.log('Skipping OpenCode integration tests (AGHAST_SKIP_OPENCODE_TESTS set)');
+}
+
+describe('OpenCode integration tests', { skip }, () => {
+  // Track providers for cleanup
+  const providers: OpenCodeProvider[] = [];
+
+  after(async () => {
+    for (const p of providers) {
+      await p.cleanup();
+    }
+  });
+
+  it('initializes with opencode/big-pickle and validates model', async () => {
+    const provider = new OpenCodeProvider();
+    providers.push(provider);
+    await provider.initialize({ model: 'opencode/big-pickle' });
+    assert.equal(provider.getModelName(), 'opencode/big-pickle');
+    const valid = await provider.validateConfig();
+    assert.equal(valid, true);
+  });
+
+  it('rejects an invalid model with FatalProviderError listing available models', async () => {
+    const provider = new OpenCodeProvider();
+    providers.push(provider);
+    await assert.rejects(
+      () => provider.initialize({ model: 'opencode/nonexistent-model-xyz' }),
+      (err: unknown) => {
+        assert.ok(err instanceof FatalProviderError);
+        assert.ok(err.message.includes('nonexistent-model-xyz'), 'Should mention the invalid model');
+        assert.ok(err.message.includes('opencode/'), 'Should list available models');
+        return true;
+      },
+    );
+  });
+
+  it('executeCheck sends a prompt and gets a parsed response', async () => {
+    const provider = new OpenCodeProvider();
+    providers.push(provider);
+    await provider.initialize({ model: 'opencode/big-pickle' });
+
+    // Simple prompt that should return empty issues
+    const result = await provider.executeCheck(
+      'Return exactly this JSON and nothing else: {"issues": []}',
+      process.cwd(),
+    );
+
+    assert.ok(result.raw !== undefined, 'Should have raw response');
+    // The model should return parseable JSON (either via structured output or text fallback)
+    assert.ok(result.parsed, 'Should have parsed response');
+    assert.ok(Array.isArray(result.parsed.issues), 'Parsed response should have issues array');
+  });
+
+  it('executeCheck returns issues when prompted to find them', async () => {
+    const provider = new OpenCodeProvider();
+    providers.push(provider);
+    await provider.initialize({ model: 'opencode/big-pickle' });
+
+    const result = await provider.executeCheck(
+      'Return exactly this JSON and nothing else: {"issues": [{"file": "test.js", "startLine": 1, "endLine": 2, "description": "Test issue"}]}',
+      process.cwd(),
+    );
+
+    assert.ok(result.parsed, 'Should have parsed response');
+    assert.equal(result.parsed.issues.length, 1, 'Should have 1 issue');
+    assert.equal(result.parsed.issues[0].file, 'test.js');
+    assert.equal(result.parsed.issues[0].startLine, 1);
+    assert.equal(result.parsed.issues[0].description, 'Test issue');
+  });
+
+  it('cleanup stops the server without error', async () => {
+    const provider = new OpenCodeProvider();
+    // Don't push to providers array — we clean up manually here
+    await provider.initialize({ model: 'opencode/big-pickle' });
+    await provider.cleanup();
+    // Second cleanup should be idempotent
+    await provider.cleanup();
+    const valid = await provider.validateConfig();
+    assert.equal(valid, false, 'Should be invalid after cleanup');
+  });
+});

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -1,0 +1,691 @@
+/**
+ * Unit tests for the OpenCode agent provider.
+ * Uses constructor DI (_client) to inject a mock OpenCode client.
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OpenCodeProvider } from '../src/opencode-provider.js';
+import { FatalProviderError } from '../src/types.js';
+
+/** Accessor for the provider's private marker methods/state in tests. */
+interface MarkerInternals {
+  skipProjectMarker: boolean;
+  createdMarkers: Map<string, number>;
+  ensureProjectMarker(path: string): Promise<void>;
+  releaseProjectMarker(path: string): Promise<void>;
+  cleanupMarkersSync(): void;
+}
+function internals(p: OpenCodeProvider): MarkerInternals {
+  return p as unknown as MarkerInternals;
+}
+
+// --- Mock client builder ---
+
+interface MockModel {
+  name: string;
+}
+
+interface MockProvider {
+  id: string;
+  name: string;
+  models: Record<string, MockModel>;
+}
+
+interface PromptCall {
+  sessionID: string;
+  model: { providerID: string; modelID: string };
+  parts: Array<{ type: string; text: string }>;
+  format?: unknown;
+  directory?: string;
+}
+
+/**
+ * Create a mock OpenCode client for testing.
+ *
+ * The mock simulates the synchronous prompt flow with background polling:
+ * - session.prompt() blocks and returns the final response
+ * - session.messages() returns messages for progress polling
+ */
+function createMockClient(options?: {
+  providers?: MockProvider[];
+  promptResponse?: {
+    info?: Record<string, unknown>;
+    parts?: Array<{ type: string; text?: string }>;
+  };
+}) {
+  const providers = options?.providers ?? [
+    {
+      id: 'test-provider',
+      name: 'Test Provider',
+      models: {
+        'test-model': { name: 'Test Model' },
+        'other-model': { name: 'Other Model' },
+      },
+    },
+  ];
+
+  const defaultPromptResponse = options?.promptResponse ?? {
+    info: {
+      role: 'assistant',
+      tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+      structured: { issues: [] },
+    },
+    parts: [{ type: 'text', text: '{"issues": []}' }],
+  };
+
+  const calls: {
+    sessionCreate: Array<Record<string, unknown>>;
+    prompt: PromptCall[];
+  } = { sessionCreate: [], prompt: [] };
+
+  let sessionCounter = 0;
+
+  const client = {
+    config: {
+      providers: async () => ({
+        data: { providers },
+      }),
+    },
+    session: {
+      create: async (params: Record<string, unknown>) => {
+        calls.sessionCreate.push(params);
+        sessionCounter++;
+        return { data: { id: `session-${sessionCounter}` } };
+      },
+      prompt: async (params: PromptCall) => {
+        calls.prompt.push(params);
+        return { data: defaultPromptResponse };
+      },
+      messages: async () => ({
+        data: [
+          { info: { role: 'user' }, parts: [] },
+          { info: { role: 'assistant' }, parts: defaultPromptResponse.parts ?? [] },
+        ],
+      }),
+    },
+    calls,
+  };
+
+  return client as unknown as typeof client;
+}
+
+// --- Tests ---
+
+describe('OpenCodeProvider — model parsing', () => {
+  it('parses providerID/modelID correctly', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+    assert.equal(provider.getModelName(), 'test-provider/test-model');
+  });
+
+  it('defaults to opencode/big-pickle when no model specified', async () => {
+    const client = createMockClient({
+      providers: [{ id: 'opencode', name: 'OpenCode', models: { 'big-pickle': { name: 'Big Pickle' } } }],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({});
+    assert.equal(provider.getModelName(), 'opencode/big-pickle');
+  });
+
+  it('throws on model string without slash', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await assert.rejects(
+      () => provider.initialize({ model: 'no-slash-model' }),
+      /Invalid model format.*Expected "providerID\/modelID"/,
+    );
+  });
+
+  it('setModel updates providerID and modelID', async () => {
+    const client = createMockClient({
+      providers: [
+        { id: 'test-provider', name: 'Test', models: { 'test-model': { name: 'Test' } } },
+        { id: 'other', name: 'Other', models: { 'model-x': { name: 'X' } } },
+      ],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+    provider.setModel('other/model-x');
+    assert.equal(provider.getModelName(), 'other/model-x');
+  });
+});
+
+describe('OpenCodeProvider — model validation', () => {
+  it('throws FatalProviderError for unknown provider', async () => {
+    const client = createMockClient({
+      providers: [{ id: 'real-provider', name: 'Real', models: { m1: { name: 'M1' } } }],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await assert.rejects(
+      () => provider.initialize({ model: 'fake-provider/some-model' }),
+      (err: unknown) => {
+        assert.ok(err instanceof FatalProviderError);
+        assert.ok(err.message.includes('fake-provider'));
+        assert.ok(err.message.includes('real-provider'));
+        return true;
+      },
+    );
+  });
+
+  it('throws FatalProviderError for unknown model', async () => {
+    const client = createMockClient({
+      providers: [{ id: 'test-provider', name: 'Test', models: { 'valid-model': { name: 'Valid' } } }],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await assert.rejects(
+      () => provider.initialize({ model: 'test-provider/invalid-model' }),
+      (err: unknown) => {
+        assert.ok(err instanceof FatalProviderError);
+        assert.ok(err.message.includes('invalid-model'));
+        assert.ok(err.message.includes('test-provider/valid-model'));
+        return true;
+      },
+    );
+  });
+
+  it('accepts valid provider and model', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+    assert.equal(provider.getModelName(), 'test-provider/test-model');
+  });
+});
+
+describe('OpenCodeProvider — executeCheck', () => {
+  it('creates session and sends prompt with correct parameters', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await provider.executeCheck('test instructions', '/repo/path');
+
+    assert.equal(client.calls.sessionCreate.length, 1);
+    assert.equal(client.calls.sessionCreate[0].directory, '/repo/path');
+
+    assert.equal(client.calls.prompt.length, 1);
+    const promptCall = client.calls.prompt[0];
+    assert.equal(promptCall.sessionID, 'session-1');
+    assert.deepEqual(promptCall.model, { providerID: 'test-provider', modelID: 'test-model' });
+    assert.equal(promptCall.parts[0].text, 'test instructions');
+    assert.deepEqual(promptCall.format, { type: 'json_schema', schema: expect_output_schema() });
+    assert.equal(promptCall.directory, '/repo/path');
+  });
+
+  it('returns structured output when available', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          tokens: { input: 200, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+          structured: {
+            issues: [
+              { file: 'app.js', startLine: 10, endLine: 15, description: 'SQL injection' },
+            ],
+          },
+        },
+        parts: [{ type: 'text', text: 'some text' }],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    const result = await provider.executeCheck('find vulns', '/repo');
+
+    assert.ok(result.parsed);
+    assert.equal(result.parsed.issues.length, 1);
+    assert.equal(result.parsed.issues[0].file, 'app.js');
+    assert.equal(result.parsed.issues[0].description, 'SQL injection');
+    assert.ok(result.tokenUsage);
+    assert.equal(result.tokenUsage!.inputTokens, 200);
+    assert.equal(result.tokenUsage!.outputTokens, 100);
+    assert.equal(result.tokenUsage!.totalTokens, 300);
+  });
+
+  it('falls back to text parsing when no structured output', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          tokens: { input: 50, output: 25, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        parts: [{ type: 'text', text: '{"issues": [{"file": "x.py", "startLine": 1, "endLine": 2, "description": "test"}]}' }],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    const result = await provider.executeCheck('find vulns', '/repo');
+
+    assert.ok(result.parsed);
+    assert.equal(result.parsed.issues.length, 1);
+    assert.equal(result.parsed.issues[0].file, 'x.py');
+  });
+
+  it('throws when no text response and no structured output', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          tokens: { input: 10, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        parts: [],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('find vulns', '/repo'),
+      /no text response/,
+    );
+  });
+
+  it('throws Error on session creation failure', async () => {
+    const client = createMockClient();
+    client.session.create = async () => ({ data: { id: undefined as unknown as string } });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test', '/repo'),
+      /no session ID/,
+    );
+  });
+});
+
+describe('OpenCodeProvider — error handling', () => {
+  it('throws FatalProviderError on ProviderAuthError', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          error: { name: 'ProviderAuthError', data: { providerID: 'test', message: 'Invalid API key' } },
+        },
+        parts: [],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test', '/repo'),
+      (err: unknown) => {
+        assert.ok(err instanceof FatalProviderError);
+        assert.ok(err.message.includes('authentication failed'));
+        return true;
+      },
+    );
+  });
+
+  it('throws FatalProviderError on rate limit APIError', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          error: { name: 'APIError', data: { message: 'rate limit exceeded 429' } },
+        },
+        parts: [],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test', '/repo'),
+      (err: unknown) => {
+        assert.ok(err instanceof FatalProviderError);
+        assert.ok(err.message.includes('rate limit'));
+        return true;
+      },
+    );
+  });
+
+  it('throws regular Error on non-fatal API errors', async () => {
+    const client = createMockClient({
+      promptResponse: {
+        info: {
+          role: 'assistant',
+          error: { name: 'UnknownError', data: { message: 'something broke' } },
+        },
+        parts: [],
+      },
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test', '/repo'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(!(err instanceof FatalProviderError));
+        assert.ok(err.message.includes('UnknownError'));
+        return true;
+      },
+    );
+  });
+});
+
+describe('OpenCodeProvider — cleanup', () => {
+  it('cleanup is idempotent', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await provider.cleanup();
+    await provider.cleanup();
+  });
+
+  it('validateConfig returns false before initialize', async () => {
+    const provider = new OpenCodeProvider();
+    const result = await provider.validateConfig();
+    assert.equal(result, false);
+  });
+
+  it('validateConfig returns true after initialize', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+    const result = await provider.validateConfig();
+    assert.equal(result, true);
+  });
+
+  it('checkPrerequisites does not throw', () => {
+    const provider = new OpenCodeProvider();
+    provider.checkPrerequisites();
+  });
+
+  it('enableDebug sets debug mode', async () => {
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    provider.enableDebug();
+    await provider.initialize({ model: 'test-provider/test-model' });
+  });
+});
+
+describe('OpenCodeProvider — listModels', () => {
+  it('flattens provider.models into providerID/modelID entries', async () => {
+    const client = createMockClient({
+      providers: [
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: {
+            'claude-sonnet-4-20250514': { name: 'Claude Sonnet 4' },
+            'claude-opus-4-20250514': { name: 'Claude Opus 4' },
+          },
+        },
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          models: { 'gpt-4o': { name: 'GPT-4o' } },
+        },
+      ],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'anthropic/claude-sonnet-4-20250514' });
+
+    const models = await provider.listModels();
+    assert.deepEqual(
+      models.map((m) => m.id).sort(),
+      ['anthropic/claude-opus-4-20250514', 'anthropic/claude-sonnet-4-20250514', 'openai/gpt-4o'],
+    );
+    const sonnet = models.find((m) => m.id === 'anthropic/claude-sonnet-4-20250514')!;
+    assert.equal(sonnet.label, 'Claude Sonnet 4');
+    assert.equal(sonnet.description, 'Anthropic');
+  });
+
+  it('falls back to modelID when model has no name', async () => {
+    const client = createMockClient({
+      providers: [{ id: 'p1', name: 'P1', models: { 'unnamed': {} as { name?: string } } }],
+    });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'p1/unnamed' });
+
+    const models = await provider.listModels();
+    assert.equal(models.length, 1);
+    assert.equal(models[0].label, 'unnamed');
+  });
+
+  it('returns empty list when no providers configured', async () => {
+    const client = createMockClient({ providers: [] });
+    const provider = new OpenCodeProvider({ _client: client as never });
+    // Can't call initialize with empty providers — the default model validation would fail.
+    // Manually wire up the provider for this edge case.
+    (provider as unknown as { _client: unknown })._client = client;
+
+    const models = await provider.listModels();
+    assert.deepEqual(models, []);
+  });
+
+  it('throws when called before initialize', async () => {
+    const provider = new OpenCodeProvider();
+    await assert.rejects(() => provider.listModels(), /not initialized/);
+  });
+});
+
+describe('OpenCodeProvider — project marker', () => {
+  let rootTmp: string;
+  before(() => {
+    rootTmp = mkdtempSync(join(tmpdir(), 'aghast-marker-'));
+  });
+  after(() => {
+    try { rmSync(rootTmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  function freshDir(name: string): string {
+    const p = join(rootTmp, name + '-' + Math.random().toString(36).slice(2, 8));
+    mkdirSync(p, { recursive: true });
+    return p;
+  }
+
+  function makeProvider(): OpenCodeProvider {
+    // Inject a minimal fake client so initialize-style state isn't needed; then
+    // flip skipProjectMarker off so marker logic runs against the real filesystem.
+    const p = new OpenCodeProvider({ _client: {} as never });
+    internals(p).skipProjectMarker = false;
+    return p;
+  }
+
+  it('creates .git when absent and tracks it via refcount', async () => {
+    const dir = freshDir('create');
+    const p = makeProvider();
+    await internals(p).ensureProjectMarker(dir);
+    assert.ok(existsSync(join(dir, '.git')), '.git should have been created');
+    assert.equal(internals(p).createdMarkers.get(dir), 1);
+  });
+
+  it('does not touch pre-existing .git and does not add a refcount entry', async () => {
+    const dir = freshDir('preexisting');
+    mkdirSync(join(dir, '.git'));
+    const p = makeProvider();
+    await internals(p).ensureProjectMarker(dir);
+    assert.ok(existsSync(join(dir, '.git')), 'pre-existing .git should remain');
+    assert.equal(
+      internals(p).createdMarkers.has(dir),
+      false,
+      'pre-existing markers must not be tracked — we would otherwise delete what we did not create',
+    );
+  });
+
+  it('refcount increments for parallel ensures on the same path and only removes on last release', async () => {
+    const dir = freshDir('refcount');
+    const p = makeProvider();
+    await internals(p).ensureProjectMarker(dir);
+    await internals(p).ensureProjectMarker(dir);
+    await internals(p).ensureProjectMarker(dir);
+    assert.equal(internals(p).createdMarkers.get(dir), 3);
+
+    await internals(p).releaseProjectMarker(dir);
+    assert.equal(internals(p).createdMarkers.get(dir), 2);
+    assert.ok(existsSync(join(dir, '.git')), '.git must persist while refcount > 0');
+
+    await internals(p).releaseProjectMarker(dir);
+    assert.equal(internals(p).createdMarkers.get(dir), 1);
+    assert.ok(existsSync(join(dir, '.git')));
+
+    await internals(p).releaseProjectMarker(dir);
+    assert.equal(internals(p).createdMarkers.has(dir), false);
+    assert.equal(existsSync(join(dir, '.git')), false, '.git should be removed after last release');
+  });
+
+  it('release on a path we never created is a no-op (does not delete pre-existing .git)', async () => {
+    const dir = freshDir('release-foreign');
+    mkdirSync(join(dir, '.git'));
+    const p = makeProvider();
+    await internals(p).ensureProjectMarker(dir); // no-op (pre-existing), no refcount
+    await internals(p).releaseProjectMarker(dir); // no-op
+    assert.ok(existsSync(join(dir, '.git')), 'pre-existing .git must not be deleted by release');
+  });
+
+  it('concurrent ensureProjectMarker calls serialize via mutex (no double-create, correct refcount)', async () => {
+    const dir = freshDir('concurrent');
+    const p = makeProvider();
+    await Promise.all([
+      internals(p).ensureProjectMarker(dir),
+      internals(p).ensureProjectMarker(dir),
+      internals(p).ensureProjectMarker(dir),
+      internals(p).ensureProjectMarker(dir),
+      internals(p).ensureProjectMarker(dir),
+    ]);
+    assert.equal(internals(p).createdMarkers.get(dir), 5);
+    assert.ok(existsSync(join(dir, '.git')));
+
+    await Promise.all([
+      internals(p).releaseProjectMarker(dir),
+      internals(p).releaseProjectMarker(dir),
+      internals(p).releaseProjectMarker(dir),
+      internals(p).releaseProjectMarker(dir),
+      internals(p).releaseProjectMarker(dir),
+    ]);
+    assert.equal(internals(p).createdMarkers.has(dir), false);
+    assert.equal(existsSync(join(dir, '.git')), false);
+  });
+
+  it('cleanupMarkersSync wipes every tracked marker and clears the map', async () => {
+    const dirA = freshDir('sync-a');
+    const dirB = freshDir('sync-b');
+    const p = makeProvider();
+    await internals(p).ensureProjectMarker(dirA);
+    await internals(p).ensureProjectMarker(dirB);
+    assert.ok(existsSync(join(dirA, '.git')));
+    assert.ok(existsSync(join(dirB, '.git')));
+
+    internals(p).cleanupMarkersSync();
+    assert.equal(existsSync(join(dirA, '.git')), false);
+    assert.equal(existsSync(join(dirB, '.git')), false);
+    assert.equal(internals(p).createdMarkers.size, 0);
+  });
+
+  it('is a no-op when skipProjectMarker is true (injected-client test mode)', async () => {
+    const dir = freshDir('skip');
+    const p = new OpenCodeProvider({ _client: {} as never });
+    // Default: skipProjectMarker=true because a _client was injected.
+    assert.equal(internals(p).skipProjectMarker, true);
+    await internals(p).ensureProjectMarker(dir);
+    assert.equal(existsSync(join(dir, '.git')), false, 'should not have created .git in skip mode');
+    assert.equal(internals(p).createdMarkers.size, 0);
+  });
+
+  it('non-fatal on git init failure: logs but does not throw, no refcount entry', async () => {
+    const p = makeProvider();
+    // Non-existent directory — `git init` can't cwd there.
+    const badDir = join(rootTmp, 'does-not-exist-' + Math.random().toString(36).slice(2));
+    await internals(p).ensureProjectMarker(badDir); // should not throw
+    assert.equal(
+      internals(p).createdMarkers.has(badDir),
+      false,
+      'failed inits must not leave a phantom refcount (would cause release to try rm on nothing)',
+    );
+  });
+});
+
+describe('OpenCodeProvider — project marker integration with executeCheck', () => {
+  let rootTmp: string;
+  beforeEach(() => {
+    rootTmp = mkdtempSync(join(tmpdir(), 'aghast-marker-exec-'));
+  });
+  afterEach(() => {
+    try { rmSync(rootTmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('creates and removes .git around a single executeCheck call', async () => {
+    const dir = join(rootTmp, 'scan-target');
+    mkdirSync(dir);
+
+    const client = createMockClient();
+    const provider = new OpenCodeProvider({ _client: client as never });
+    internals(provider).skipProjectMarker = false; // opt-in: exercise real marker logic
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    assert.equal(existsSync(join(dir, '.git')), false, 'starts without .git');
+    await provider.executeCheck('test instructions', dir);
+    assert.equal(
+      existsSync(join(dir, '.git')),
+      false,
+      '.git must be removed after executeCheck finishes',
+    );
+  });
+
+  it('cleans up marker even when the session prompt throws', async () => {
+    const dir = join(rootTmp, 'scan-throws');
+    mkdirSync(dir);
+
+    const client = createMockClient();
+    // Override prompt to throw
+    client.session.prompt = async () => { throw new Error('simulated prompt failure'); };
+
+    const provider = new OpenCodeProvider({ _client: client as never });
+    internals(provider).skipProjectMarker = false;
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(() => provider.executeCheck('test', dir), /simulated prompt failure/);
+    assert.equal(
+      existsSync(join(dir, '.git')),
+      false,
+      '.git should have been cleaned up even on failure',
+    );
+  });
+});
+
+// Helper to get the expected OUTPUT_SCHEMA shape for assertion
+function expect_output_schema() {
+  return {
+    type: 'object',
+    properties: {
+      issues: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            file: { type: 'string' },
+            startLine: { type: 'integer' },
+            endLine: { type: 'integer' },
+            description: { type: 'string' },
+            dataFlow: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  file: { type: 'string' },
+                  lineNumber: { type: 'integer' },
+                  label: { type: 'string' },
+                },
+                required: ['file', 'lineNumber', 'label'],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ['file', 'startLine', 'endLine', 'description'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['issues'],
+    additionalProperties: false,
+  };
+}

--- a/tests/production-mock-agent-provider.test.ts
+++ b/tests/production-mock-agent-provider.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the production mock AI provider (src/mock-ai-provider.ts).
+ * Tests for the production mock agent provider (src/mock-agent-provider.ts).
  *
  * This tests the lightweight mock that ships with the package and is used
  * by the CLI when AGHAST_MOCK_AI is set. It must NOT reference tests/mocks/.
@@ -7,11 +7,11 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { MockAIProvider } from '../src/mock-ai-provider.js';
+import { MockAgentProvider } from '../src/mock-agent-provider.js';
 
-describe('Production MockAIProvider', () => {
-  it('implements AIProvider interface', () => {
-    const provider = new MockAIProvider({ rawResponse: '{}' });
+describe('Production MockAgentProvider', () => {
+  it('implements AgentProvider interface', () => {
+    const provider = new MockAgentProvider({ rawResponse: '{}' });
     assert.equal(typeof provider.initialize, 'function');
     assert.equal(typeof provider.executeCheck, 'function');
     assert.equal(typeof provider.validateConfig, 'function');
@@ -19,13 +19,13 @@ describe('Production MockAIProvider', () => {
   });
 
   it('initialize succeeds without error', async () => {
-    const provider = new MockAIProvider({ rawResponse: '{}' });
+    const provider = new MockAgentProvider({ rawResponse: '{}' });
     await provider.initialize({});
   });
 
   it('executeCheck returns the configured raw response', async () => {
     const rawResponse = '{"issues": [{"file": "test.ts", "description": "test issue"}]}';
-    const provider = new MockAIProvider({ rawResponse });
+    const provider = new MockAgentProvider({ rawResponse });
     const result = await provider.executeCheck('instructions', '/repo');
 
     assert.equal(result.raw, rawResponse);
@@ -33,27 +33,27 @@ describe('Production MockAIProvider', () => {
   });
 
   it('executeCheck returns default empty issues response', async () => {
-    const provider = new MockAIProvider({ rawResponse: '{"issues": []}' });
+    const provider = new MockAgentProvider({ rawResponse: '{"issues": []}' });
     const result = await provider.executeCheck('instructions', '/repo');
 
     assert.equal(result.raw, '{"issues": []}');
   });
 
   it('validateConfig always returns true', async () => {
-    const provider = new MockAIProvider({ rawResponse: '{}' });
+    const provider = new MockAgentProvider({ rawResponse: '{}' });
     const valid = await provider.validateConfig();
     assert.equal(valid, true);
   });
 
   it('enableDebug is a no-op', () => {
-    const provider = new MockAIProvider({ rawResponse: '{}' });
+    const provider = new MockAgentProvider({ rawResponse: '{}' });
     // Should not throw
     provider.enableDebug();
   });
 
   it('returns same response on multiple calls', async () => {
     const rawResponse = '{"issues": []}';
-    const provider = new MockAIProvider({ rawResponse });
+    const provider = new MockAgentProvider({ rawResponse });
 
     const result1 = await provider.executeCheck('instructions1', '/repo1');
     const result2 = await provider.executeCheck('instructions2', '/repo2');

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the provider registry and AIProvider interface compliance.
+ * Unit tests for the provider registry and AgentProvider interface compliance.
  */
 
 import { describe, it } from 'node:test';
@@ -13,25 +13,27 @@ import {
   DEFAULT_PROVIDER_NAME,
 } from '../src/provider-registry.js';
 import { ClaudeCodeProvider } from '../src/claude-code-provider.js';
+import { OpenCodeProvider } from '../src/opencode-provider.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Helper to dynamically import MockAIProvider (avoids tsc emitting stray .js files)
+// Helper to dynamically import MockAgentProvider (avoids tsc emitting stray .js files)
 async function getMockProvider() {
-  const mockModulePath = pathToFileURL(resolve(__dirname, 'mocks', 'mock-ai-provider.js')).href;
-  const { MockAIProvider } = await import(mockModulePath);
-  return MockAIProvider;
+  const mockModulePath = pathToFileURL(resolve(__dirname, 'mocks', 'mock-agent-provider.js')).href;
+  const { MockAgentProvider } = await import(mockModulePath);
+  return MockAgentProvider;
 }
 
 // ─── Provider registry ────────────────────────────────────────────────────────
 
 describe('Provider registry', () => {
-  it('getProviderNames() returns [\'claude-code\'] by default', () => {
+  it('getProviderNames() includes claude-code and opencode', () => {
     const names = getProviderNames();
     assert.ok(names.includes('claude-code'), `Expected 'claude-code' in ${JSON.stringify(names)}`);
+    assert.ok(names.includes('opencode'), `Expected 'opencode' in ${JSON.stringify(names)}`);
   });
 
-  it('createProviderByName(\'claude-code\') returns an object with all AIProvider methods', () => {
+  it('createProviderByName(\'claude-code\') returns an object with all AgentProvider methods', () => {
     const provider = createProviderByName('claude-code');
     assert.equal(typeof provider.initialize, 'function');
     assert.equal(typeof provider.executeCheck, 'function');
@@ -43,7 +45,7 @@ describe('Provider registry', () => {
       () => createProviderByName('unknown-xyz'),
       (err: unknown) => {
         assert.ok(err instanceof Error);
-        assert.ok(err.message.includes('Unknown AI provider'), `message: ${err.message}`);
+        assert.ok(err.message.includes('Unknown agent provider'), `message: ${err.message}`);
         assert.ok(err.message.includes('claude-code'), `should list claude-code: ${err.message}`);
         return true;
       },
@@ -94,9 +96,9 @@ describe('Provider registry', () => {
   });
 });
 
-// ─── AIProvider interface compliance — ClaudeCodeProvider ─────────────────────
+// ─── AgentProvider interface compliance — ClaudeCodeProvider ─────────────────────
 
-describe('AIProvider interface compliance — ClaudeCodeProvider', () => {
+describe('AgentProvider interface compliance — ClaudeCodeProvider', () => {
   it('has initialize method', () => {
     const provider = new ClaudeCodeProvider();
     assert.equal(typeof provider.initialize, 'function');
@@ -163,52 +165,77 @@ describe('AIProvider interface compliance — ClaudeCodeProvider', () => {
   });
 });
 
-// ─── AIProvider interface compliance — MockAIProvider ─────────────────────────
+// ─── AgentProvider interface compliance — OpenCodeProvider ──────────────────────
 
-describe('AIProvider interface compliance — MockAIProvider', () => {
+describe('AgentProvider interface compliance — OpenCodeProvider', () => {
+  it('has all required AgentProvider methods', () => {
+    const provider = new OpenCodeProvider();
+    assert.equal(typeof provider.initialize, 'function');
+    assert.equal(typeof provider.executeCheck, 'function');
+    assert.equal(typeof provider.validateConfig, 'function');
+  });
+
+  it('has optional AgentProvider methods', () => {
+    const provider = new OpenCodeProvider();
+    assert.equal(typeof provider.getModelName, 'function');
+    assert.equal(typeof provider.setModel, 'function');
+    assert.equal(typeof provider.enableDebug, 'function');
+    assert.equal(typeof provider.checkPrerequisites, 'function');
+    assert.equal(typeof provider.cleanup, 'function');
+  });
+
+  it('createProviderByName(\'opencode\') returns an OpenCodeProvider', () => {
+    const provider = createProviderByName('opencode');
+    assert.ok(provider instanceof OpenCodeProvider);
+  });
+});
+
+// ─── AgentProvider interface compliance — MockAgentProvider ─────────────────────────
+
+describe('AgentProvider interface compliance — MockAgentProvider', () => {
   it('has initialize method', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     assert.equal(typeof provider.initialize, 'function');
   });
 
   it('has executeCheck method', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     assert.equal(typeof provider.executeCheck, 'function');
   });
 
   it('has validateConfig method', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     assert.equal(typeof provider.validateConfig, 'function');
   });
 
   it('validateConfig() returns true by default', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     const result = await provider.validateConfig();
     assert.equal(result, true);
   });
 
   it('validateConfig() returns false when configured with validConfig: false', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider({ validConfig: false });
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider({ validConfig: false });
     const result = await provider.validateConfig();
     assert.equal(result, false);
   });
 
   it('initialize() sets initialized flag', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     assert.equal(provider.initialized, false);
     await provider.initialize({});
     assert.equal(provider.initialized, true);
   });
 
   it('executeCheck() returns default empty issues response', async () => {
-    const MockAIProvider = await getMockProvider();
-    const provider = new MockAIProvider();
+    const MockAgentProvider = await getMockProvider();
+    const provider = new MockAgentProvider();
     await provider.initialize({});
     const response = await provider.executeCheck('test prompt', '/tmp');
     assert.ok(response.parsed, 'Should have parsed response');

--- a/tests/response-parser.test.ts
+++ b/tests/response-parser.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseAIResponse } from '../src/response-parser.js';
+import { parseAgentResponse } from '../src/response-parser.js';
 
-describe('parseAIResponse', () => {
+describe('parseAgentResponse', () => {
   it('parses valid PASS response (empty issues)', () => {
     const raw = JSON.stringify({ issues: [] });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.deepEqual(result.issues, []);
   });
@@ -27,7 +27,7 @@ describe('parseAIResponse', () => {
         },
       ],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 2);
     assert.equal(result.issues[0].file, 'src/api/users.ts');
@@ -38,7 +38,7 @@ describe('parseAIResponse', () => {
   });
 
   it('returns undefined for malformed JSON', () => {
-    const result = parseAIResponse('This is not valid JSON at all.');
+    const result = parseAgentResponse('This is not valid JSON at all.');
     assert.equal(result, undefined);
   });
 
@@ -46,23 +46,23 @@ describe('parseAIResponse', () => {
     const raw = JSON.stringify({
       findings: [{ location: 'src/api/users.ts', line: 45 }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.equal(result, undefined);
   });
 
   it('returns undefined when issues is not an array', () => {
     const raw = JSON.stringify({ issues: 'not an array' });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.equal(result, undefined);
   });
 
   it('returns undefined for non-object JSON', () => {
-    const result = parseAIResponse('"just a string"');
+    const result = parseAgentResponse('"just a string"');
     assert.equal(result, undefined);
   });
 
   it('returns undefined for null JSON', () => {
-    const result = parseAIResponse('null');
+    const result = parseAgentResponse('null');
     assert.equal(result, undefined);
   });
 
@@ -73,7 +73,7 @@ describe('parseAIResponse', () => {
         { file: 'src/app.ts', startLine: 1, endLine: 5, description: 'valid issue' },
       ],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.equal(result.issues[0].file, 'src/app.ts');
@@ -86,7 +86,7 @@ describe('parseAIResponse', () => {
         { file: 'src/other.ts', startLine: 10, endLine: 15, description: 'valid' },
       ],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.equal(result.issues[0].file, 'src/other.ts');
@@ -100,7 +100,7 @@ describe('parseAIResponse', () => {
         { file: 'src/other.ts', startLine: 1, endLine: 10, description: 'valid' },
       ],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.equal(result.issues[0].file, 'src/other.ts');
@@ -124,7 +124,7 @@ describe('parseAIResponse', () => {
         },
       ],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.equal(result.issues[0].file, 'src/valid.ts');
@@ -136,7 +136,7 @@ describe('parseAIResponse', () => {
       summary: 'Found 1 issue.',
       analysisNotes: 'Focused on auth patterns.',
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.summary, 'Found 1 issue.');
     assert.equal(result.analysisNotes, 'Focused on auth patterns.');
@@ -148,7 +148,7 @@ describe('parseAIResponse', () => {
       summary: 42,
       analysisNotes: { nested: true },
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.summary, undefined);
     assert.equal(result.analysisNotes, undefined);
@@ -158,7 +158,7 @@ describe('parseAIResponse', () => {
     const raw = JSON.stringify({
       issues: ['string item', null, 42, { file: 'a.ts', startLine: 1, endLine: 5, description: 'ok' }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.equal(result.issues[0].file, 'a.ts');
@@ -177,7 +177,7 @@ describe('parseAIResponse', () => {
         ],
       }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues.length, 1);
     assert.ok(result.issues[0].dataFlow);
@@ -204,7 +204,7 @@ describe('parseAIResponse', () => {
         ],
       }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues[0].dataFlow!.length, 2);
     assert.equal(result.issues[0].dataFlow![0].file, 'src/a.ts');
@@ -220,7 +220,7 @@ describe('parseAIResponse', () => {
         description: 'issue without data flow',
       }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues[0].dataFlow, undefined);
   });
@@ -235,14 +235,14 @@ describe('parseAIResponse', () => {
         dataFlow: [],
       }],
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.issues[0].dataFlow, undefined);
   });
 
   it('flagged:true on empty issues sets result.flagged', () => {
     const raw = JSON.stringify({ issues: [], flagged: true });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.flagged, true);
     assert.deepEqual(result.issues, []);
@@ -253,7 +253,7 @@ describe('parseAIResponse', () => {
       issues: [{ file: 'src/a.ts', startLine: 1, endLine: 5, description: 'issue' }],
       flagged: true,
     });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.flagged, true);
     assert.equal(result.issues.length, 1);
@@ -261,7 +261,7 @@ describe('parseAIResponse', () => {
 
   it('no flagged field → result.flagged is undefined', () => {
     const raw = JSON.stringify({ issues: [] });
-    const result = parseAIResponse(raw);
+    const result = parseAgentResponse(raw);
     assert.ok(result);
     assert.equal(result.flagged, undefined);
   });

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -13,8 +13,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 test('loadRuntimeConfig: valid config file', async () => {
   const validDir = resolve(__dirname, 'fixtures', 'runtime-config', 'valid-dir');
   const config = await loadRuntimeConfig(validDir);
-  assert.equal(config.aiProvider?.name, 'claude-code');
-  assert.equal(config.aiProvider?.model, 'claude-opus-4-6');
+  assert.equal(config.agentProvider?.name, 'claude-code');
+  assert.equal(config.agentProvider?.model, 'claude-opus-4-6');
 });
 
 test('loadRuntimeConfig: file absent returns empty object', async () => {
@@ -39,10 +39,10 @@ test('loadRuntimeConfig: malformed JSON throws error', async () => {
 test('loadRuntimeConfig: explicitPath parameter overrides default', async () => {
   const validPath = resolve(__dirname, 'fixtures', 'runtime-config', 'valid.json');
   const config = await loadRuntimeConfig('/unused', validPath);
-  assert.equal(config.aiProvider?.name, 'claude-code');
+  assert.equal(config.agentProvider?.name, 'claude-code');
 });
 
-test('loadRuntimeConfig: rejects aiProvider as a non-object', async () => {
+test('loadRuntimeConfig: rejects agentProvider as a non-object', async () => {
   const badTypesPath = resolve(__dirname, 'fixtures', 'runtime-config', 'bad-types.json');
   await assert.rejects(
     async () => {
@@ -50,9 +50,37 @@ test('loadRuntimeConfig: rejects aiProvider as a non-object', async () => {
     },
     (err: unknown) => {
       const error = err as Error;
-      return error.message.includes('"aiProvider" must be an object');
+      return error.message.includes('"agentProvider" must be an object');
     },
   );
+});
+
+test('loadRuntimeConfig: rejects legacy aiProvider key with rename hint', async () => {
+  const { writeFile: writeFileSync, unlink: unlinkSync } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const tmpPath = join(tmpdir(), `legacy-ai-provider-${process.pid}-${Date.now()}.json`);
+  await writeFileSync(
+    tmpPath,
+    JSON.stringify({ aiProvider: { name: 'claude-code', model: 'haiku' } }),
+    'utf-8',
+  );
+  try {
+    await assert.rejects(
+      async () => {
+        await loadRuntimeConfig('/unused', tmpPath);
+      },
+      (err: unknown) => {
+        const error = err as Error;
+        return (
+          error.message.includes('"aiProvider" has been renamed to "agentProvider"') &&
+          error.message.includes('0.5.0')
+        );
+      },
+    );
+  } finally {
+    await unlinkSync(tmpPath);
+  }
 });
 
 test('loadRuntimeConfig: rejects failOnCheckFailure as a non-boolean', async () => {

--- a/tests/sarif-formatter.test.ts
+++ b/tests/sarif-formatter.test.ts
@@ -15,7 +15,7 @@ function makeResults(overrides: Partial<ScanResults> = {}): ScanResults {
     executionTime: 100,
     startTime: '2026-01-01T12:00:00.000Z',
     endTime: '2026-01-01T12:00:00.100Z',
-    aiProvider: { name: 'mock', models: ['mock'] },
+    agentProvider: { name: 'mock', models: ['mock'] },
     ...overrides,
   };
 }

--- a/tests/scan-runner.test.ts
+++ b/tests/scan-runner.test.ts
@@ -7,16 +7,17 @@ import {
   runMultiScan,
   generateScanId,
 } from '../src/scan-runner.js';
+import { getRegisteredDiscoveries, registerDiscovery, unregisterDiscovery } from '../src/discovery.js';
 import type { SecurityCheck, CheckDetails } from '../src/types.js';
-import type { AIProvider, AIResponse, CheckResponse } from '../src/types.js';
+import type { AgentProvider, AgentResponse, CheckResponse } from '../src/types.js';
 import { FatalProviderError } from '../src/types.js';
 import {
   createPassProvider,
   createPassProviderWithTokens,
   createMalformedProvider,
   createTimeoutProvider,
-  MockAIProvider,
-} from './mocks/mock-ai-provider.js';
+  MockAgentProvider,
+} from './mocks/mock-agent-provider.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -91,7 +92,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.version, pkgVersion);
@@ -110,11 +111,11 @@ describe('runMultiScan (single check)', () => {
     assert.ok(results.startTime);
     assert.ok(results.endTime);
     assert.ok(results.executionTime >= 0);
-    assert.equal(results.aiProvider.name, 'claude-code');
+    assert.equal(results.agentProvider.name, 'claude-code');
   });
 
   it('produces FAIL result with enriched issues', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [
           {
@@ -130,7 +131,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -157,7 +158,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -168,12 +169,12 @@ describe('runMultiScan (single check)', () => {
     assert.equal(results.summary.errorChecks, 1);
   });
 
-  it('produces ERROR result when AI provider throws', async () => {
+  it('produces ERROR result when agent provider throws', async () => {
     const provider = createTimeoutProvider();
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -188,19 +189,19 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.ok(results.checks[0].executionTime >= 0);
     assert.ok(results.executionTime >= 0);
   });
 
-  it('sends prompt with check instructions to AI provider', async () => {
+  it('sends prompt with check instructions to agent provider', async () => {
     const provider = createPassProvider();
     await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(provider.callHistory.length, 1);
@@ -214,7 +215,7 @@ describe('runMultiScan (single check)', () => {
   });
 
   it('handles issues for non-existent files gracefully (no codeSnippet)', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [
           {
@@ -230,7 +231,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -243,7 +244,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     // ISO 8601 format
@@ -253,7 +254,7 @@ describe('runMultiScan (single check)', () => {
   });
 
   it('propagates severity and confidence from check config to issues', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [
           {
@@ -273,7 +274,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [checkWithMetadata],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     const issue = results.issues[0];
@@ -282,7 +283,7 @@ describe('runMultiScan (single check)', () => {
   });
 
   it('issues have no severity/confidence when check config omits them', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [
           {
@@ -298,7 +299,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     const issue = results.issues[0];
@@ -311,7 +312,7 @@ describe('runMultiScan (single check)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     // branch and commit should only be inside repository, not at top level
@@ -332,7 +333,7 @@ describe('runMultiScan (multiple checks)', () => {
         makeCheckAndDetails('check-1', 'Check One'),
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks.length, 2);
@@ -347,7 +348,7 @@ describe('runMultiScan (multiple checks)', () => {
   });
 
   it('aggregates results from mix of PASS and FAIL checks', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // PASS for first check
       {
@@ -363,7 +364,7 @@ describe('runMultiScan (multiple checks)', () => {
         makeCheckAndDetails('check-pass', 'Pass Check'),
         makeCheckAndDetails('check-fail', 'Fail Check'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.summary.totalChecks, 2);
@@ -373,7 +374,7 @@ describe('runMultiScan (multiple checks)', () => {
   });
 
   it('issues from all checks appear in flat list with correct checkId/checkName', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       {
         issues: [
@@ -393,7 +394,7 @@ describe('runMultiScan (multiple checks)', () => {
         makeCheckAndDetails('check-a', 'Check A'),
         makeCheckAndDetails('check-b', 'Check B'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.issues.length, 2);
@@ -404,7 +405,7 @@ describe('runMultiScan (multiple checks)', () => {
   });
 
   it('handles ERROR in one check while other checks succeed', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // PASS
     ]);
@@ -417,7 +418,7 @@ describe('runMultiScan (multiple checks)', () => {
         makeCheckAndDetails('check-ok', 'OK Check'),
         makeCheckAndDetails('check-err', 'Error Check'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.summary.totalChecks, 2);
@@ -432,7 +433,7 @@ describe('runMultiScan (multiple checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks.length, 0);
@@ -446,7 +447,7 @@ describe('runMultiScan (multiple checks)', () => {
   });
 
   it('executes checks sequentially (order preserved)', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] },
       { issues: [] },
@@ -460,7 +461,7 @@ describe('runMultiScan (multiple checks)', () => {
         makeCheckAndDetails('second', 'Second'),
         makeCheckAndDetails('third', 'Third'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].checkId, 'first');
@@ -514,7 +515,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'PASS');
@@ -525,7 +526,7 @@ describe('runMultiScan (multi-target checks)', () => {
 
   it('3 targets, 1 has issues → FAIL with enriched issues', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // target 1: pass
       {
@@ -542,7 +543,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -560,7 +561,7 @@ describe('runMultiScan (multi-target checks)', () => {
 
   it('3 targets, 1 AI error → ERROR', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // target 1: pass
       { issues: [] }, // target 2: pass
@@ -571,7 +572,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -610,7 +611,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: mixedProvider,
+      agentProvider: mixedProvider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -626,7 +627,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'PASS');
@@ -644,7 +645,7 @@ describe('runMultiScan (multi-target checks)', () => {
       checks: [makeMultiTargetCheck({
         checkTarget: { type: 'targeted', discovery: 'semgrep', rules: 'unused.yaml', maxTargets: 1 },
       })],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].targetsAnalyzed, 1);
@@ -660,21 +661,21 @@ describe('runMultiScan (multi-target checks)', () => {
       checks: [makeMultiTargetCheck({
         checkTarget: { type: 'targeted', discovery: 'semgrep', rules: 'unused.yaml', maxTargets: 2 },
       })],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].targetsAnalyzed, 2);
     assert.equal(provider.callHistory.length, 2);
   });
 
-  it('target location embedded in prompt sent to AI provider', async () => {
+  it('target location embedded in prompt sent to agent provider', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
     const provider = createPassProvider();
 
     await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(provider.callHistory.length, 3);
@@ -693,9 +694,55 @@ describe('runMultiScan (multi-target checks)', () => {
     assert.ok(provider.callHistory[2].instructions.includes('- Lines: 1-2'));
   });
 
+  it('agentOptions from discovery propagate to agent provider executeCheck', async () => {
+    // Register a one-off test discovery that returns a single target with
+    // a known agentOptions value, so we can assert the scan runner forwards
+    // it to provider.executeCheck() without relying on a real discovery.
+    const TEST_DISCOVERY = 'test-agent-options';
+    // Guard against test-ordering issues: assert the name is not already
+    // registered before we overwrite it with our test discovery. Non-mutating
+    // so a leak-source test failure is not silently self-healed on rerun.
+    assert.ok(
+      !getRegisteredDiscoveries().includes(TEST_DISCOVERY),
+      `${TEST_DISCOVERY} unexpectedly present in discovery registry — find and fix the leaking test`,
+    );
+    try {
+      registerDiscovery({
+        name: TEST_DISCOVERY,
+        defaultGenericPrompt: 'generic-instructions.md',
+        needsInstructions: false,
+        async discover() {
+          return [
+            {
+              file: 'src/example.ts',
+              startLine: 1,
+              endLine: 1,
+              label: '[test target]',
+              agentOptions: { maxTurns: 7 },
+            },
+          ];
+        },
+      });
+
+      const provider = createPassProvider();
+      await runMultiScan({
+        repositoryPath: fixtureRepo,
+        checks: [makeMultiTargetCheck({
+          checkTarget: { type: 'targeted', discovery: TEST_DISCOVERY },
+        })],
+        agentProvider: provider,
+      });
+
+      assert.equal(provider.callHistory.length, 1);
+      assert.deepEqual(provider.callHistory[0].options, { maxTurns: 7 });
+    } finally {
+      unregisterDiscovery(TEST_DISCOVERY);
+    }
+  });
+
   it('issues include codeSnippet from fixture file', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [{
           file: 'src/example.ts',
@@ -709,7 +756,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     // All 3 targets return the same issue
@@ -722,7 +769,7 @@ describe('runMultiScan (multi-target checks)', () => {
 
   it('severity and confidence propagated in multi-target mode', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [{
           file: 'src/example.ts',
@@ -737,7 +784,7 @@ describe('runMultiScan (multi-target checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [check],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     for (const issue of results.issues) {
@@ -750,21 +797,21 @@ describe('runMultiScan (multi-target checks)', () => {
 // --- runMultiScan tests (concurrency) ---
 
 /**
- * Create a tracking AI provider that records concurrency metrics.
+ * Create a tracking agent provider that records concurrency metrics.
  * Uses closures to safely track active/max under concurrent execution.
  */
 function createTrackingProvider(
   delayMs: number,
   responseFn?: (callIndex: number) => CheckResponse,
-): { provider: AIProvider; getMaxActive: () => number; getCurrentActive: () => number } {
+): { provider: AgentProvider; getMaxActive: () => number; getCurrentActive: () => number } {
   let currentActive = 0;
   let maxActive = 0;
   let callIndex = 0;
 
-  const provider: AIProvider = {
+  const provider: AgentProvider = {
     async initialize() {},
     async validateConfig() { return true; },
-    async executeCheck(_instructions: string, _repositoryPath: string): Promise<AIResponse> {
+    async executeCheck(_instructions: string, _repositoryPath: string): Promise<AgentResponse> {
       const myIndex = callIndex++;
       currentActive++;
       if (currentActive > maxActive) maxActive = currentActive;
@@ -803,7 +850,7 @@ describe('runMultiScan (concurrency)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
       concurrency: 3,
     });
 
@@ -820,7 +867,7 @@ describe('runMultiScan (concurrency)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'PASS');
@@ -838,7 +885,7 @@ describe('runMultiScan (concurrency)', () => {
       checks: [makeMultiTargetCheck({
         checkTarget: { type: 'targeted', discovery: 'semgrep', rules: 'unused.yaml', concurrency: 2 },
       })],
-      aiProvider: provider,
+      agentProvider: provider,
       concurrency: 10,
     });
 
@@ -852,10 +899,10 @@ describe('runMultiScan (concurrency)', () => {
     const delays = [100, 10, 50];
     let callIdx = 0;
 
-    const provider: AIProvider = {
+    const provider: AgentProvider = {
       async initialize() {},
       async validateConfig() { return true; },
-      async executeCheck(): Promise<AIResponse> {
+      async executeCheck(): Promise<AgentResponse> {
         const myIdx = callIdx++;
         const delay = delays[myIdx] ?? 10;
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -874,7 +921,7 @@ describe('runMultiScan (concurrency)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
       concurrency: 3,
     });
 
@@ -893,7 +940,7 @@ describe('runMultiScan (concurrency)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck({ checkTarget: { type: 'targeted', discovery: 'semgrep', rules: 'unused-in-mock.yaml', maxTargets: 1 } })],
-      aiProvider: provider,
+      agentProvider: provider,
       concurrency: 5,
     });
 
@@ -917,14 +964,14 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('single check: provider returns flagged:true → status FLAG, flaggedChecks=1', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: { issues: [], flagged: true },
     });
 
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FLAG');
@@ -936,7 +983,7 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('FAIL overrides FLAG: issues present even if flagged:true → FAIL', async () => {
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: {
         issues: [{ file: 'src/example.ts', startLine: 4, endLine: 4, description: 'Issue.' }],
         flagged: true,
@@ -946,7 +993,7 @@ describe('runMultiScan (FLAG status)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -956,14 +1003,14 @@ describe('runMultiScan (FLAG status)', () => {
 
   it('multi-target: all 3 targets flag → check status FLAG', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider({
+    const provider = new MockAgentProvider({
       response: { issues: [], flagged: true },
     });
 
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FLAG');
@@ -992,7 +1039,7 @@ describe('runMultiScan (FLAG status)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: mixedFlagProvider,
+      agentProvider: mixedFlagProvider,
     });
 
     assert.equal(results.checks[0].status, 'FLAG');
@@ -1002,7 +1049,7 @@ describe('runMultiScan (FLAG status)', () => {
 
   it('multi-target: FAIL overrides FLAG (some flag, one has issues) → FAIL', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [], flagged: true }, // target 1: flag
       {
@@ -1014,7 +1061,7 @@ describe('runMultiScan (FLAG status)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -1029,7 +1076,7 @@ describe('runMultiScan (FLAG status)', () => {
       async validateConfig() { return true; },
       async executeCheck(_instructions: string, _repositoryPath: string) {
         const n = callCount++;
-        if (n === 0) throw new Error('AI provider request timed out after 60000ms');
+        if (n === 0) throw new Error('Agent provider request timed out after 60000ms');
         const response = { issues: [] };
         return { raw: JSON.stringify(response), parsed: response };
       },
@@ -1041,7 +1088,7 @@ describe('runMultiScan (FLAG status)', () => {
         makeCheckAndDetails('check-1', 'Check One'),
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: mixedProvider,
+      agentProvider: mixedProvider,
     });
 
     assert.equal(results.checks.length, 2);
@@ -1057,7 +1104,7 @@ describe('runMultiScan (FLAG status)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -1066,7 +1113,7 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('3 checks, middle errors: all 3 summaries returned, errorChecks=1, passedChecks=2', async () => {
-    const provider = new MockAIProvider();
+    const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // check-1: PASS
     ]);
@@ -1105,7 +1152,7 @@ describe('runMultiScan (FLAG status)', () => {
         makeCheckAndDetails('check-2', 'Check Two'),
         makeCheckAndDetails('check-3', 'Check Three'),
       ],
-      aiProvider: sequentialProvider,
+      agentProvider: sequentialProvider,
     });
 
     assert.equal(results.checks.length, 3);
@@ -1136,7 +1183,7 @@ describe('runMultiScan (token usage)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.ok(results.checks[0].tokenUsage, 'Check summary should have tokenUsage');
@@ -1158,7 +1205,7 @@ describe('runMultiScan (token usage)', () => {
         makeCheckAndDetails('check-1', 'Check One'),
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     // Each check gets 200/100/300
@@ -1173,7 +1220,7 @@ describe('runMultiScan (token usage)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].tokenUsage, undefined);
@@ -1187,7 +1234,7 @@ describe('runMultiScan (token usage)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeMultiTargetCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     // 3 targets × 50/25/75
@@ -1205,7 +1252,7 @@ describe('runMultiScan (token usage)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSqlCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -1259,7 +1306,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSemgrepOnlyCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'PASS');
@@ -1276,7 +1323,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSemgrepOnlyCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'FAIL');
@@ -1306,7 +1353,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSemgrepOnlyCheck({ severity: 'critical', confidence: 'medium' })],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     for (const issue of results.issues) {
@@ -1324,7 +1371,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
       checks: [makeSemgrepOnlyCheck({
         checkTarget: { type: 'static', discovery: 'semgrep', rules: 'unused.yaml', maxTargets: 1 },
       })],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].targetsAnalyzed, 1);
@@ -1340,7 +1387,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSemgrepOnlyCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].status, 'ERROR');
@@ -1356,7 +1403,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
     const results = await runMultiScan({
       repositoryPath: fixtureRepo,
       checks: [makeSemgrepOnlyCheck()],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks[0].tokenUsage, undefined, 'semgrep-only should have no tokenUsage');
@@ -1373,7 +1420,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
         makeSemgrepOnlyCheck(),
         makeCheckAndDetails('ai-check', 'AI Check'),
       ],
-      aiProvider: provider,
+      agentProvider: provider,
     });
 
     assert.equal(results.checks.length, 2);
@@ -1402,7 +1449,7 @@ describe('runMultiScan (fatal error abort)', () => {
 
   it('FatalProviderError aborts remaining checks', async () => {
     let callCount = 0;
-    const fatalProvider: AIProvider = {
+    const fatalProvider: AgentProvider = {
       async initialize() {},
       async validateConfig() { return true; },
       async executeCheck() {
@@ -1413,7 +1460,7 @@ describe('runMultiScan (fatal error abort)', () => {
           return { raw: JSON.stringify(response), parsed: response };
         }
         // Check 2: fatal error
-        throw new FatalProviderError('AI provider authentication failed (401)');
+        throw new FatalProviderError('Agent provider authentication failed (401)');
       },
     };
 
@@ -1424,7 +1471,7 @@ describe('runMultiScan (fatal error abort)', () => {
         makeCheckAndDetails('check-2', 'Check Two'),
         makeCheckAndDetails('check-3', 'Check Three'),
       ],
-      aiProvider: fatalProvider,
+      agentProvider: fatalProvider,
     });
 
     assert.equal(results.checks.length, 3, 'All 3 checks should have summaries');
@@ -1440,12 +1487,12 @@ describe('runMultiScan (fatal error abort)', () => {
 
   it('non-fatal errors still continue to next check (regression)', async () => {
     let callCount = 0;
-    const mixedProvider: AIProvider = {
+    const mixedProvider: AgentProvider = {
       async initialize() {},
       async validateConfig() { return true; },
       async executeCheck() {
         const n = callCount++;
-        if (n === 0) throw new Error('AI provider request timed out after 60000ms');
+        if (n === 0) throw new Error('Agent provider request timed out after 60000ms');
         const response = { issues: [] };
         return { raw: JSON.stringify(response), parsed: response };
       },
@@ -1457,7 +1504,7 @@ describe('runMultiScan (fatal error abort)', () => {
         makeCheckAndDetails('check-1', 'Check One'),
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: mixedProvider,
+      agentProvider: mixedProvider,
     });
 
     assert.equal(results.checks.length, 2);
@@ -1467,11 +1514,11 @@ describe('runMultiScan (fatal error abort)', () => {
   });
 
   it('FatalProviderError on first check aborts all remaining', async () => {
-    const fatalProvider: AIProvider = {
+    const fatalProvider: AgentProvider = {
       async initialize() {},
       async validateConfig() { return true; },
       async executeCheck() {
-        throw new FatalProviderError('AI provider rate limit reached');
+        throw new FatalProviderError('Agent provider rate limit reached');
       },
     };
 
@@ -1481,7 +1528,7 @@ describe('runMultiScan (fatal error abort)', () => {
         makeCheckAndDetails('check-1', 'Check One'),
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: fatalProvider,
+      agentProvider: fatalProvider,
     });
 
     assert.equal(results.checks.length, 2, 'Both checks should have summaries');
@@ -1494,11 +1541,11 @@ describe('runMultiScan (fatal error abort)', () => {
   it('FatalProviderError in multi-target check aborts remaining checks', async () => {
     process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
 
-    const fatalProvider: AIProvider = {
+    const fatalProvider: AgentProvider = {
       async initialize() {},
       async validateConfig() { return true; },
       async executeCheck() {
-        throw new FatalProviderError('AI provider authentication failed (401)');
+        throw new FatalProviderError('Agent provider authentication failed (401)');
       },
     };
 
@@ -1524,7 +1571,7 @@ describe('runMultiScan (fatal error abort)', () => {
         multiTargetCheck,
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
-      aiProvider: fatalProvider,
+      agentProvider: fatalProvider,
     });
 
     assert.equal(results.checks.length, 2, 'Both checks should have summaries');

--- a/tests/semgrep-integration.itest.ts
+++ b/tests/semgrep-integration.itest.ts
@@ -12,7 +12,7 @@ import { unlink, writeFile } from 'node:fs/promises';
 import { runSemgrep } from '../src/semgrep-runner.js';
 import { parseSARIF } from '../src/sarif-parser.js';
 import { runMultiScan } from '../src/scan-runner.js';
-import { MockAIProvider } from './mocks/mock-ai-provider.js';
+import { MockAgentProvider } from './mocks/mock-agent-provider.js';
 import type { SecurityCheck, CheckDetails } from '../src/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -100,7 +100,7 @@ describe('Semgrep integration tests', { skip }, () => {
       delete process.env.AGHAST_MOCK_SEMGREP;
 
       try {
-        const provider = new MockAIProvider({ response: { issues: [] } });
+        const provider = new MockAgentProvider({ response: { issues: [] } });
 
         const check: SecurityCheck = {
           id: 'integ-sqli',
@@ -124,7 +124,7 @@ describe('Semgrep integration tests', { skip }, () => {
         const results = await runMultiScan({
           repositoryPath: testCodebase,
           checks: [{ check, details }],
-          aiProvider: provider,
+          agentProvider: provider,
         });
 
         assert.equal(results.checks.length, 1);


### PR DESCRIPTION
## Summary

- **OpenCode SDK provider**: new agent provider (`src/opencode-provider.ts`) using `@opencode-ai/sdk`, giving access to 75+ LLM providers as an alternative to the Claude Code provider.
- **Rename "AI provider" → "agent provider"**: terminology shift across the codebase. `mock-ai-provider.{ts,test.ts}` and friends rename to `mock-agent-provider.*`. The legacy `aiProvider` runtime-config key is rejected with a rename hint so old configs surface a clear error.
- **`checkTarget.maxIssuesPerTarget` cap**: targeted checks can cap the number of issues the AI returns per discovered target.
- **Shared `OUTPUT_SCHEMA`**: extracted into `src/provider-utils.ts` so both providers share the same structured-output contract.
- **Prompt tightening**: minor refinements to `config/prompts/general-vuln-discovery.md`.
- **Fix**: remove dead yield branch in `listModelsViaAgentSdk`.

## Test plan

- [ ] CI passes (lint, build, full test suite)
- [ ] `npm install && npm test` clean locally
- [ ] Spot-check that `mock-agent-provider` rename is consistent across imports
- [ ] Verify legacy `aiProvider` runtime-config key produces the rename hint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)