### PR TITLE
OpenCode provider: replace 1s progress poller with SSE event stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           pattern: test-results-*
 
       - name: Publish test results
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           report_paths: '**/test-results.xml'
           check_name: Test Results

--- a/docs/opencode-provider-internals.md
+++ b/docs/opencode-provider-internals.md
@@ -1,0 +1,89 @@
+# OpenCode provider — implementation notes
+
+Developer notes for `src/opencode-provider.ts`. Documents dead ends and confirmed findings from investigation so they aren't re-explored.
+
+---
+
+## SSE event types (opencode v1.15.5)
+
+**Use `message.part.updated`, not `session.next.tool.*`.**
+
+The SDK type file (`dist/v2/gen/types.gen.d.ts`) declares both event families in the `Event` union:
+- `message.part.updated` — carries a typed `Part` object with `state.status` (pending / running / completed / error), `state.input`, `state.output`
+- `session.next.tool.called`, `session.next.tool.success`, `session.next.tool.failed`, `session.next.text.delta`, etc.
+
+In practice, the running server (v1.15.5) only publishes `message.part.updated` and `message.part.delta`. The `session.next.*` family was never observed across multiple spike runs including tool-forcing prompts. Do not chase `session.next.*` events until confirmed working in a newer server version.
+
+**Session scoping field:** `properties.sessionID` (confirmed from spike). The `/event` SSE stream carries events for all sessions on the server; filter by this field to isolate a single check's events.
+
+**`session.error` shape:**
+```json
+{
+  "type": "session.error",
+  "properties": {
+    "sessionID": "ses_...",
+    "error": {
+      "name": "UnknownError",
+      "data": { "message": "Model not found: provider/model." }
+    }
+  }
+}
+```
+Access the human-readable message via `properties.error.data.message`.
+
+---
+
+## Server-side debug logs (`--print-logs`)
+
+**`--log-level=DEBUG` does not produce more output.** Source analysis of the opencode server confirmed that the hot paths — `session/llm.ts`, `session/prompt.ts`, `session/processor.ts`, `provider/provider.ts`, `tool/shell.ts`, `permission/index.ts` — contain no `.debug()` call sites. Only INFO is emitted on the prompt path regardless of the `--log-level` flag. There are ~35 `.debug()` sites in the codebase but they are all in config loading, MCP transport, LSP, and TUI code that never runs during `serve`.
+
+**`--print-logs` and disk logging are mutually exclusive.** When `--print-logs` is set, `log.ts` skips `createWriteStream` entirely — no log file is created in `~/.local/share/opencode/log/`. The flag redirects the same log lines to stderr instead of disk.
+
+**Most INFO lines are noise**, but `service=llm` lines are valuable: they include each LLM request attempt and — crucially — 429 rate-limit retries that opencode handles internally without emitting `session.error`. Without these lines, a rate-limited scan looks identical to a thinking scan from aghast's perspective. The implementation therefore captures stderr but filters to only `service=llm`, `service=permission`, `service=provider`, and `service=session.prompt` lines (see `USEFUL_SERVER_LOG` regex in `opencode-provider.ts`), discarding `service=bus`, `service=tool.registry`, `service=snapshot`, and all other noise.
+
+**`service=llm` error lines contain the full request body.** When the model hits a 429 (or any other API error), the logged line includes the complete LLM request body — system prompt, user messages, tool schemas — making the raw line many kilobytes long and unreadable on the console. `summariseServerError()` in `opencode-provider.ts` extracts the useful fields via regex (`providerID`, `modelID`, `statusCode`, `isRetryable`) and emits a compact one-liner at info level, e.g.:
+```
+[opencode-server] HTTP 429 — nvidia/moonshotai/kimi-k2.6 (retrying)
+```
+The full raw line is still forwarded at trace level for deep diagnosis.
+
+**Log level split:** `service=llm` error lines (matching `\berror\b`) → `logProgress` (info, always visible). Normal streaming heartbeat lines → `logTrace` (trace only, file log).
+
+**`getLogLevel()` only reads the console handler.** When running with `--log-file`, the file handler is typically at `trace` while the console stays at `info`. `getLogLevel()` returns `'info'` in that case, so any code gating on `isDebugOrTrace = getLogLevel() === 'debug' || ...` will silently disable itself even though the file log is capturing debug/trace output. Use `isDebugEnabled()` / `isTraceEnabled()` from `logging.ts` instead — these check the minimum level across all registered handlers.
+
+---
+
+## `session.create` model field
+
+The `model` body parameter is an **object**, not a string:
+```ts
+{ id: string; providerID: string; variant?: string }
+```
+Passing a `"providerID/modelID"` string is silently ignored by the server (session creates successfully but uses the default model).
+
+---
+
+## `@opencode-ai/sdk/dist/process.js` is not exported
+
+The package exports map does not include `./dist/process.js`. Attempting to import `stop` or `bindAbort` from that path throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. If you need process lifecycle helpers, inline the ~10-line `stop()` function directly.
+
+---
+
+## ⚠️ Open issue: agentic loop not running for some models
+
+**Observed with `nvidia/moonshotai/kimi-k2.6`.** `session.prompt()` is supposed to run the full agentic loop — execute tool calls, feed results back, and loop until the model produces a final answer. In practice, with this model the loop does not run: the SSE stream reports 0 tool call parts, and the "response" text returned by `extractTextFromParts()` is a JSON array of tool call invocations the model wanted to make, e.g.:
+
+```json
+[{"name": "read", "parameters": {"filePath": "routes\\run.py"}}]
+```
+
+This surfaces as a `StructuredOutputError` (the structured output schema check fails because the text is not `{"issues":[...]}`), falls through to text parsing, and produces a malformed response error.
+
+**The model is doing the right thing** — trying to read files before answering — but the tool execution step never happens. The full request body (visible in `service=llm` error lines at trace level) confirms opencode sends `tool_choice: required` with read/glob/grep/StructuredOutput tools. The model responds with tool call API invocations but they don't execute.
+
+**Root cause not yet confirmed.** Candidates:
+- Model-specific incompatibility with opencode's function-calling mechanism (kimi-k2.6 via NVIDIA's API endpoint)
+- Conflict between `format: { type: 'json_schema', schema: OUTPUT_SCHEMA }` on `session.prompt()` and the tool execution loop
+- opencode version (v1.15.5) not fully supporting this model's tool-call response format
+
+**Do not assume this is fixed by changing aghast's code alone.** The spike (scripts/opencode-logging-spike.ts, now deleted) confirmed that `session.prompt()` works correctly end-to-end with models that support the mechanism. The failure is model/provider-specific.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.144",
         "@opencode-ai/sdk": "^1.4.6",
         "dotenv": "^17.3.1",
         "picocolors": "^1.1.1",
