### PR TITLE
docs: add Cost Tracking to README documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Results are structured JSON (or SARIF) with per-check status and detailed issues
 - [Getting Started](docs/getting-started.md) — installation, setup, and first scan
 - [Trying It Out](docs/trying-it-out.md) — example checks walkthrough and first scan guide
 - [Scanning](docs/scanning.md) — scan command options, environment variables, output formats
+- [Cost Tracking](docs/cost-tracking.md) — how scan cost is measured, sources, and labels
 - [Creating Checks](docs/creating-checks.md) — scaffolding new security checks
 - [Configuration Reference](docs/configuration.md) — check schemas, check types, runtime config
 - [Development](docs/development.md) — setup, building, testing, releasing


### PR DESCRIPTION
## Summary

- `docs/cost-tracking.md` exists and is linked in `docs/README.md` and has proper nav links between Scanning and Creating Checks
- The main `README.md` documentation section was missing an entry for it — this adds the link in the correct position

## Test plan

- [x] Verify the link renders correctly in the README on GitHub
- [x] Confirm it sits between Scanning and Creating Checks (matching the order in `docs/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)