### PR TITLE
Bump brace-expansion dev dependency from 5.0.5 to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Bumps the transitive dev dependency `brace-expansion` from `5.0.5` to `5.0.6` (lockfile-only change).
- Patch-level update; no source code or runtime behavior changes.

## Test plan

- [x] `npm install` clean (0 vulnerabilities)
- [x] `npm test` — 871 passing, 2 skipped, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)