@@ -33,35 +33,33 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.139.tgz",
-      "integrity": "sha512-9zmitYoxCQiQZsTUbm9IGC6VyZt70J3NLtkRQPQvFVfz7bKDrhlZZKzXmyl2XmqedXEIeQy2ACmwdjwzPIVIAw==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.144.tgz",
+      "integrity": "sha512-8TENU/XxsKeQD+TNQ1dWOH0O878sUXl7u6d1KOkCDBhr6Us1GVYNh99AjDikPq3oM9DGW3ZyXS0THqtcVF7bXQ==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.139",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.139"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.144",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.144"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.139.tgz",
-      "integrity": "sha512-dnuO2E0x6o9GAk9iZZKlEd10h+0PQFdTfr5aQU4I0W+0ReKsFEoE9LAqfomS2EvLUQ9L62X0+n0iyZQmAVi1kw==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.144.tgz",
+      "integrity": "sha512-pq5o/3yhzn/XCEO/BHEU5pDEYEE+4CL8d2VeGrKH1lWBNrlvjxIjesCe7VsDXgUN5JZVKAdr2DxYzLM8x3z89A==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.139.tgz",
-      "integrity": "sha512-SXyldBIwpMHDXppPGObXZ1wjSSWf/YPgD6vK4nssIXarC/DtMRnAQ419Hb3q5MaBB29vSjOPKmG0MOkMltFR/A==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.144.tgz",
+      "integrity": "sha512-v9fJKR+5ZFLd+TsAelBZTk2PB7/540Un7zaep1OKA67GKyv6odQaE317h9cQotsLpF14q7Uil1JlNA+eAv3XGw==",
       "cpu": [
         "x64"
       ],
