### PR TITLE
Fall back to a logged-in local Claude session when no API key is set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 
 ## Environment Variables
 
-- `ANTHROPIC_API_KEY` — Required for Claude Code agent provider (unless `AGHAST_LOCAL_CLAUDE=true`)
+- `ANTHROPIC_API_KEY` — API key for the Claude Code agent provider. When unset, the provider falls back to a logged-in local Claude session (auto-detected via the agent SDK's `accountInfo()`); the scan errors only if neither an API key nor a logged-in local session is available
 - `AGHAST_CONFIG_DIR` — Default config directory (CLI `--config-dir` takes precedence)
 - `AGHAST_AI_MODEL` — AI model override (CLI `--model` takes precedence)
 - `AGHAST_GENERIC_PROMPT` — Generic prompt template filename (CLI `--generic-prompt` takes precedence)
@@ -107,13 +107,14 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_LOG_LEVEL` — Console log level: `error`, `warn`, `info`, `debug`, `trace` (CLI `--log-level` takes precedence)
 - `AGHAST_LOG_FILE` — Log file path (CLI `--log-file` takes precedence)
 - `AGHAST_LOG_TYPE` — Log file handler type (CLI `--log-type` takes precedence, default: `file`)
-- `AGHAST_LOCAL_CLAUDE` — Set to `true` to use local Claude instead of API
+- `AGHAST_LOCAL_CLAUDE` — Set to `true` to force local Claude mode, skipping both the API key and the login-detection probe (escape hatch / override)
 - `AGHAST_MOCK_AI` — Enables mock agent provider. Set to `true` for default `{"issues":[]}` response, or set to a file path
 - `AGHAST_MOCK_SEMGREP` — Path to SARIF file for mock Semgrep output
 - `AGHAST_OPENANT_DATASET` — Path to a pre-generated OpenAnt dataset JSON file (skips invoking `openant parse`)
 - `AGHAST_DIFF_REF` — Git ref to diff against; enables diff filtering on supporting discoveries (CLI `--diff-ref` takes precedence)
 - `AGHAST_HISTORY_FILE` — Override the scan history file path (default: `~/.aghast/history.json`)
 - `AGHAST_MOCK_TOKENS` — Format `<input>,<output>`; injects token usage into the mock agent provider for cost/budget tests
+- `AGHAST_MOCK_LOCAL_LOGIN` — Test hook for the Claude Code provider's local-login probe: `true` reports a logged-in session, `false` reports not-logged-in, both without spawning the agent SDK (keeps CLI auth tests hermetic)
 - `AGHAST_DEBUG_PRINTPROMPT` — Print full prompts (requires `--debug`)
 - `NO_COLOR` — Set to `1` to disable colored CLI output (standard; respected automatically by `picocolors`)
 

--- a/docs/cost-tracking.md
+++ b/docs/cost-tracking.md
@@ -42,9 +42,10 @@ discounts (cache reads are billed at roughly 10% of the regular input rate,
 cache writes at roughly 125%), and reflects any provider-side adjustments.
 It is as accurate as any cost figure available outside the Anthropic Console.
 
-When `AGHAST_LOCAL_CLAUDE=true`, the SDK reports an API-equivalent figure.
-AGHAST labels it `(covered by subscription — claude-agent-sdk)` and shows the
-word "equivalent" in the banner. See [Subscription mode](#subscription-mode-local-claude) below.
+When the `claude-code` provider runs against a local Claude session instead of
+an API key, the SDK reports an API-equivalent figure. AGHAST labels it
+`(covered by subscription — claude-agent-sdk)` and shows the word "equivalent"
+in the banner. See [Subscription mode](#subscription-mode-local-claude) below.
 
 ### 2. OpenCode `msg.cost` — `(reported by opencode — see docs/cost-tracking.md)`
 
@@ -116,9 +117,11 @@ For the rate-table fallback, cache reads and writes are costed at the
 
 ## Subscription mode (local Claude)
 
-When `AGHAST_LOCAL_CLAUDE=true`, AGHAST uses a locally installed Claude Code
-session rather than the API. **No per-token billing occurs** — consumption
-comes out of your Pro or Max subscription quota instead.
+When the `claude-code` provider authenticates with a local Claude session
+instead of an API key — auto-detected when no `ANTHROPIC_API_KEY` is set but
+you're logged in to a local session — AGHAST uses that session rather than the
+API. **No per-token billing occurs** — consumption comes out of your Pro or Max
+subscription quota instead.
 
 The Claude Agent SDK still returns a `total_cost_usd` value in this mode. That
 number represents the API-equivalent cost of the work — what it *would have*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ This guide walks you through installing aghast and setting up your environment.
 
 - **Node.js 20+**
 - **An agent provider**, required for AI-based checks (`repository` and `targeted` types; not needed for `static` checks). Either:
-  - An **Anthropic API key** for the default `claude-code` provider, or
+  - The default `claude-code` provider, authenticated with **either** an **Anthropic API key** **or** a **logged-in local Claude session** (see step 2), or
   - **[OpenCode](https://opencode.ai)** installed and authenticated for the `opencode` provider, which delegates to any of the 75+ LLM providers OpenCode supports, including some **free options**.
 
   See [Scanning → Agent Providers](scanning.md#agent-providers) for the full comparison.
@@ -43,6 +43,8 @@ export ANTHROPIC_API_KEY=your-api-key
 ```
 
 Claude Code is the default provider, so no flag is needed at scan time. To override the model, pass `--model <name>` per scan (see [Scanning](scanning.md)) or pin a default as shown below.
+
+If you don't set `ANTHROPIC_API_KEY`, the `claude-code` provider falls back to a **logged-in local Claude session** (the OAuth login used by Claude Code — run `claude` and `/login` if you aren't signed in already). aghast errors only when it finds neither an API key nor a logged-in local session.
 
 **Option B — OpenCode**
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -40,7 +40,7 @@ Run `aghast scan --help` for the full list of options.
 
 | Variable | Description |
 |----------|-------------|
