### PR TITLE
Gate auto-merge on the integration and regression suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,43 @@ jobs:
             exit 1
           fi
 
+  # Aggregates the integration & regression suites into a single required check.
+  # Marked required in branch protection so auto-merge waits for these (slower,
+  # previously non-blocking) jobs instead of merging the moment lint/test/build
+  # pass — which left them still running and defeated the post-merge CI skip.
+  integration-gate:
+    runs-on: ubuntu-latest
+    needs: [check-ci-skip, semgrep-integration, openant-integration, opencode-integration, regression-test-semgrep]
+    if: always()
+    steps:
+      - name: Check integration & regression results
+        env:
+          CI_SKIP: ${{ needs.check-ci-skip.outputs.skip }}
+          SEMGREP_RESULT: ${{ needs.semgrep-integration.result }}
+          OPENANT_RESULT: ${{ needs.openant-integration.result }}
+          OPENCODE_RESULT: ${{ needs.opencode-integration.result }}
+          REGRESSION_RESULT: ${{ needs.regression-test-semgrep.result }}
+        run: |
+          if [ "$CI_SKIP" = "true" ]; then
+            echo "CI skipped — PR checks already passed"
+            exit 0
+          fi
+          status=0
+          for entry in \
+            "semgrep-integration:$SEMGREP_RESULT" \
+            "openant-integration:$OPENANT_RESULT" \
+            "opencode-integration:$OPENCODE_RESULT" \
+            "regression-test-semgrep:$REGRESSION_RESULT"; do
+            name="${entry%%:*}"
+            result="${entry#*:}"
+            # 'success' and 'skipped' are acceptable; 'failure'/'cancelled' are not
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "::error::$name did not pass: $result"
+              status=1
+            fi
+          done
+          exit $status
+
   test-results:
     permissions:
       contents: read


### PR DESCRIPTION
## Why

Auto-merge only waits for the **required** status checks (`lint`, `test-gate`, `build-and-install-gate`). The integration suites (`semgrep-integration`, `openant-integration`, `opencode-integration`) and `regression-test-semgrep` are not required, so auto-merge can fire the moment lint/test/build go green while those slower jobs are still running.

When that happens, the post-merge `check-ci-skip` step sees those jobs still pending on the PR, counts them as "not passed", and runs a full **redundant** CI pass on `main` (observed after #88 was auto-merged).

## What

Adds an `integration-gate` aggregator job — same pattern as the existing `test-gate` / `build-and-install-gate` — that succeeds only once all four suites have passed (and short-circuits to success when `check-ci-skip` says CI is skipped, so it never blocks markdown-only or post-merge skip runs).

## Follow-up (manual, after merge)

`integration-gate` must be added to `main`'s required status checks in branch protection so auto-merge actually waits for it. Without that step this job runs but is advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)