@@ -85,9 +83,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.139.tgz",
-      "integrity": "sha512-qfnQ4SjEcq//iGAJkk25J6j4Tq+dvQe9wHks0dcaSdGOs2D96Teqrb358YJe+nke2DBKVUa9Y4ComW3aUBM29w==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.144.tgz",
+      "integrity": "sha512-PulvfnScH2mWXOHWyNPhYWzq46moL1VzflGyogrEg911EEBHoUBISCBvcAitGjwpsOgoSm1lM+8k/J2yWoI8pA==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +96,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.139.tgz",
-      "integrity": "sha512-gzMfit9t7Fiy5taZ+miAaP8ZmOMc+hv8Ov3UOXGwJunK6H+0F88ctBSnolDPMPQaS6s2WoMD0o8fhUbBudtMVw==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.144.tgz",
+      "integrity": "sha512-nem/AgXOlTKJdRO+v8WD51KeAd2z1rl/sKprlaepyAsQ5vJ5xMWKuWpnTPvLJsT/VdFGQIBgDRTNI+UMsh0Uag==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +109,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.139.tgz",
-      "integrity": "sha512-2Gqy5hV/MyObbwSyNhj5ha2cY5EZnUfDLvpEwR1eeOaU1yqnxzsdNzXWgHIyWQGKGNE2ICwgLYtt6AtOJGWpPg==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.144.tgz",
+      "integrity": "sha512-zzLNbAVgbmu1rcyfT8qBQcyT3tO/plxoN+4JeqPhK0gVNrwTTjru3/VKnVG+11MYIEprC4DPzJGeRMHGLHhfzw==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +122,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.139.tgz",
-      "integrity": "sha512-Fg/aQs1vdyqLrNXqGa1i7/ODpGxP6ud/K/2AgVarLteg2Z3ZnrHPvPQ6iQmTGI8+BhxAZ141t4Dg0CWz3CoqCQ==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.144.tgz",
+      "integrity": "sha512-gDMjhk5PnE9BLXWxgHHCuJ7MpM+2hsBth/FJiHv5T0HWPw/oU2a3aMpkmgn7cTuva+hZ9Sp+gcPy8pbZOp6QVQ==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +135,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.139.tgz",
-      "integrity": "sha512-HusAU/gSQ0G0AHU+Hj/ps0Tl5JaUF2nxkp+G42tU6hpnwLMOQMdLx/yqvSQnz4WSxggxiDFmYvMDLYAmuE9Qdg==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.144.tgz",
+      "integrity": "sha512-5ZbYkxeS+zxMzjTLq/wCpFBpZBZYObr9FDm/RvshQcenFVjTnkVyxUYtnF5PtCy1DqX035iCEF8dlRK//uhY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -150,9 +148,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.139",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.139.tgz",
-      "integrity": "sha512-eJjbtLvEBJcTrl4WJhmhP7FYdTVvx/XtioifH7OEnCoxQozMHhOmA0X90csplIRpttX+jX2PqnE5j2FwU20eCw==",
+      "version": "0.3.144",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.144.tgz",
+      "integrity": "sha512-fLWcb133NaSLegLtUV19S9qh8modpyIia9dX6bxobS7NOaCYGmxWkCFGm6F2IuyF0h6yt33EMXFL8HnnYU8jaQ==",
       "cpu": [
         "x64"
       ],
@@ -167,6 +165,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.0.tgz",
       "integrity": "sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"