-| `ANTHROPIC_API_KEY` | API key for Claude (required for AI-based checks with the `claude-code` provider) |
+| `ANTHROPIC_API_KEY` | API key for Claude. Used by the `claude-code` provider for AI-based checks; if unset, the provider falls back to a logged-in local Claude session |
 | `AGHAST_CONFIG_DIR` | Default config directory (CLI `--config-dir` takes precedence) |
 | `AGHAST_AI_MODEL` | AI model override (CLI `--model` takes precedence) |
 | `AGHAST_GENERIC_PROMPT` | Generic prompt template filename (CLI `--generic-prompt` takes precedence) |
@@ -59,7 +59,7 @@ aghast supports multiple agent providers via the `--agent-provider` flag or `age
 
 | Provider | `--agent-provider` | `--model` format | Prerequisites |
 |----------|--------------------|------------------|---------------|
-| Claude Code (default) | `claude-code` | Model name (e.g. `haiku`, `sonnet`) | `ANTHROPIC_API_KEY` env var |
+| Claude Code (default) | `claude-code` | Model name (e.g. `haiku`, `sonnet`) | `ANTHROPIC_API_KEY` env var, or a logged-in local Claude session |
 | OpenCode | `opencode` | `providerID/modelID` (e.g. `opencode/nemotron-3-super-free`, `cursor-acp/composer-2-fast`) | [OpenCode CLI](https://opencode.ai) installed and configured |
 
 ### Using OpenCode

--- a/package-lock.json
+++ b/package-lock.json
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -71,30 +71,100 @@ export type QueryFn = (params: {
   options: Record<string, unknown>;
 }) => AsyncIterable<Record<string, unknown>>;
 
+const LOGIN_PROBE_TIMEOUT_MS = 8000; // accountInfo() round-trip cap; treat a hang as "not logged in"
+
+/** Probe whether a local Claude Code session is logged in, via the agent SDK's
+ * `accountInfo()` control request — the same streaming-input pattern as
+ * {@link listModelsViaAgentSdk}: spin up a query whose prompt never yields, issue one
+ * control request, then interrupt. Returns `false` on any error or timeout (treated as
+ * "not logged in"). Honours the `AGHAST_MOCK_LOCAL_LOGIN` test hook (`true`/`false`)
+ * so CLI integration tests stay hermetic without spawning the SDK. */
+async function probeLocalLogin(): Promise<boolean> {
+  const mock = process.env.AGHAST_MOCK_LOCAL_LOGIN;
+  if (mock === 'true') return true;
+  if (mock === 'false') return false;
+
+  const { query } = await import('@anthropic-ai/claude-agent-sdk');
+  let release: (() => void) | undefined;
+  const block = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // eslint-disable-next-line require-yield -- intentional: streaming-input prompt that never yields, kept alive by `block` so `accountInfo()` can run.
+  const prompt = (async function* (): AsyncGenerator<never, void, unknown> {
+    await block;
+    await new Promise<never>(() => {});
+  })();
+  const q = query({ prompt, options: {} });
+  try {
+    const info = await Promise.race([
+      q.accountInfo(),
+      new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), LOGIN_PROBE_TIMEOUT_MS)),
+    ]);
+    // We only probe when ANTHROPIC_API_KEY is unset, so any populated account/credential
+    // field indicates an authenticated local (OAuth) session.
+    return !!(info && (info.email || info.subscriptionType || info.tokenSource || info.apiKeySource || info.apiProvider));
+  } catch (err) {
+    logDebug(TAG, `Local login probe (accountInfo) failed, treating as not logged in: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  } finally {
+    release?.();
+    await Promise.race([
+      q.interrupt().catch(() => undefined),
+      new Promise((resolve) => setTimeout(resolve, 5000)),
+    ]);
+  }
+}
+
+/** Memoized local-login probe — one detection per process run. */
+let localLoginProbe: Promise<boolean> | undefined;
+function detectLocalLogin(): Promise<boolean> {
+  if (!localLoginProbe) {
+    localLoginProbe = probeLocalLogin();
+  }
+  return localLoginProbe;
+}
+
 export class ClaudeCodeProvider implements AgentProvider {
   private apiKey: string | undefined;
   private useLocalClaude: boolean = false;
   private model: string = DEFAULT_MODEL;
   private _queryFn: QueryFn | undefined;
-  constructor(options?: { _queryFn?: QueryFn }) {
+  private _detectLocalLogin: () => Promise<boolean>;
+  constructor(options?: { _queryFn?: QueryFn; _detectLocalLogin?: () => Promise<boolean> }) {
     this._queryFn = options?._queryFn;
+    this._detectLocalLogin = options?._detectLocalLogin ?? detectLocalLogin;
   }
 
-  checkPrerequisites(): void {
-    if (!process.env.ANTHROPIC_API_KEY && process.env.AGHAST_LOCAL_CLAUDE !== 'true') {
-      throw new Error('ANTHROPIC_API_KEY environment variable is required');
-    }
+  async checkPrerequisites(): Promise<void> {
+    // Auth resolution order: explicit API key → forced local mode → detected local login.
+    if (process.env.ANTHROPIC_API_KEY) return;
+    if (process.env.AGHAST_LOCAL_CLAUDE === 'true') return;
+    if (await this._detectLocalLogin()) return;
+    throw new Error(
+      'No Claude credentials found. Set ANTHROPIC_API_KEY, or log in to a local Claude session (run `claude` and use /login).',
+    );
   }
 
   async initialize(config: ProviderConfig): Promise<void> {
-    this.useLocalClaude = process.env.AGHAST_LOCAL_CLAUDE === 'true';
     this.apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY;
     // Model selection priority: config.model (from AGHAST_AI_MODEL env or runtime config) > DEFAULT_MODEL
     if (config.model) {
       this.model = config.model;
     }
+    // Local mode when no API key is available: forced via AGHAST_LOCAL_CLAUDE, otherwise
+    // auto-detected by probing the local session's login status (memoized, so this reuses
+    // any probe already run in checkPrerequisites).
+    if (this.apiKey) {
+      this.useLocalClaude = false;
+    } else if (process.env.AGHAST_LOCAL_CLAUDE === 'true') {
+      this.useLocalClaude = true;
+    } else {
+      this.useLocalClaude = await this._detectLocalLogin();
+    }
     if (!this.apiKey && !this.useLocalClaude) {
-      throw new Error('ANTHROPIC_API_KEY is required');
+      throw new Error(
+        'ANTHROPIC_API_KEY is required, or log in to a local Claude session (run `claude` and use /login).',
+      );
     }
     if (this.useLocalClaude) {
       logProgress(TAG, 'Using local Claude Code session for authentication');
@@ -102,6 +172,11 @@ export class ClaudeCodeProvider implements AgentProvider {
       logDebug(TAG, 'Using API key for authentication');
     }
     logDebug(TAG, `Provider initialized with model ${this.model}`);
+  }
+
+  /** True when authentication resolved to a local Claude session (no API key). */
+  isLocalMode(): boolean {
+    return this.useLocalClaude;
   }
 
   getModelName(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,8 @@ General options:
                              Warns at 80%, aborts at 100%
 
 Environment variables:
-  ANTHROPIC_API_KEY           API key for Claude (required for AI-based checks)
+  ANTHROPIC_API_KEY           API key for Claude. If unset, AI-based checks fall
+                              back to a logged-in local Claude session
   AGHAST_CONFIG_DIR           Default config directory (CLI --config-dir takes precedence)
   AGHAST_AI_MODEL             AI model override (CLI --model takes precedence)
   AGHAST_GENERIC_PROMPT       Generic prompt template filename (CLI --generic-prompt takes precedence)
@@ -601,7 +602,7 @@ export async function runScan(args: string[]): Promise<void> {
     // Validate provider-specific prerequisites (API keys, binaries, etc.)
     try {
       const tempProvider = createProviderByName(agentProviderName);
-      tempProvider.checkPrerequisites?.();
+      await tempProvider.checkPrerequisites?.();
     } catch (err) {
       console.error(formatError(ERROR_CODES.E3001, err instanceof Error ? err.message : String(err)));
       process.exit(1);
@@ -707,7 +708,9 @@ export async function runScan(args: string[]): Promise<void> {
       pricing,
       budgetLimits,
       scanHistory: scanHistoryForBudget,
-      isLocalClaude: process.env.AGHAST_LOCAL_CLAUDE === 'true',
+      // Prefer the provider's resolved auth mode (covers auto-detected local login);
+      // fall back to the env var for providers without the concept (e.g. mock).
+      isLocalClaude: provider?.isLocalMode?.() ?? (process.env.AGHAST_LOCAL_CLAUDE === 'true'),
     });
     const results = outcome.results;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,9 +359,16 @@ export interface AgentProvider {
   /**
    * Check that required prerequisites (API keys, binaries, etc.) are available.
    * Called before initialize() to give early feedback. Throws with a descriptive
-   * error message if a prerequisite is missing.
+   * error message if a prerequisite is missing. May be async (e.g. the Claude Code
+   * provider probes local login status when no API key is set).
    */
-  checkPrerequisites?(): void;
+  checkPrerequisites?(): void | Promise<void>;
+  /**
+   * Whether the provider resolved to local (subscription-covered) authentication rather
+   * than an API key. Used to label cost/budget output. Returns undefined-equivalent when
+   * the provider has no concept of local mode (callers fall back to env detection).
+   */
+  isLocalMode?(): boolean;
   getModelName?(): string;
   setModel?(model: string): void;
   cleanup?(): Promise<void>;

--- a/tests/build-config.test.ts
+++ b/tests/build-config.test.ts
@@ -33,15 +33,17 @@ interface CLIResult {
 function runCLI(args: string[], extraEnv: Record<string, string | undefined> = {}): Promise<CLIResult> {
   return new Promise((resolvePromise) => {
     // Empty strings (rather than `delete`) so dotenv in the child won't refill from .env.
-    // ANTHROPIC_API_KEY/AGHAST_LOCAL_CLAUDE are blanked so listModels() rejects fast on the
-    // claude-code provider's "API key required" check, instead of falling through to the
-    // agent SDK path which spawns a Claude CLI subprocess (slow on Windows/WSL).
+    // ANTHROPIC_API_KEY/AGHAST_LOCAL_CLAUDE are blanked, and AGHAST_MOCK_LOCAL_LOGIN='false'
+    // forces the local-login probe to report "not logged in", so listModels() rejects fast
+    // on the claude-code provider's credential check instead of spawning a Claude CLI
+    // subprocess to probe `accountInfo()` (slow on Windows/WSL).
     const baseEnv = {
       ...process.env,
       NO_COLOR: '1',
       AGHAST_CONFIG_DIR: '',
       ANTHROPIC_API_KEY: '',
       AGHAST_LOCAL_CLAUDE: '',
+      AGHAST_MOCK_LOCAL_LOGIN: 'false',
     };
     for (const [k, v] of Object.entries(extraEnv)) {
       if (v === undefined) {

--- a/tests/claude-code-provider.test.ts
+++ b/tests/claude-code-provider.test.ts
@@ -613,3 +613,100 @@ describe('ClaudeCodeProvider: thinking blocks and tool_result handling', () => {
   });
 });
 
+describe('ClaudeCodeProvider: authentication resolution', () => {
+  /** Run `fn` with ANTHROPIC_API_KEY / AGHAST_LOCAL_CLAUDE set to the given values, restoring after. */
+  async function withAuthEnv(
+    env: { ANTHROPIC_API_KEY?: string; AGHAST_LOCAL_CLAUDE?: string },
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const saved = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      AGHAST_LOCAL_CLAUDE: process.env.AGHAST_LOCAL_CLAUDE,
+    };
+    const apply = (k: 'ANTHROPIC_API_KEY' | 'AGHAST_LOCAL_CLAUDE', v: string | undefined): void => {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    };
+    apply('ANTHROPIC_API_KEY', env.ANTHROPIC_API_KEY);
+    apply('AGHAST_LOCAL_CLAUDE', env.AGHAST_LOCAL_CLAUDE);
+    try {
+      await fn();
+    } finally {
+      apply('ANTHROPIC_API_KEY', saved.ANTHROPIC_API_KEY);
+      apply('AGHAST_LOCAL_CLAUDE', saved.AGHAST_LOCAL_CLAUDE);
+    }
+  }
+
+  it('checkPrerequisites passes when ANTHROPIC_API_KEY is set, without probing local login', async () => {
+    await withAuthEnv({ ANTHROPIC_API_KEY: 'test-key', AGHAST_LOCAL_CLAUDE: undefined }, async () => {
+      let probed = false;
+      const provider = new ClaudeCodeProvider({
+        _detectLocalLogin: async () => {
+          probed = true;
+          return false;
+        },
+      });
+      await provider.checkPrerequisites();
+      assert.equal(probed, false, 'should not probe local login when an API key is present');
+    });
+  });
+
+  it('checkPrerequisites passes when AGHAST_LOCAL_CLAUDE=true, without probing local login', async () => {
+    await withAuthEnv({ ANTHROPIC_API_KEY: undefined, AGHAST_LOCAL_CLAUDE: 'true' }, async () => {
+      let probed = false;
+      const provider = new ClaudeCodeProvider({
+        _detectLocalLogin: async () => {
+          probed = true;
+          return false;
+        },
+      });
+      await provider.checkPrerequisites();
+      assert.equal(probed, false, 'forced local mode should not probe');
+    });
+  });
+
+  it('checkPrerequisites passes when local login is detected (no key, not forced)', async () => {
+    await withAuthEnv({ ANTHROPIC_API_KEY: undefined, AGHAST_LOCAL_CLAUDE: undefined }, async () => {
+      const provider = new ClaudeCodeProvider({ _detectLocalLogin: async () => true });
+      await provider.checkPrerequisites();
+    });
+  });
+
+  it('checkPrerequisites throws when no key, not forced, and not logged in', async () => {
+    await withAuthEnv({ ANTHROPIC_API_KEY: undefined, AGHAST_LOCAL_CLAUDE: undefined }, async () => {
+      const provider = new ClaudeCodeProvider({ _detectLocalLogin: async () => false });
+      await assert.rejects(
+        () => provider.checkPrerequisites(),
+        /No Claude credentials|ANTHROPIC_API_KEY/,
+      );
+    });
+  });
+
+  it('initialize enters local mode (coveredBySubscription) when local login is detected', async () => {
+    await withAuthEnv({ ANTHROPIC_API_KEY: undefined, AGHAST_LOCAL_CLAUDE: undefined }, async () => {
+      const messages = [
+        assistantMsg('Analyzing...'),
+        {
+          type: 'result',
+          subtype: 'success',
+          result: '{"issues":[]}',
+          structured_output: { issues: [] },
+          total_cost_usd: 0.0500,
+          modelUsage: {
+            'claude-sonnet-4-20250514': { inputTokens: 1000, outputTokens: 200 },
+          },
+        },
+      ];
+      const provider = new ClaudeCodeProvider({
+        _queryFn: createFakeQueryFn(messages),
+        _detectLocalLogin: async () => true,
+      });
+      await provider.initialize({});
+
+      const result = await provider.executeCheck('test prompt', '/tmp/repo');
+      assert.ok(result.tokenUsage?.reportedCost, 'Should have reportedCost');
+      assert.equal(result.tokenUsage!.reportedCost!.coveredBySubscription, true);
+    });
+  });
+});
+

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -84,11 +84,14 @@ describe('CLI: --output flag', () => {
 describe('CLI: ANTHROPIC_API_KEY and --agent-provider flag', () => {
   afterEach(cleanupOutput);
 
-  it('missing ANTHROPIC_API_KEY exits 1 with error message', async () => {
+  it('missing ANTHROPIC_API_KEY and not logged in exits 1 with error message', async () => {
+    // AGHAST_MOCK_LOCAL_LOGIN=false forces the local-login probe to report "not logged in"
+    // so the test is hermetic regardless of the host's actual Claude login state.
     const { exitCode, stderr } = await runCLI({
       ANTHROPIC_API_KEY: '',
       AGHAST_LOCAL_CLAUDE: '',
       AGHAST_MOCK_AI: '',
+      AGHAST_MOCK_LOCAL_LOGIN: 'false',
     }, [fixtureRepo, '--config-dir', singleCheckConfigDir]);
     assert.equal(exitCode, 1);
     assert.ok(stderr.includes('ANTHROPIC_API_KEY'));
@@ -96,7 +99,7 @@ describe('CLI: ANTHROPIC_API_KEY and --agent-provider flag', () => {
 
   it('AGHAST_LOCAL_CLAUDE=true skips ANTHROPIC_API_KEY requirement', async () => {
     // This would fail at the API call stage (no real local Claude in tests),
-    // but it should NOT fail with the "ANTHROPIC_API_KEY is required" error.
+    // but it should NOT fail with the credentials error.
     // Use a short timeout — we only need to confirm the API key check was skipped,
     // not wait for the full local Claude connection attempt to time out.
     const { stderr } = await runCLI({
@@ -104,7 +107,20 @@ describe('CLI: ANTHROPIC_API_KEY and --agent-provider flag', () => {
       AGHAST_LOCAL_CLAUDE: 'true',
       AGHAST_MOCK_AI: undefined,
     }, [fixtureRepo, '--config-dir', singleCheckConfigDir], { timeout: 5_000 });
-    assert.ok(!stderr.includes('ANTHROPIC_API_KEY environment variable is required'));
+    assert.ok(!stderr.includes('No Claude credentials found'));
+  });
+
+  it('detected local login skips ANTHROPIC_API_KEY requirement', async () => {
+    // No API key and AGHAST_LOCAL_CLAUDE unset: the provider auto-detects a logged-in
+    // local session (mocked here). The auth gate should pass — the run fails later at the
+    // real API call stage, but NOT with the credentials error.
+    const { stderr } = await runCLI({
+      ANTHROPIC_API_KEY: undefined,
+      AGHAST_LOCAL_CLAUDE: undefined,
+      AGHAST_MOCK_AI: undefined,
+      AGHAST_MOCK_LOCAL_LOGIN: 'true',
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir], { timeout: 5_000 });
+    assert.ok(!stderr.includes('No Claude credentials found'));
   });
 
   it('unknown --agent-provider exits 1 with error message', async () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -152,7 +152,8 @@ describe('AgentProvider interface compliance — ClaudeCodeProvider', () => {
     const originalLocalClaude = process.env.AGHAST_LOCAL_CLAUDE;
     delete process.env.AGHAST_LOCAL_CLAUDE;
     try {
-      const provider = new ClaudeCodeProvider();
+      // Inject a "not logged in" detector so the test never spawns the real agent SDK.
+      const provider = new ClaudeCodeProvider({ _detectLocalLogin: async () => false });
       await assert.rejects(
         async () => provider.initialize({}),
         /ANTHROPIC_API_KEY/,


### PR DESCRIPTION
## What changed

The default `claude-code` provider can now authenticate with **either** an Anthropic API key **or** a logged-in local Claude session.

- When `ANTHROPIC_API_KEY` is unset, the provider auto-detects a logged-in local Claude session (via the agent SDK's `accountInfo()`) and uses it instead of erroring.
- A scan now fails for missing auth only when **neither** an API key **nor** a logged-in local session is available.
- `checkPrerequisites()` is now async so the provider can probe local-login status before the scan starts.
- Cost/budget output is labelled as subscription-covered when running against a local session (the SDK still returns an API-equivalent figure).
- `AGHAST_MOCK_LOCAL_LOGIN` test hook added so CLI auth tests stay hermetic (no agent SDK spawn).

## Docs

- Getting Started, Scanning, and Cost Tracking updated to describe the local-session fallback.

## Tests

- New provider and CLI mock-mode coverage for the local-login probe and auth resolution. Full suite passes locally (878 pass, 2 Semgrep tests skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)