### PR TITLE
Change OpenCode default model and update integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGRESSION_TEST_MODEL: opencode/minimax-m2.5-free
+  REGRESSION_TEST_MODEL: opencode/nemotron-3-super-free
 
 permissions:
   contents: read

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,7 +330,7 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | Field                           | Type       | Default | Description |
 |---------------------------------|------------|---------|-------------|
 | `agentProvider.name`            | `string`   | `claude-code` | Agent provider name (`claude-code` or `opencode`) |
-| `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/minimax-m2.5-free`) |
+| `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/nemotron-3-super-free`) |
 | `reporting.outputDirectory`     | `string`   | (target repo) | Directory for result files |
 | `reporting.outputFormat`        | `string`   | `json` | Output format: `json` or `sarif` |
 | `logging.logFile`               | `string`   | (none) | Path to log file. When set, all log output is written to this file |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ Install OpenCode from [https://opencode.ai](https://opencode.ai), then run `open
 
 ```bash
 # Per-scan:
-aghast scan <repo-path> --config-dir <path> --agent-provider opencode --model opencode/minimax-m2.5-free
+aghast scan <repo-path> --config-dir <path> --agent-provider opencode --model opencode/nemotron-3-super-free
 ```
 
 **Pin defaults (applies to both options).** Use `aghast build-config` to write a `runtime-config.json` in your config directory so future scans use your chosen provider and model without any flags:
@@ -62,7 +62,7 @@ aghast build-config --config-dir <path>            # interactive (covers both op
 aghast build-config --config-dir <path> --provider claude-code --model sonnet --non-interactive
 
 # Option B — pin opencode with a specific model:
-aghast build-config --config-dir <path> --provider opencode --model opencode/minimax-m2.5-free --non-interactive
+aghast build-config --config-dir <path> --provider opencode --model opencode/nemotron-3-super-free --non-interactive
 ```
 
 See [Configuration Reference → Runtime Configuration](configuration.md#runtime-configuration) for the full schema.

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -60,7 +60,7 @@ aghast supports multiple agent providers via the `--agent-provider` flag or `age
 | Provider | `--agent-provider` | `--model` format | Prerequisites |
 |----------|--------------------|------------------|---------------|
 | Claude Code (default) | `claude-code` | Model name (e.g. `haiku`, `sonnet`) | `ANTHROPIC_API_KEY` env var |
-| OpenCode | `opencode` | `providerID/modelID` (e.g. `opencode/minimax-m2.5-free`, `cursor-acp/composer-2-fast`) | [OpenCode CLI](https://opencode.ai) installed and configured |
+| OpenCode | `opencode` | `providerID/modelID` (e.g. `opencode/nemotron-3-super-free`, `cursor-acp/composer-2-fast`) | [OpenCode CLI](https://opencode.ai) installed and configured |
 
 ### Using OpenCode
 
@@ -72,10 +72,10 @@ The OpenCode provider delegates to any of the 75+ LLM providers supported by [Op
 2. Configure a provider: run `opencode` and use `/connect` to set up credentials
 3. Run a scan:
    ```bash
-   aghast scan ./my-repo --config-dir ./checks --agent-provider opencode --model opencode/minimax-m2.5-free
+   aghast scan ./my-repo --config-dir ./checks --agent-provider opencode --model opencode/nemotron-3-super-free
    ```
 
-The default model is `opencode/minimax-m2.5-free`. Use the `providerID/modelID` format to select any configured provider and model.
+The default model is `opencode/nemotron-3-super-free`. Use the `providerID/modelID` format to select any configured provider and model.
 
 ## Runtime Configuration
 

--- a/docs/trying-it-out.md
+++ b/docs/trying-it-out.md
@@ -43,7 +43,7 @@ Then run your check:
 aghast scan /path/to/target-repo --config-dir ./my-checks --output-format sarif
 ```
 
-> **Using OpenCode?** Add `--agent-provider opencode --model opencode/minimax-m2.5-free` to the command above, or choose another model that you want to use.
+> **Using OpenCode?** Add `--agent-provider opencode --model opencode/nemotron-3-super-free` to the command above, or choose another model that you want to use.
 
 Results are written to `security_checks_results.sarif` in the target repo, a SARIF 2.1.0 file compatible with GitHub Code Scanning and other SARIF viewers.
 
@@ -66,7 +66,7 @@ The repo includes six example checks demonstrating the three check types (`repos
 | 5 | [Various Security Vulnerabilities](#example-5-various-security-vulnerabilities-targeted-check-openant-discovery-general-vulnerability-analysis) | targeted | OpenAnt | general vulnerability discovery | API key, OpenAnt |
 | 6 | [Diff-Scoped Validation Scanning](#example-6-diff-scoped-validation-scanning-targeted-check-semgrep-discovery-with-diff-filtering) | targeted | Semgrep | custom | API key, Semgrep |
 
-> **Using OpenCode?** All examples that require an API key also work with the OpenCode provider. Add `--agent-provider opencode --model opencode/minimax-m2.5-free` to any `aghast scan` command below, or choose the model you want. See [Scanning → Using OpenCode](scanning.md#using-opencode) for setup.
+> **Using OpenCode?** All examples that require an API key also work with the OpenCode provider. Add `--agent-provider opencode --model opencode/nemotron-3-super-free` to any `aghast scan` command below, or choose the model you want. See [Scanning → Using OpenCode](scanning.md#using-opencode) for setup.
 
 ### Example 1: Business Logic Bypass (repository check)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2608,9 +2608,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/tests/opencode-integration.itest.ts
+++ b/tests/opencode-integration.itest.ts
@@ -1,7 +1,8 @@
 /**
  * Real OpenCode integration tests.
  * These tests actually invoke the OpenCode SDK and send prompts to a real LLM.
- * Uses opencode/minimax-m2.5-free (free, no API key needed).
+ * Uses opencode/nemotron-3-super-free (free, no API key needed).
+ * This model might need to be updated every so often...
  * Requires opencode CLI to be installed (npm install -g opencode-ai).
  * Skip explicitly by setting AGHAST_SKIP_OPENCODE_TESTS=true.
  */
@@ -27,11 +28,11 @@ describe('OpenCode integration tests', { skip }, () => {
     }
   });
 
-  it('initializes with opencode/minimax-m2.5-free and validates model', async () => {
+  it('initializes with opencode/nemotron-3-super-free and validates model', async () => {
     const provider = new OpenCodeProvider();
     providers.push(provider);
-    await provider.initialize({ model: 'opencode/minimax-m2.5-free' });
-    assert.equal(provider.getModelName(), 'opencode/minimax-m2.5-free');
+    await provider.initialize({ model: 'opencode/nemotron-3-super-free' });
+    assert.equal(provider.getModelName(), 'opencode/nemotron-3-super-free');
     const valid = await provider.validateConfig();
     assert.equal(valid, true);
   });
@@ -53,7 +54,7 @@ describe('OpenCode integration tests', { skip }, () => {
   it('executeCheck sends a prompt and gets a parsed response', async () => {
     const provider = new OpenCodeProvider();
     providers.push(provider);
-    await provider.initialize({ model: 'opencode/minimax-m2.5-free' });
+    await provider.initialize({ model: 'opencode/nemotron-3-super-free' });
 
     // Simple prompt that should return empty issues
     const result = await provider.executeCheck(
@@ -70,7 +71,7 @@ describe('OpenCode integration tests', { skip }, () => {
   it('executeCheck returns issues when prompted to find them', async () => {
     const provider = new OpenCodeProvider();
     providers.push(provider);
-    await provider.initialize({ model: 'opencode/minimax-m2.5-free' });
+    await provider.initialize({ model: 'opencode/nemotron-3-super-free' });
 
     const result = await provider.executeCheck(
       'Return exactly this JSON and nothing else: {"issues": [{"file": "test.js", "startLine": 1, "endLine": 2, "description": "Test issue"}]}',
@@ -87,7 +88,7 @@ describe('OpenCode integration tests', { skip }, () => {
   it('cleanup stops the server without error', async () => {
     const provider = new OpenCodeProvider();
     // Don't push to providers array — we clean up manually here
-    await provider.initialize({ model: 'opencode/minimax-m2.5-free' });
+    await provider.initialize({ model: 'opencode/nemotron-3-super-free' });
     await provider.cleanup();
     // Second cleanup should be idempotent
     await provider.cleanup();


### PR DESCRIPTION
## Summary

- Update the OpenCode provider default model reference in docs and CI configuration
- Update OpenCode integration test documentation to match the new default model
- Bump `qs` indirect dependency from 6.15.1 to 6.15.2

## Test plan

- [ ] All 872 tests pass locally (verified before PR)
- [ ] OpenCode integration tests updated to reflect new default model