@@ -193,9 +192,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -210,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -227,9 +226,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +243,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -261,9 +260,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -278,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -295,9 +294,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -312,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -329,9 +328,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -346,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -363,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -380,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -397,9 +396,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -414,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -431,9 +430,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -448,9 +447,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -465,9 +464,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -482,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -499,9 +498,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -516,9 +515,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -533,9 +532,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -550,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -567,9 +566,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -584,9 +583,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -601,9 +600,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -618,9 +617,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +691,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -831,6 +830,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.48",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.48.tgz",
-      "integrity": "sha512-wKM86jCzV/ZApyWrdm3uP8XdWcS0LMbu3FV+OWz1ChiGGg1wiIWNGMJs5CY8/QX2/rUuZrd1Q1DqvdamZ0zLeg==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.5.tgz",
+      "integrity": "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -903,13 +903,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/picomatch": {
@@ -920,17 +920,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -943,7 +943,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -959,17 +959,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -985,14 +985,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1007,14 +1007,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1042,15 +1042,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1081,16 +1081,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1109,16 +1109,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1133,13 +1133,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1494,32 +1494,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escape-html": {
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1552,7 +1552,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
@@ -2042,19 +2042,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -2668,16 +2655,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -2922,14 +2899,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2984,16 +2960,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+      "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.3",
-        "@typescript-eslint/parser": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3"
+        "@typescript-eslint/eslint-plugin": "8.59.4",
+        "@typescript-eslint/parser": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3008,9 +2984,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript-eslint": "^8.57.1"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.144",
     "@opencode-ai/sdk": "^1.4.6",
     "dotenv": "^17.3.1",
     "picocolors": "^1.1.1",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -288,6 +288,22 @@ export function getLogLevel(): LogLevel | 'silent' {
   return ensureConsoleHandler().level;
 }
 
+/**
+ * Return true if any registered handler will output debug (or lower) entries.
+ * Use this instead of getLogLevel() when a file handler may be active at a
+ * finer level than the console handler.
+ */
+export function isDebugEnabled(): boolean {
+  return handlers.some((h) => h.level !== 'silent' && LOG_LEVEL_PRIORITY[h.level as LogLevel] >= LOG_LEVEL_PRIORITY['debug']);
+}
+
+/**
+ * Return true if any registered handler will output trace entries.
+ */
+export function isTraceEnabled(): boolean {
+  return handlers.some((h) => h.level === 'trace');
+}
+
 // --- Timestamp ---
 
 export function formatTimestamp(): string {
@@ -329,6 +345,13 @@ export function logDebug(tag: string, message: string, data?: unknown): void {
  * Log debug information without truncation (for full prompts and responses).
  */
 export function logDebugFull(tag: string, message: string, data?: string): void {
+  log('trace', tag, message, data);
+}
+
+/**
+ * Log a trace-level message (finer-grained than debug; for raw internal data).
+ */
+export function logTrace(tag: string, message: string, data?: unknown): void {
   log('trace', tag, message, data);
 }
 

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -2,11 +2,11 @@
  * OpenCode agent provider implementation.
  * Uses @opencode-ai/sdk v2 API to delegate to any LLM provider supported by OpenCode.
  *
- * Progress logging: at trace level, a 1-second poller fetches session messages to
- * log tool calls and text parts in real-time while session.prompt() blocks.
+ * Progress logging: at debug/trace level, subscribes to the SSE event stream to
+ * log tool calls and session errors in real-time while session.prompt() blocks.
  */
 
-import { exec } from 'node:child_process';
+import { exec, spawn, spawnSync } from 'node:child_process';
 import { existsSync, rmSync } from 'node:fs';
 import { rm as rmAsync } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -15,7 +15,7 @@ import type { AgentProvider, AgentResponse, ProviderConfig, CheckResponse, Provi
 import { FatalProviderError } from './types.js';
 import { parseAgentResponse } from './response-parser.js';
 import { OUTPUT_SCHEMA } from './provider-utils.js';
-import { logProgress, logDebug, logDebugFull, createTimer, getLogLevel } from './logging.js';
+import { logProgress, logDebug, logDebugFull, logTrace, logWarn, createTimer, isDebugEnabled, isTraceEnabled } from './logging.js';
 
 const execAsync = promisify(exec);
 
@@ -25,7 +25,6 @@ const DEFAULT_OPENCODE_MODEL = 'opencode/hy3-preview-free';
 // Tools the agent is permitted to use — everything else is denied.
 const ALLOWED_TOOL_PERMISSIONS = new Set(['read', 'glob', 'grep', 'list']);
 const HEARTBEAT_INTERVAL_MS = 15000;
-const TRACE_POLL_MS = 1000;
 const CLOSE_TIMEOUT_MS = 5000;
 
 /**
@@ -41,6 +40,109 @@ function parseModelString(model?: string): { providerID: string; modelID: string
     );
   }
   return { providerID: raw.slice(0, slashIdx), modelID: raw.slice(slashIdx + 1) };
+}
+
+// Regex for stderr lines worth forwarding — drops service=bus, tool.registry, snapshot,
+// config, file.watcher, lsp, plugin, etc. Keeps LLM calls (including 429 retries),
+// provider routing, permission decisions, and session loop steps.
+const USEFUL_SERVER_LOG = /service=(llm|permission|provider|session\.prompt|session\.processor)\b/;
+// Lines matching USEFUL_SERVER_LOG that also contain an error indicator are promoted to debug.
+const SERVER_LOG_ERROR = /\berror\b/i;
+
+/** Extract a compact summary from a raw opencode server error log line. */
+function summariseServerError(line: string): string {
+  const providerID = line.match(/providerID=(\S+)/)?.[1] ?? '';
+  const modelID = line.match(/modelID=(\S+)/)?.[1] ?? '';
+  const statusCode = line.match(/"statusCode":(\d+)/)?.[1];
+  const isRetryable = /"isRetryable":true/.test(line);
+  const errorName = line.match(/"name":"([^"]+)"/)?.[1] ?? 'LLM error';
+  const model = [providerID, modelID].filter(Boolean).join('/');
+  const status = statusCode ? `HTTP ${statusCode}` : errorName;
+  const suffix = isRetryable ? ' (retrying)' : '';
+  return `[opencode-server] ${status}${model ? ` — ${model}` : ''}${suffix}`;
+}
+
+// Inlined from @opencode-ai/sdk/dist/process.js — that path is not in the package exports map.
+// See docs/opencode-provider-internals.md.
+function stopProcess(proc: ReturnType<typeof spawn>): void {
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+  if (process.platform === 'win32' && proc.pid) {
+    const out = spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true });
+    if (!out.error && out.status === 0) return;
+  }
+  proc.kill();
+}
+
+/**
+ * Spawn `opencode serve` directly so we can forward filtered server logs.
+ * Returns the same `{ url, close() }` shape as the SDK's createOpencode().
+ * At debug/trace log level, useful stderr lines (LLM calls, permission decisions,
+ * provider routing) are forwarded to logDebug — surfacing 429 retries and auth errors
+ * that would otherwise be invisible while session.prompt() blocks.
+ */
+async function spawnOpencodeServer(): Promise<{ url: string; close(): void }> {
+  // Always pass --print-logs so opencode writes server logs to stderr instead of disk.
+  // We capture and forward those logs via logDebug, which routes to whichever handlers
+  // are active (file handler at debug level sees them even if console is at info).
+  // Shell is required on Windows for the .cmd wrapper (CVE-2024-27980 mitigation).
+  const cmd = 'opencode serve --hostname=127.0.0.1 --port=0 --print-logs';
+  const proc = spawn(cmd, { shell: true });
+
+  const forwardStderr = (chunk: Buffer): void => {
+    for (const line of chunk.toString().split('\n')) {
+      if (!line.trim()) continue;
+      if (USEFUL_SERVER_LOG.test(line)) {
+        // Log error lines (e.g. 429 retries) at info so they're visible without --debug.
+        if (SERVER_LOG_ERROR.test(line)) {
+          logProgress(TAG, summariseServerError(line));
+        } else {
+          logTrace(TAG, `[opencode-server] ${line.trim()}`);
+        }
+      }
+    }
+  };
+
+  let stdoutBuf = '';
+  const url = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      stopProcess(proc);
+      reject(new Error('Timeout: opencode server did not start within 30s'));
+    }, 30_000);
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString();
+      const lines = stdoutBuf.split('\n');
+      stdoutBuf = lines.pop() ?? '';
+      for (const line of lines) {
+        const m = line.match(/opencode server listening on\s+(https?:\/\/[^\s]+)/);
+        if (m) {
+          clearTimeout(timeout);
+          resolve(m[1]);
+        }
+      }
+    });
+
+    proc.stderr?.on('data', forwardStderr);
+
+    proc.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`opencode server exited with code ${code} before becoming ready`));
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(new Error(`opencode server spawn error: ${err.message}`));
+    });
+  });
+
+  // Continue forwarding stderr after server is ready.
+  proc.stderr?.off('data', forwardStderr);
+  proc.stderr?.on('data', forwardStderr);
+
+  return {
+    url,
+    close: () => stopProcess(proc),
+  };
 }
 
 /** Verify that the opencode binary is installed and runnable. */
@@ -123,15 +225,12 @@ export class OpenCodeProvider implements AgentProvider {
     // Verify opencode binary is installed
     await verifyOpenCodeInstalled();
 
-    const { createOpencode } = await import('@opencode-ai/sdk/v2');
+    const { createOpencodeClient } = await import('@opencode-ai/sdk/v2/client');
 
     logProgress(TAG, 'Starting OpenCode server...');
-    const opencode = await createOpencode({
-      port: 0,
-    });
-    this._client = opencode.client as OpenCodeClient;
-    this._server = opencode.server;
-    logProgress(TAG, `OpenCode server started at ${this._server!.url}`);
+    this._server = await spawnOpencodeServer();
+    this._client = createOpencodeClient({ baseUrl: this._server.url }) as OpenCodeClient;
+    logProgress(TAG, `OpenCode server started at ${this._server.url}`);
 
     // Register signal handlers for cleanup on unexpected exit.
     // SIGHUP catches terminal-window-close (sent as SIGHUP on Unix; Node maps
@@ -384,78 +483,85 @@ export class OpenCodeProvider implements AgentProvider {
     logDebug(TAG, `${prefix}Starting query: model=${this.providerID}/${this.modelID}, promptLen=${instructions.length}`);
     logDebugFull(TAG, `${prefix}Full prompt sent to AI`, instructions);
 
-    // At trace level, poll session messages every second for real-time progress.
-    // session.prompt() blocks, but setInterval callbacks run during the await.
     let toolCallCount = 0;
-    let lastLoggedPartCount = 0;
     let lastActivityTime = Date.now();
-    const logLevel = getLogLevel();
-    const isDebugOrTrace = logLevel === 'debug' || logLevel === 'trace';
-    const trace = logLevel === 'trace';
+    const debugEnabled = isDebugEnabled();
+    const trace = isTraceEnabled();
 
-    const progressInterval = isDebugOrTrace ? setInterval(async () => {
+    // Subscribe to the SSE event stream before calling session.prompt() so we
+    // catch events from the very first step. Filter to our sessionId so concurrent
+    // checks sharing the same server don't see each other's events.
+    // session.error is always surfaced at warn regardless of log level.
+    // Tool-progress events (message.part.updated) are only logged at debug/trace.
+    // See docs/opencode-provider-internals.md for why message.part.updated is used
+    // instead of session.next.tool.* and the --print-logs stderr capture.
+    const sseAbort = new AbortController();
+    const seenPartStatuses = new Map<string, string>(); // partId → last logged status
+
+    const sseTask = (async () => {
       try {
-        const messagesResult = await client.session.messages({
-          sessionID: sessionId,
-          directory: repositoryPath,
-        });
-        const messages = messagesResult.data ?? [];
-        const assistantMsg = [...messages].reverse().find(
-          (m: { info: { role: string } }) => m.info.role === 'assistant',
+        const sseResult = await client.event.subscribe(
+          { directory: repositoryPath },
+          { signal: sseAbort.signal },
         );
-        if (!assistantMsg) return;
+        for await (const evt of sseResult.stream) {
+          const e = evt as { type?: string; properties?: Record<string, unknown> };
+          const evtType = e.type ?? '';
+          const props = (e.properties ?? {}) as Record<string, unknown>;
+          if ((props['sessionID'] as string) !== sessionId) continue;
 
-        const parts = assistantMsg.parts as Array<{
-          type: string; tool?: string; text?: string;
-          state?: {
-            status: string;
-            input?: Record<string, unknown>;
-            error?: string;
-            output?: string;
-          };
-        }>;
-        if (parts.length <= lastLoggedPartCount) return;
-
-        for (let i = lastLoggedPartCount; i < parts.length; i++) {
-          const part = parts[i];
           lastActivityTime = Date.now();
 
-          if (part.type === 'tool') {
-            const state = part.state;
-            const toolName = part.tool ?? 'unknown';
-            const inputPreview = previewJSON(state?.input, 200);
-            if (state?.status === 'running') {
-              toolCallCount++;
-              logDebug(TAG, `${prefix}Tool[${toolCallCount}]: ${toolName} ${inputPreview} (${timer.elapsedStr()})`);
-              if (trace && JSON.stringify(state?.input).length > 200) {
-                logDebugFull(TAG, `${prefix}Full tool call input`, JSON.stringify(state?.input));
+          if (evtType === 'message.part.updated' && debugEnabled) {
+            const part = props['part'] as Record<string, unknown> | undefined;
+            if (!part) continue;
+            const partId = part['id'] as string;
+            const partType = part['type'] as string;
+            const state = part['state'] as Record<string, unknown> | undefined;
+            const status = (state?.['status'] as string) ?? '';
+
+            if (partType === 'tool') {
+              if (seenPartStatuses.get(partId) === status) continue;
+              // Record the status before the switch so that any unhandled status
+              // is still deduplicated on the next duplicate event, preventing
+              // re-admission after a status transition (e.g. spurious running
+              // after completed). Terminal statuses are deleted afterward to
+              // bound map size — once deleted, no further events are expected.
+              seenPartStatuses.set(partId, status);
+
+              const toolName = (part['tool'] as string) ?? 'unknown';
+              const input = state?.['input'] as Record<string, unknown> | undefined;
+              const inputPreview = previewJSON(input, 200);
+
+              if (status === 'running') {
+                toolCallCount++;
+                logDebug(TAG, `${prefix}Tool[${toolCallCount}]: ${toolName} ${inputPreview} (${timer.elapsedStr()})`);
+                if (trace && JSON.stringify(input).length > 200) {
+                  logDebugFull(TAG, `${prefix}Full tool call input`, JSON.stringify(input));
+                }
+              } else if (status === 'completed') {
+                seenPartStatuses.delete(partId); // terminal — no further events expected
+                logDebug(TAG, `${prefix}Tool done: ${toolName} (${timer.elapsedStr()})`);
+                const toolOutput = (state?.['output'] as string) ?? '';
+                if (trace && toolOutput.length > 200) logDebugFull(TAG, `${prefix}Full tool output (${toolOutput.length} chars)`, toolOutput);
+              } else if (status === 'error') {
+                seenPartStatuses.delete(partId); // terminal
+                const errorMsg = (state?.['error'] as string) ?? '(no error message)';
+                const errorPreview = errorMsg.length > 300 ? errorMsg.slice(0, 300) + '...' : errorMsg;
+                logDebug(TAG, `${prefix}Tool error: ${toolName} ${inputPreview} → ${errorPreview} (${timer.elapsedStr()})`);
               }
-            } else if (state?.status === 'completed') {
-              logDebug(TAG, `${prefix}Tool done: ${toolName} (${timer.elapsedStr()})`);
-              const toolOutput = state?.output ?? '';
-              if (trace && toolOutput.length > 200) logDebugFull(TAG, `${prefix}Full tool output (${toolOutput.length} chars)`, toolOutput);
-            } else if (state?.status === 'error') {
-              // Tools can transition running → error between polls, so the "running" log
-              // line may never fire for this tool. Always include the input so the user
-              // can see what was being attempted, plus the error message from the SDK.
-              const errorMsg = state.error ?? '(no error message)';
-              const errorPreview = errorMsg.length > 300 ? errorMsg.slice(0, 300) + '...' : errorMsg;
-              logDebug(
-                TAG,
-                `${prefix}Tool error: ${toolName} ${inputPreview} → ${errorPreview} (${timer.elapsedStr()})`,
-              );
             }
-          } else if (part.type === 'text' && part.text) {
-            const preview = part.text.length > 150 ? part.text.slice(0, 150) + '...' : part.text;
-            logDebug(TAG, `${prefix}Text: ${preview}`);
-            if (trace && part.text.length > 150) logDebugFull(TAG, `${prefix}Full assistant text`, part.text);
+          } else if (evtType === 'session.error') {
+            const error = props['error'] as Record<string, unknown> | undefined;
+            const errData = error?.['data'] as Record<string, unknown> | undefined;
+            const message = (errData?.['message'] as string) ?? (error?.['name'] as string) ?? 'unknown error';
+            logWarn(TAG, `${prefix}OpenCode session error: ${message}`);
           }
         }
-        lastLoggedPartCount = parts.length;
       } catch {
-        // Polling failure is non-fatal
+        // SSE stream error (including AbortError on teardown) is non-fatal
       }
-    }, TRACE_POLL_MS) : undefined;
+    })();
 
     // Heartbeat timer (all log levels)
     const heartbeatInterval = setInterval(() => {
@@ -478,7 +584,8 @@ export class OpenCodeProvider implements AgentProvider {
         directory: repositoryPath,
       });
     } finally {
-      if (progressInterval) clearInterval(progressInterval);
+      sseAbort.abort();
+      await sseTask;
       clearInterval(heartbeatInterval);
     }
 

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OpenCodeProvider } from '../src/opencode-provider.js';
 import { FatalProviderError } from '../src/types.js';
+import { addHandler, removeHandler, type LogEntry, type LogHandler } from '../src/logging.js';
 
 /** Accessor for the provider's private marker methods/state in tests. */
 interface MarkerInternals {
@@ -52,6 +53,9 @@ interface PromptCall {
  */
 const DEFAULT_MOCK_TOOL_IDS = ['read', 'glob', 'grep', 'list', 'bash', 'edit', 'webfetch', 'websearch'];
 
+/** Seed events for the SSE mock stream. */
+type SseEvent = { type: string; properties: Record<string, unknown> };
+
 function createMockClient(options?: {
   providers?: MockProvider[];
   promptResponse?: {
@@ -59,6 +63,7 @@ function createMockClient(options?: {
     parts?: Array<{ type: string; text?: string }>;
   };
   toolIds?: string[];
+  sseEvents?: SseEvent[];
 }) {
   const providers = options?.providers ?? [
     {
@@ -81,6 +86,7 @@ function createMockClient(options?: {
   };
 
   const toolIds = options?.toolIds ?? DEFAULT_MOCK_TOOL_IDS;
+  const sseEvents = options?.sseEvents ?? [];
 
   const calls: {
     sessionCreate: Array<Record<string, unknown>>;
@@ -114,6 +120,27 @@ function createMockClient(options?: {
           { info: { role: 'assistant' }, parts: defaultPromptResponse.parts ?? [] },
         ],
       }),
+    },
+    event: {
+      subscribe: async (_params?: unknown, options?: { signal?: AbortSignal }) => {
+        const signal = options?.signal;
+        async function* makeStream() {
+          for (const evt of sseEvents) {
+            if (signal?.aborted) return;
+            yield evt;
+          }
+          // After seeded events are exhausted, block until aborted so the SSE task
+          // mirrors real server behaviour (stream stays open until the caller aborts).
+          // Check signal.aborted first — abort() may have been called before we reach
+          // this point (signal already set when addEventListener would be registered,
+          // and AbortSignal does not re-fire already-dispatched events).
+          if (!signal || signal.aborted) return;
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+        }
+        return { stream: makeStream() };
+      },
     },
     calls,
   };
@@ -410,6 +437,57 @@ describe('OpenCodeProvider — error handling', () => {
         return true;
       },
     );
+  });
+});
+
+describe('OpenCodeProvider — SSE event stream', () => {
+  it('surfaces session.error events at warn level regardless of log level', async () => {
+    const warnMessages: string[] = [];
+    const spy: LogHandler = {
+      name: 'test-warn-spy',
+      level: 'warn',
+      handle(entry: LogEntry) {
+        if (entry.level === 'warn') warnMessages.push(entry.message);
+      },
+      close: async () => {},
+    };
+    addHandler(spy);
+
+    try {
+      // Capture the session ID dynamically from the mock's session.create so the
+      // SSE event's sessionID matches what the provider actually uses, without
+      // hardcoding mock internals.
+      let capturedSessionId = '';
+      const pendingEvents: SseEvent[] = [];
+      const client = createMockClient({ sseEvents: pendingEvents });
+      const origCreate = client.session.create;
+      client.session.create = async (params: Record<string, unknown>) => {
+        const result = await origCreate(params);
+        capturedSessionId = (result.data?.id as string) ?? '';
+        // Seed the event now that we know the session ID.
+        pendingEvents.push({
+          type: 'session.error',
+          properties: {
+            sessionID: capturedSessionId,
+            error: { name: 'UnknownError', data: { message: 'Model not found: provider/model.' } },
+          },
+        });
+        return result;
+      };
+
+      const provider = new OpenCodeProvider({ _client: client as never });
+      await provider.initialize({ model: 'test-provider/test-model' });
+
+      await provider.executeCheck('test instructions', '/repo/path');
+
+      assert.ok(capturedSessionId !== '', 'Expected session.create to have been called');
+      assert.ok(
+        warnMessages.some((m) => m.includes('Model not found: provider/model.')),
+        `Expected a warn log containing the session.error message. Got: ${JSON.stringify(warnMessages)}`,
+      );
+    } finally {
+      removeHandler('test-warn-spy');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaces the 1-second polling loop in the OpenCode provider with a real-time SSE (Server-Sent Events) event stream, reducing latency and unnecessary HTTP requests during AI runs
- Adds logging improvements to surface provider progress and errors more clearly
- Adds `docs/opencode-provider-internals.md` documenting the OpenCode provider's internal architecture and SSE event handling
- Expands `tests/opencode-provider.test.ts` with new coverage for SSE stream handling

## Test plan

- [ ] All 872 existing tests pass (`npm test`)
- [ ] OpenCode provider SSE path tested via new unit tests
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)