### PR TITLE
feat: add opengrep discovery support and diff filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             "${files[@]}"
         env:
           AGHAST_SKIP_SEMGREP_TESTS: 'true'
+          AGHAST_SKIP_OPENGREP_TESTS: 'true'
           SHARD: ${{ matrix.shard }}
 
       - name: Upload test results
@@ -326,6 +327,88 @@ jobs:
       - name: Run Semgrep integration tests
         run: npm run test:semgrep
 
+  opengrep-integration:
+    needs: [check-ci-skip]
+    if: always() && (needs.check-ci-skip.result == 'skipped' || needs.check-ci-skip.outputs.skip != 'true')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors the semgrep-integration matrix: public repo tests 3 OSes, internal tests ubuntu only.
+        os: ${{ github.event.repository.name == 'aghast' && fromJSON('["windows-latest","ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install Opengrep (Linux / macOS)
+        # The upstream install.sh calls the unauthenticated GitHub API to list releases
+        # (https://github.com/opengrep/opengrep#quick-install-recommended) and hits shared-IP rate
+        # limits on CI runners. We bypass it with `gh release download` (authenticated via GH_TOKEN).
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64)  ASSET="opengrep_manylinux_x86" ;;
+            Linux-aarch64) ASSET="opengrep_manylinux_aarch64" ;;
+            Darwin-x86_64) ASSET="opengrep_osx_x86" ;;
+            Darwin-arm64)  ASSET="opengrep_osx_arm64" ;;
+            *) echo "Unsupported platform: $(uname -s)-$(uname -m)"; exit 1 ;;
+          esac
+
+          VERSION=$(gh release view --repo opengrep/opengrep --json tagName --jq .tagName)
+          INST="$HOME/.opengrep/cli/$VERSION"
+          mkdir -p "$INST"
+
+          gh release download "$VERSION" --repo opengrep/opengrep --pattern "$ASSET" --output "$INST/opengrep"
+          chmod +x "$INST/opengrep"
+
+          LATEST="$HOME/.opengrep/cli/latest"
+          rm -f "$LATEST"
+          ln -s "$INST" "$LATEST"
+
+          echo "$LATEST" >> "$GITHUB_PATH"
+
+      - name: Install Opengrep (Windows)
+        # Same rationale as above: upstream install.ps1 hits the unauthenticated GitHub API.
+        # Use `gh release download` authenticated via GH_TOKEN, and a directory junction
+        # (no admin required) for the 'latest' pointer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $asset = 'opengrep_windows_x86.exe'
+          $version = gh release view --repo opengrep/opengrep --json tagName --jq .tagName
+          $inst = Join-Path $env:USERPROFILE ".opengrep\cli\$version"
+          New-Item -ItemType Directory -Force -Path $inst | Out-Null
+
+          gh release download $version --repo opengrep/opengrep --pattern $asset --output (Join-Path $inst 'opengrep.exe')
+
+          $latest = Join-Path $env:USERPROFILE ".opengrep\cli\latest"
+          if (Test-Path $latest) { Remove-Item -Recurse -Force $latest }
+          New-Item -ItemType Junction -Path $latest -Target $inst | Out-Null
+
+          Add-Content -Path $env:GITHUB_PATH -Value $latest
+
+      - name: Verify Opengrep is on PATH
+        run: opengrep --version
+
+      - name: Run Opengrep integration tests
+        run: npm run test:opengrep
+
   openant-integration:
     needs: [check-ci-skip]
     if: always() && (needs.check-ci-skip.result == 'skipped' || needs.check-ci-skip.outputs.skip != 'true')
@@ -353,19 +436,19 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Build OpenAnt from fork (Unix)
+      - name: Build OpenAnt (Unix)
         if: runner.os != 'Windows'
         run: |
-          git clone https://github.com/joshbouncesecurity/OpenAnt.git /tmp/openant
+          git clone https://github.com/knostic/OpenAnt.git /tmp/openant
           cd /tmp/openant/apps/openant-cli
           go build -o bin/openant ./main.go
           echo "$PWD/bin" >> $GITHUB_PATH
 
-      - name: Build OpenAnt from fork (Windows)
+      - name: Build OpenAnt (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          git clone https://github.com/joshbouncesecurity/OpenAnt.git $env:RUNNER_TEMP\openant
+          git clone https://github.com/knostic/OpenAnt.git $env:RUNNER_TEMP\openant
           Set-Location $env:RUNNER_TEMP\openant\apps\openant-cli
           go build -o bin\openant.exe .\main.go
           "$PWD\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,18 +21,18 @@ Seven core components orchestrated by the Security Scanner:
 2. **Check Library** — Two-layer config: loads check registry from `checks-config.json` (Layer 1: id, repositories, enabled) and per-check definitions from `checks/<id>/<id>.json` (Layer 2: name, instructions, severity, checkTarget) within a config directory specified via `--config-dir`. Merges layers, filters by repository, loads markdown instructions from each check folder.
 3. **Agent Provider** — Abstraction layer over agent SDKs / harnesses that delegate to LLMs (reference impls: Claude Code, OpenCode)
 4. **Repository Analyzer** — Extracts Git metadata (remote URL, branch, commit) from target repos
-5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, OpenAnt, and SARIF providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
+5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, Opengrep, OpenAnt, and SARIF providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
 6. **Diff Filter** — Optional post-discovery transformation (`src/diff-filter.ts`) that narrows any SARIF-producing discovery's output to findings touching a git diff, using OpenAnt's call graph for flow-adjacency. Activated automatically when a diff source is provided; individual checks can opt out via `checkTarget.diffFilter: false`.
 7. **Report Generator** — Produces `security_checks_results.json` (or `.sarif`) conforming to the `ScanResults` schema
 
-**Scan workflow**: User initiates → repo metadata extracted → checks filtered for repo → for each check: load instructions (if applicable), run discovery (Semgrep, OpenAnt, or SARIF for targeted/static checks), optionally apply diff filter, AI analyzes (or map findings directly for static checks), results parsed → aggregate → JSON report → exit code.
+**Scan workflow**: User initiates → repo metadata extracted → checks filtered for repo → for each check: load instructions (if applicable), run discovery (Semgrep, Opengrep, OpenAnt, or SARIF for targeted/static checks), optionally apply diff filter, AI analyzes (or map findings directly for static checks), results parsed → aggregate → JSON report → exit code.
 
 **Check types**: Three check types with pluggable discovery:
 - `repository` — AI analyzes the whole repo (no discovery needed)
-- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings)
-- `static` — A discovery method finds issues mapped directly to results, no AI involvement. Discovery methods: `semgrep`
+- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `opengrep` (Opengrep rules — Semgrep fork, identical rule syntax), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings)
+- `static` — A discovery method finds issues mapped directly to results, no AI involvement. Discovery methods: `semgrep`, `opengrep`
 
-Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `openant`, `sarif`) to select the discovery strategy. Targeted checks can also set `checkTarget.analysisMode` to control what the AI does with each target: `custom` (default, uses `instructionsFile`), `false-positive-validation`, or `general-vuln-discovery` (built-in prompt templates, no `instructionsFile` needed).
+Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `opengrep`, `openant`, `sarif`) to select the discovery strategy. Targeted checks can also set `checkTarget.analysisMode` to control what the AI does with each target: `custom` (default, uses `instructionsFile`), `false-positive-validation`, or `general-vuln-discovery` (built-in prompt templates, no `instructionsFile` needed).
 
 **Diff filtering**: Activates automatically on all discoveries (`semgrep`, `sarif`, `openant`) whenever a diff source is provided at scan time (`--diff-ref`, `--diff-file`, `AGHAST_DIFF_REF`, runtime config `diffRef`, or a check-level `diffRef`). OpenAnt is used for the call graph (depth-1 mode); if it's unavailable and no `AGHAST_OPENANT_DATASET` is provided, the filter falls back to depth-0 mode (file+line overlap only, no call-graph flow) with a clear warning log. Required strictly for `openant` discovery itself. Individual checks can opt out with `checkTarget.diffFilter: false`. When both discovery and filter need OpenAnt (e.g. an openant check with a diff source), the scan runner runs it once and shares the dataset.
 
@@ -51,9 +51,10 @@ Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `
 - Test fixtures live alongside tests: sample configs, markdown checks, AI responses, SARIF output
 - GitHub Actions CI runs on push to main and all PRs
 - The CLI supports `AGHAST_MOCK_AI=true` to use a mock agent provider (no API key needed), or `AGHAST_MOCK_AI=<path>` to supply a custom response fixture file
-- `AGHAST_MOCK_SEMGREP=<path>` — Provide a SARIF file to use instead of running Semgrep (for testing targeted/static checks without Semgrep installed)
+- `AGHAST_MOCK_SARIF=<path>` — Provide a SARIF file to use instead of running the configured SARIF-producing scanner (Semgrep or Opengrep). Bypasses the install prerequisite check for whichever tool the check targets. Test/development use only
 - `AGHAST_OPENANT_DATASET=<path>` — Provide a pre-generated OpenAnt dataset JSON file to use instead of invoking `openant parse`. Used for tests (so suites pass without OpenAnt installed) and supports production use cases like caching the dataset across runs or splitting OpenAnt into a separate CI job
 - `AGHAST_SKIP_SEMGREP_TESTS=true` — Skip real Semgrep integration tests (used in CI main job; Semgrep tests run in a separate CI job)
+- `AGHAST_SKIP_OPENGREP_TESTS=true` — Skip real Opengrep integration tests (Opengrep tests run in a separate CI job)
 - **When adding new functionality, always add CLI-level integration tests** in `tests/cli-mock-mode.test.ts` that spawn the real CLI process with `AGHAST_MOCK_AI=true`. These tests exercise the full pipeline (prompt building, response parsing, snippet extraction, issue enrichment, report generation) end-to-end. Include tests for PASS, FAIL, and ERROR scenarios as appropriate.
 
 ## CLI
@@ -78,7 +79,7 @@ The unified entry point is `src/cli.ts` which routes to `runScan()` (from `src/i
 - `npm run build` — Compile TypeScript
 - `npm run lint` — Run ESLint on src/ and tests/
 - `npm run lint:fix` — Run ESLint with auto-fix on src/ and tests/
-- `npm run scan -- <repo-path> --config-dir <path> [--output <path>] [--output-format json|sarif] [--fail-on-check-failure] [--debug] [--log-level <level>] [--log-file <path>] [--log-type <type>] [--model <model>] [--agent-provider <name>] [--generic-prompt <file>] [--runtime-config <path>] [--diff-ref <ref>] [--diff-file <path>]` — Run checks (`--config-dir` required, default format: `json`, default output: `<repo-path>/security_checks_results.<ext>`, exit 1 on FAIL/ERROR with `--fail-on-check-failure`, `--debug` is shorthand for `--log-level debug`, `--log-file` writes all logs to a file at trace level). Discovery methods (Semgrep, OpenAnt, SARIF) are configured per-check via `checkTarget.discovery` in check definitions. Providing `--diff-ref`/`--diff-file`/`AGHAST_DIFF_REF` enables diff filtering on supporting discoveries automatically. Precedence: CLI flags > env vars > runtime config > defaults.
+- `npm run scan -- <repo-path> --config-dir <path> [--output <path>] [--output-format json|sarif] [--fail-on-check-failure] [--debug] [--log-level <level>] [--log-file <path>] [--log-type <type>] [--model <model>] [--agent-provider <name>] [--generic-prompt <file>] [--runtime-config <path>] [--diff-ref <ref>] [--diff-file <path>]` — Run checks (`--config-dir` required, default format: `json`, default output: `<repo-path>/security_checks_results.<ext>`, exit 1 on FAIL/ERROR with `--fail-on-check-failure`, `--debug` is shorthand for `--log-level debug`, `--log-file` writes all logs to a file at trace level). Discovery methods (Semgrep, Opengrep, OpenAnt, SARIF) are configured per-check via `checkTarget.discovery` in check definitions. Providing `--diff-ref`/`--diff-file`/`AGHAST_DIFF_REF` enables diff filtering on supporting discoveries automatically. Precedence: CLI flags > env vars > runtime config > defaults.
 - `npm run new-check -- --config-dir <path> [--id <id> --name <name> ...]` — Interactive CLI to scaffold a new check (creates check folder with `<id>.json`, `<id>.md`, optional `<id>.yaml` Semgrep rule + tests; appends to `checks-config.json`). Bootstraps config directory if it doesn't exist.
 - `npm run build-config -- --config-dir <path> [--non-interactive] [--provider <name>] [--model <id>] [--output-format json|sarif] [--log-level <level>] [--diff-ref <ref>] [--clear <field>] ...` — Build or edit `runtime-config.json`. Interactive when no value flags are given; non-interactive when `--non-interactive` is passed (or when all needed values come from flags). Loads existing config so omitted fields stay untouched. Models come from `provider.listModels()`: the Claude Code provider tries `@anthropic-ai/sdk` `models.list()` first when `ANTHROPIC_API_KEY` is set (full canonical list with display names), then falls back to `claude-agent-sdk` `supportedModels()` (curated 3 aliases — works with `AGHAST_LOCAL_CLAUDE=true`).
 
@@ -109,7 +110,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_LOG_TYPE` — Log file handler type (CLI `--log-type` takes precedence, default: `file`)
 - `AGHAST_LOCAL_CLAUDE` — Set to `true` to force local Claude mode, skipping both the API key and the login-detection probe (escape hatch / override)
 - `AGHAST_MOCK_AI` — Enables mock agent provider. Set to `true` for default `{"issues":[]}` response, or set to a file path
-- `AGHAST_MOCK_SEMGREP` — Path to SARIF file for mock Semgrep output
+- `AGHAST_MOCK_SARIF` — Path to SARIF file for mock Semgrep/Opengrep output (test/dev only)
 - `AGHAST_OPENANT_DATASET` — Path to a pre-generated OpenAnt dataset JSON file (skips invoking `openant parse`)
 - `AGHAST_DIFF_REF` — Git ref to diff against; enables diff filtering on supporting discoveries (CLI `--diff-ref` takes precedence)
 - `AGHAST_HISTORY_FILE` — Override the scan history file path (default: `~/.aghast/history.json`)
@@ -131,8 +132,10 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 - `src/scan-runner.ts` — Security Scanner orchestrator (`runMultiScan` for config-based multi-check; `executeTargetedCheck` for discovery-based checks with concurrent target analysis via `mapWithConcurrency`)
 - `src/discovery.ts` — Pluggable discovery abstraction: `DiscoveryProvider` interface, `DiscoveryRegistry`, and discovery orchestration
 - `src/discoveries/semgrep-discovery.ts` — Semgrep discovery provider (runs Semgrep rules, parses SARIF output into targets)
+- `src/discoveries/opengrep-discovery.ts` — Opengrep discovery provider (runs Opengrep rules — identical SARIF output to Semgrep)
 - `src/discoveries/openant-discovery.ts` — OpenAnt discovery provider (runs OpenAnt to extract code units with call graph context)
 - `src/discoveries/sarif-discovery.ts` — SARIF discovery provider (reads external SARIF files for AI validation)
+- `src/discoveries/sarif-target-enrichment.ts` — Shared prompt enrichment helper used by semgrep and opengrep discovery providers
 - `src/diff-filter.ts` — Diff filter (`applyDiffFilter`); called post-discovery whenever a diff source is available and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets to diff scope using OpenAnt call graph (depth-1), or falls back to file+line overlap (depth-0) when OpenAnt is unavailable
 - `src/diff-parser.ts` — Unified diff parsing (`parseDiff`, `getDiff`, `loadDiffFromFile`)
 - `src/diff-unit-matcher.ts` — Unit-to-diff matching with call graph traversal (`findTouchedUnits`, `filterFindingsByScope`)
@@ -142,7 +145,8 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 - `src/prompt-template.ts` — Prompt builder (prepends generic instructions to check markdown)
 - `src/snippet-extractor.ts` — Code snippet extractor (extracts lines from source files for issue enrichment)
 - `src/sarif-parser.ts` — SARIF 2.1.0 parser (`parseSARIF`, `deduplicateTargets`, `limitTargets`)
-- `src/semgrep-runner.ts` — Semgrep execution with mock support (`runSemgrep`, `buildSemgrepArgs`)
+- `src/semgrep-runner.ts` — Semgrep execution with mock support (`runSemgrep`, `buildSemgrepArgs`); also exports the shared `runSarifScanner`/`verifySarifScannerInstalled` helpers used by the opengrep runner
+- `src/opengrep-runner.ts` — Opengrep execution with mock support (`runOpengrep`, `verifyOpengrepInstalled`); delegates to the shared helpers in `semgrep-runner.ts`
 - `src/openant-runner.ts` — OpenAnt execution with mock support (runs OpenAnt CLI, parses output)
 - `src/openant-loader.ts` — OpenAnt dataset loading, unit filtering, and prompt formatting. Uses base datasets (`dataset.json`) not enhanced — the AI forms its own security judgment
 - `src/check-types.ts` — Check type descriptor system; each check type (`repository`, `targeted`, `static`) declares its characteristics (needsAI, needsDiscovery, needsInstructions, etc.) in one place
@@ -178,10 +182,11 @@ Precedence: CLI flags > environment variables > runtime config > built-in defaul
 - `docs/development.md` — Development setup, building, testing, releasing
 - `tests/` — All test files with fixtures in `tests/fixtures/`
 - `tests/openant-integration.itest.ts` — Real OpenAnt integration tests (requires OpenAnt + Python 3.11+)
+- `tests/opengrep-integration.itest.ts` — Real Opengrep integration tests (requires Opengrep installed)
 
 ## Conventions
 
-- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep, E6xxx=OpenAnt, E70xx=budget, E9xxx=internal/fatal.
+- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep/Opengrep, E6xxx=OpenAnt, E70xx=budget, E9xxx=internal/fatal.
 - **Color output**: Use helpers from `src/colors.ts` for colored output, never raw ANSI codes. The `NO_COLOR` env var is respected automatically via `picocolors`.
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Define your checks, which repositories they relate to, and get accurate and stru
 To cut to the chase, AGHAST uses three core mechanisms:
 
 - **Repository-wide AI analysis** — let the LLM analyze the whole repo against your security check instructions
-- **Targeted checks** — a pluggable discovery method (Semgrep rules, [OpenAnt](https://github.com/knostic/OpenAnt/) code units, or external SARIF findings) identifies specific code locations, then AI analyzes each independently. This is the sweet spot for most use cases
-- **Static checks** — a discovery method (e.g., Semgrep) finds issues mapped directly to results with no AI involvement, for when a traditional static rule is all you need
+- **Targeted checks** — a pluggable discovery method (Semgrep or Opengrep rules, [OpenAnt](https://github.com/knostic/OpenAnt/) code units, or external SARIF findings) identifies specific code locations, then AI analyzes each independently. This is the sweet spot for most use cases
+- **Static checks** — a discovery method (Semgrep or Opengrep) finds issues mapped directly to results with no AI involvement, for when a traditional static rule is all you need
 
 The beauty of the approach is what you *don't* need:
 
@@ -58,6 +58,7 @@ There are almost certainly other ways of achieving this, but to our mind, this a
 
   See [Scanning → Agent Providers](docs/scanning.md#agent-providers) for the full comparison.
 - For checks that use `semgrep` discovery: **[Semgrep Community Edition](https://semgrep.dev/docs/getting-started/)** (LGPL-2.1)
+- For checks that use `opengrep` discovery: **[Opengrep](https://github.com/opengrep/opengrep)** (LGPL-2.1 fork of Semgrep)
 - For checks that use `openant` discovery: **[OpenAnt](https://github.com/knostic/OpenAnt/)** (Apache-2.0) + **Python 3.11+** + **Go** (for building CLI)
 
 ## Quick Start

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,8 @@ my-checks/
     aghast-sqli/
       aghast-sqli.json
       aghast-sqli.md
-      aghast-sqli.yaml        # Semgrep rule (for checks with semgrep discovery)
-      tests/                  # Semgrep rule test files
+      aghast-sqli.yaml        # Semgrep/Opengrep rule (for semgrep or opengrep discovery)
+      tests/                  # Semgrep/Opengrep rule test files
         aghast-sqli.py        # .py, .js, or .ts based on --language
   runtime-config.json          # (Optional) Agent provider & reporting overrides
 ```
@@ -113,6 +113,8 @@ Each check folder contains a JSON definition file with the check's metadata.
 }
 ```
 
+Opengrep can be used as a drop-in replacement for Semgrep: change `discovery: "semgrep"` to `discovery: "opengrep"` in any check definition, and the rule file syntax remains identical. Opengrep is a community fork of Semgrep with the same CLI interface and SARIF output format.
+
 **Targeted check with SARIF discovery** (external SARIF findings validated by AI):
 
 ```json
@@ -180,9 +182,9 @@ Diff filtering works identically for `openant` discovery: the filter narrows the
 | `model`            | `string`                      | No       | AI model override for this check (e.g. `claude-sonnet-4-20250514`). Takes precedence over CLI `--model` and runtime config |
 | `checkTarget`      | `object`                      | No       | Target configuration (omit for repository checks) |
 | `checkTarget.type` | `string`                      | Yes**    | `repository`, `targeted`, or `static` (**required if `checkTarget` present) |
-| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `sarif`, or `openant` (***required for `targeted` and `static` types) |
+| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `opengrep`, `sarif`, or `openant` (***required for `targeted` and `static` types) |
 | `checkTarget.analysisMode` | `string`              | No       | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery`. Built-in modes use their own prompt template and don't require `instructionsFile`. See [How It Works](how-it-works.md) |
-| `checkTarget.rules`| `string` or `string[]`        | Yes****  | Semgrep rule file path(s) relative to check folder (****only for `semgrep` discovery) |
+| `checkTarget.rules`| `string` or `string[]`        | Yes****  | Rule file path(s) relative to check folder (****only for `semgrep` or `opengrep` discovery — both tools share the same rule syntax) |
 | `checkTarget.sarifFile` | `string`                 | Yes***** | Path to SARIF file relative to target repository (*****only for `sarif` discovery) |
 | `checkTarget.maxTargets` | `number`               | No       | Limit number of targets/units to analyze |
 | `checkTarget.concurrency` | `number`              | No       | Max parallel AI analyses for targeted checks (default: 5) |
@@ -214,6 +216,7 @@ The `discovery` field on `checkTarget` specifies how targets are found for `targ
 | Discovery | Requires | Description | Supports diff filter |
 |-----------|----------|-------------|----------------------|
 | `semgrep` | Semgrep installed | Runs Semgrep rules to discover specific code locations | Yes |
+| `opengrep` | Opengrep installed | Runs Opengrep (a Semgrep fork with identical rule syntax and SARIF output) — supports `targeted` and `static` check types | Yes |
 | `sarif` | SARIF file in check definition (`sarifFile`) | Reads findings from an external SARIF file | Yes |
 | `openant` | OpenAnt + Python 3.11+ | Runs `openant parse` on the target repo to extract code units with call graph context | Yes |
 

--- a/docs/creating-checks.md
+++ b/docs/creating-checks.md
@@ -23,12 +23,12 @@ Scaffolds a new security check interactively. Any values not provided via flags 
 | `--id <id>` | Check ID (auto-prefixed with `aghast-` if needed) |
 | `--name <name>` | Human-readable check name |
 | `--check-type <type>` | `repository` (default), `targeted`, or `static` |
-| `--discovery <method>` | Discovery method: `semgrep`, `sarif`, or `openant` (required for `targeted` and `static` types) |
+| `--discovery <method>` | Discovery method: `semgrep`, `opengrep`, `sarif`, or `openant` (required for `targeted` and `static` types; `sarif` and `openant` are targeted-only) |
 | `--analysis-mode <mode>` | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery` |
 | `--severity <level>` | `critical`, `high`, `medium`, `low`, or `informational` |
 | `--confidence <level>` | `high`, `medium`, or `low` |
 
-Run `aghast new-check --help` for the full list of flags including `--check-overview`, `--check-items`, `--pass-condition`, `--fail-condition`, `--flag-condition`, `--repositories`, `--semgrep-rules`, `--max-targets`, and `--language`.
+Run `aghast new-check --help` for the full list of flags including `--check-overview`, `--check-items`, `--pass-condition`, `--fail-condition`, `--flag-condition`, `--repositories`, `--semgrep-rules` / `--opengrep-rules` (aliases for the same flag — don't pass both in the same command), `--max-targets`, and `--language`.
 
 ## What gets created
 
@@ -36,8 +36,8 @@ Running `new-check` creates a check folder in `<config-dir>/checks/<check-id>/` 
 
 - `<id>.json` - check definition (name, severity, type, discovery method, target config)
 - `<id>.md` - markdown instructions for AI analysis (not created for `static` checks or targeted checks using a built-in analysis mode)
-- `<id>.yaml` - Semgrep rule file (for checks with `semgrep` discovery only)
-- `tests/` - Semgrep rule test files (for checks with `semgrep` discovery only)
+- `<id>.yaml` - Semgrep/Opengrep rule file (for checks with `semgrep` or `opengrep` discovery — both tools share the same rule syntax)
+- `tests/` - Semgrep/Opengrep rule test files (for checks with `semgrep` or `opengrep` discovery)
 
 The check is also registered in `checks-config.json`.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -90,8 +90,8 @@ flowchart TD
     Start(["For each check..."]) --> TypeCheck{Check Type?}
 
     TypeCheck -->|repository| RepoCheck["Whole-repo AI analysis<br/>No discovery needed"]
-    TypeCheck -->|targeted| TargetCheck["Run discovery<br/><i>semgrep · openant · sarif</i>"]
-    TypeCheck -->|static| StaticCheck["Run discovery<br/><i>semgrep only</i>"]
+    TypeCheck -->|targeted| TargetCheck["Run discovery<br/><i>semgrep · opengrep · openant · sarif</i>"]
+    TypeCheck -->|static| StaticCheck["Run discovery<br/><i>semgrep · opengrep</i>"]
 
     TargetCheck --> DiffFilterStep{Diff source<br/>available?}
     DiffFilterStep -->|yes| DiffFilter["Apply diff filter<br/>(OpenAnt call graph)"]
@@ -99,7 +99,7 @@ flowchart TD
     DiffFilter --> ModeCheck{Analysis Mode?}
 
     ModeCheck -->|custom| Custom["AI analyzes with<br/>custom instructions"]
-    ModeCheck -->|false-positive-validation| FPV["AI validates findings<br/>as true/false positive<br/><i>(semgrep, sarif)</i>"]
+    ModeCheck -->|false-positive-validation| FPV["AI validates findings<br/>as true/false positive<br/><i>(semgrep, opengrep, sarif only)</i>"]
     ModeCheck -->|general-vuln-discovery| GVD["AI performs general<br/>vulnerability discovery"]
 
     RepoCheck --> Parse
@@ -180,6 +180,7 @@ When you can narrow down where to look before involving the AI. This is the swee
 Discovery methods are deterministic: they use static analysis or pre-existing results to identify code locations, without involving the AI. The discovery method determines how AGHAST finds the code locations to examine:
 
 - **Semgrep**: write a Semgrep rule that matches code patterns you care about. For example, a rule that finds all functions calling `send_ai_query()`, so the AI can check whether each one performs the required validations first.
+- **Opengrep**: identical to Semgrep discovery but runs the Opengrep binary (a Semgrep fork). Use this when you prefer Opengrep for licensing or tooling reasons — the rule syntax and SARIF output are the same.
 - **OpenAnt**: runs [OpenAnt](https://github.com/knostic/OpenAnt/) to extract individual code units (functions, classes) with call graph context (who calls this function, what does it call).
 - **SARIF**: reads findings from an external SARIF file (e.g., output from another SAST scanner) and feeds each finding to the AI.
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -48,7 +48,7 @@ Run `aghast scan --help` for the full list of options.
 | `AGHAST_LOG_LEVEL` | Console log level (CLI `--log-level` takes precedence) |
 | `AGHAST_LOG_FILE` | Log file path (CLI `--log-file` takes precedence) |
 | `AGHAST_LOG_TYPE` | Log file handler type (CLI `--log-type` takes precedence) |
-| `AGHAST_MOCK_SEMGREP` | Path to a SARIF file to use instead of running Semgrep (for testing `semgrep` discovery without Semgrep installed) |
+| `AGHAST_MOCK_SARIF` | Path to a SARIF file to use instead of running Semgrep or Opengrep (test/dev use only; also skips the install prerequisite check for whichever tool the check targets) |
 | `AGHAST_OPENANT_DATASET` | Path to a pre-generated OpenAnt dataset JSON file. When set, aghast uses this dataset directly instead of invoking `openant parse`. Useful for caching the dataset across multiple scans, splitting OpenAnt and aghast into separate CI jobs, running aghast where Python 3.11+ isn't available, or stubbing OpenAnt output in tests |
 | `AGHAST_DIFF_REF` | Git ref to diff against; enables diff filtering on supporting discoveries (CLI `--diff-ref` takes precedence) |
 | `NO_COLOR` | Set to `1` to disable colored CLI output ([standard](https://no-color.org/)) |
@@ -105,6 +105,7 @@ Discovery methods for `targeted` and `static` checks:
 | Discovery | Requires | Description | Supports `diffFilter` |
 |-----------|----------|-------------|-----------------------|
 | `semgrep` | Semgrep installed | Runs Semgrep rules to discover specific code locations | Yes |
+| `opengrep` | Opengrep installed | Runs Opengrep (a Semgrep fork with identical rule syntax and SARIF output) | Yes |
 | `sarif` | SARIF file in check definition | Reads findings from an external SARIF file | Yes |
 | `openant` | OpenAnt + Python 3.11+ | Runs `openant parse` on the target repo to extract code units with call graph context | Yes |
 
@@ -115,7 +116,7 @@ Analysis modes for `targeted` checks (`checkTarget.analysisMode`):
 | Mode | Discovery | Description |
 |------|-----------|-------------|
 | `custom` (default) | All | AI analyzes each target using your custom instructions markdown file |
-| `false-positive-validation` | `semgrep`, `sarif` | AI validates each finding as a true or false positive |
+| `false-positive-validation` | `semgrep`, `opengrep`, `sarif` | AI validates each finding as a true or false positive |
 | `general-vuln-discovery` | All | AI scans each target for a broad range of security vulnerabilities |
 
 Built-in modes (`false-positive-validation`, `general-vuln-discovery`) provide their own prompt template and don't require an instructions file. See [How It Works](how-it-works.md#three-check-types) for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint": "^10.0.3",
         "fast-check": "^4.6.0",
         "tsx": "^4.21.0",
-        "typescript": "~6.0.2",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.57.1"
       },
       "engines": {
@@ -33,22 +33,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.196.tgz",
-      "integrity": "sha512-yqsp1/04T2/tJ54jz+7YLsTZOPeQ/myUCrv17/IVZ9dbl+izIMP9ULuLpPCH5pj5msXxR80es+hpVgHoFuNm0A==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
+      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.196"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.196.tgz",
-      "integrity": "sha512-k1MKRDhSiNKpkTwhtU8QKGzfuRfr3YXS6oqsTuldMROX56L5iMXjzC7AYU1/KmPTeMl3SCQBQeDu0i8ciA0hQA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
+      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
       "cpu": [
         "arm64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.196.tgz",
-      "integrity": "sha512-bBwx/7yKZMQ9NSUt4bg8P+zp6pgd/O/DTkzdqsRIivBvARmwo1QY/2qGrLO8RH0T8CG2lTjFNfDfOlJWbAkvAg==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
+      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
       "cpu": [
         "x64"
       ],
@@ -83,9 +83,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.196.tgz",
-      "integrity": "sha512-fR5fy+pSQSpKZK0zTtAl3LZEGQTuwVK7svutH1bZUS5RGT2HdUWc71oltSZgW4upGaslj+gyusHGJHA5eAc+dw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
+      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
       "cpu": [
         "arm64"
       ],
@@ -96,9 +96,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.196.tgz",
-      "integrity": "sha512-BhLxfx4j6mC3Uzmve1IbhFS1uvNlwATeo6uWyYDOMW4n3XKjiSgjD8bTfkamijrxCMvJo5swLju2y14ayDsokA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
+      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.196.tgz",
-      "integrity": "sha512-9spZON7/tn0q9J+jICrdfHi7o7Fmjs9pIohCCxL+Yv7HbBXWVtEYJbYipBGLTl8ICG3mgPeEVMNsvOuh/jDTuA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
+      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
       "cpu": [
         "x64"
       ],
@@ -122,9 +122,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.196.tgz",
-      "integrity": "sha512-EOiNbxCXQLYzV7SQhMWkUC1ScWyTw/Qp+JyV2sEmIbzl/e7KMOxNE9J20k+lpPs6CXdxVzuMwH7yAGuDu5y+IQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
+      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
       "cpu": [
         "x64"
       ],
@@ -135,9 +135,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.196.tgz",
-      "integrity": "sha512-0xXkAWlDof/qFi3k5KJZ5WYbgp1X8hZHjyasOWTZWAmldoYaENI0vkL+PVMarvoAFYRRqcWoS81FSgm0QgH2sA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
+      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +148,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.196.tgz",
-      "integrity": "sha512-FxWLA3aOYgDf2J0o6Ov1/wgg9X6RkrgnX4ifUWO1i3+6mbc4efNLHkDZLxCHEnQgW8yBidX+iro19f9k64vV8A==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
+      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
       "cpu": [
         "x64"
       ],
@@ -187,6 +187,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -766,6 +767,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
       "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -867,9 +869,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.11.tgz",
-      "integrity": "sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw==",
+      "version": "1.17.20",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.20.tgz",
+      "integrity": "sha512-Urb7Tp4mvJmyckNI/N79uEpWzZOyn4lE5LVPDVidXZ8BIlw6kxx2ctTPRYPJDF8HLPWGCZ7pCpHcmWgQCYyiNQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -879,7 +881,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -903,9 +906,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -919,102 +922,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1022,54 +938,12 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1078,68 +952,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.64.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1155,6 +977,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1169,7 +992,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1192,6 +1014,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1208,6 +1031,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1235,6 +1059,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -1272,6 +1097,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1281,6 +1107,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1294,6 +1121,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1310,6 +1138,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1323,6 +1152,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1332,6 +1162,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1341,6 +1172,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1350,6 +1182,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1405,6 +1238,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1426,6 +1260,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1439,13 +1274,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1455,6 +1292,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1464,6 +1302,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1473,6 +1312,7 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1526,7 +1366,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1542,12 +1383,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -1726,6 +1566,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1735,6 +1576,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -1747,6 +1589,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1800,6 +1643,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
       "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -1814,9 +1658,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "dev": true,
       "funding": [
         {
@@ -1860,7 +1704,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -1876,7 +1721,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1914,6 +1760,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1973,6 +1820,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1982,6 +1830,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2006,6 +1855,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2015,6 +1865,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2039,6 +1890,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2065,6 +1917,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2077,6 +1930,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2089,6 +1943,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2111,6 +1966,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -2131,6 +1987,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2166,13 +2023,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2182,6 +2041,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2213,7 +2073,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2226,6 +2087,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2242,6 +2104,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -2254,13 +2117,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2314,6 +2179,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2323,6 +2189,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2332,6 +2199,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2344,6 +2212,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2353,6 +2222,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2398,6 +2268,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2407,6 +2278,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2416,6 +2288,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2428,6 +2301,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2440,6 +2314,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2499,6 +2374,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2527,6 +2403,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -2539,11 +2416,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2556,6 +2432,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -2575,6 +2452,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2615,6 +2493,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -2630,6 +2509,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2639,6 +2519,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -2654,6 +2535,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2663,6 +2545,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -2678,7 +2561,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2698,6 +2582,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -2724,6 +2609,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -2742,7 +2628,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2770,6 +2657,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -2789,6 +2677,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -2805,6 +2694,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2823,6 +2713,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2842,6 +2733,7 @@
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -2852,6 +2744,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2878,6 +2771,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2886,7 +2780,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -2902,9 +2797,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2938,6 +2833,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -2953,7 +2849,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2963,16 +2858,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.1",
-        "@typescript-eslint/parser": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1"
+        "@typescript-eslint/eslint-plugin": "8.64.0",
+        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2984,6 +2879,186 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.64.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/undici-types": {
@@ -2998,6 +3073,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3017,6 +3093,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3050,7 +3127,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -3080,6 +3158,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "node --experimental-test-coverage --import tsx --test tests/*.test.ts",
     "test:ci": "node --import tsx --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml tests/*.test.ts",
     "test:semgrep": "node --import tsx --test tests/semgrep-integration.itest.ts",
+    "test:opengrep": "node --import tsx --test tests/opengrep-integration.itest.ts",
     "test:openant": "node --import tsx --test tests/openant-integration.itest.ts",
     "test:opencode": "node --import tsx --test --test-force-exit tests/opencode-integration.itest.ts",
     "lint": "eslint src/ tests/",
@@ -44,7 +45,7 @@
     "eslint": "^10.0.3",
     "fast-check": "^4.6.0",
     "tsx": "^4.21.0",
-    "typescript": "~6.0.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.57.1"
   },
   "dependencies": {

--- a/src/discoveries/opengrep-discovery.ts
+++ b/src/discoveries/opengrep-discovery.ts
@@ -1,11 +1,12 @@
 /**
- * Semgrep-based target discovery.
+ * Opengrep-based target discovery.
  *
- * Runs Semgrep rules against the repository, parses SARIF output,
- * and returns discovered targets with inline prompt enrichment.
+ * Runs Opengrep rules (drop-in-compatible with Semgrep rules) against the
+ * repository, parses SARIF output, and returns discovered targets with
+ * inline prompt enrichment.
  */
 
-import { runSemgrep } from '../semgrep-runner.js';
+import { runOpengrep } from '../opengrep-runner.js';
 import { parseSARIF, deduplicateTargets } from '../sarif-parser.js';
 import { logDebug } from '../logging.js';
 import { buildSarifTargetPromptEnrichment } from './sarif-target-enrichment.js';
@@ -13,10 +14,10 @@ import { DEFAULT_GENERIC_PROMPT } from '../defaults.js';
 import type { TargetDiscovery, DiscoveredTarget, DiscoveryOptions } from '../discovery.js';
 import type { SecurityCheck } from '../types.js';
 
-const TAG = 'semgrep-discovery';
+const TAG = 'opengrep-discovery';
 
-export const semgrepDiscovery: TargetDiscovery = {
-  name: 'semgrep',
+export const opengrepDiscovery: TargetDiscovery = {
+  name: 'opengrep',
   defaultGenericPrompt: DEFAULT_GENERIC_PROMPT,
   needsInstructions: true,
   supportsDiffFilter: true,
@@ -28,9 +29,9 @@ export const semgrepDiscovery: TargetDiscovery = {
   ): Promise<DiscoveredTarget[]> {
     const checkTarget = check.checkTarget!;
 
-    logDebug(TAG, `Running Semgrep for check: ${check.id}`);
+    logDebug(TAG, `Running Opengrep for check: ${check.id}`);
 
-    const sarifContent = await runSemgrep({
+    const sarifContent = await runOpengrep({
       repositoryPath: repoPath,
       rules: checkTarget.rules,
       config: checkTarget.config,

--- a/src/discoveries/sarif-target-enrichment.ts
+++ b/src/discoveries/sarif-target-enrichment.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared prompt enrichment for SARIF-producing discovery providers
+ * (semgrep, opengrep). Injects target location context so the AI only
+ * analyzes the specific code location discovered by the scanner.
+ */
+
+export function buildSarifTargetPromptEnrichment(
+  file: string,
+  startLine: number,
+  endLine: number,
+): string {
+  return `\n\nTARGET LOCATION:
+
+You are analyzing a specific code location:
+- File: ${file}
+- Lines: ${startLine}-${endLine}
+
+You MUST:
+- Analyze ONLY this specific target location — do not search for or report issues at other locations
+- You may read other files to understand context (e.g., imports, type definitions, data flow), but only report issues for this target
+- If the code at this location is not vulnerable, return {"issues": []} — do not "spend" the target by reporting an issue you noticed somewhere else in the file
+- Do NOT scan the broader repository for other instances of this vulnerability pattern
+
+REPORTING RULES (strict — these prevent cross-target hallucinations):
+- Each reported issue's "file"/"startLine"/"endLine" MUST point at this target's range above, OR at a line inside a function this target directly/transitively calls. They must NOT point at a sibling location (e.g. another function, another route handler, another class) that simply happens to live in the same file. If that sibling is genuinely vulnerable, it has its own target run — leave it alone here.
+
+DESCRIPTION OPENING (mandatory output contract):
+- Your description's first heading MUST identify the entry point this target represents — its function name, route path+verb, class method, or equivalent — exactly as it appears in the source. For example: a route handler → "## Missing X in DELETE /:id"; a function → "## Missing X in processPayment".
+- The rest of the description must then describe THAT specific symbol's vulnerability — not a sibling's. If, while writing, you find yourself describing a different route/function than the one you opened with, stop: you are hallucinating across targets. Discard the issue and return {"issues": []}.
+- If you noticed a real vulnerability while reading the file but it is in a sibling location, do NOT smuggle it into this target's report. That sibling has its own target run.
+`;
+}

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -6,8 +6,9 @@
  *   E2xxx — Configuration (config dir, checks, runtime config)
  *   E3xxx — Agent provider
  *   E4xxx — Repository/target validation
- *   E5xxx — Semgrep
+ *   E5xxx — Semgrep / Opengrep
  *   E6xxx — OpenAnt
+ *   E7xxx — Budget / cost controls
  *   E9xxx — Internal/fatal
  */
 
@@ -46,8 +47,9 @@ export const ERROR_CODES = {
   // E4xxx — Repository/target validation
   E4001: ec('E4001', 'Repository path not found'),
 
-  // E5xxx — Semgrep
+  // E5xxx — Semgrep / Opengrep
   E5001: ec('E5001', 'Semgrep not installed'),
+  E5101: ec('E5101', 'Opengrep not installed'),
 
   // E6xxx — OpenAnt
   E6001: ec('E6001', 'OpenAnt not installed'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import type { LogLevel } from './logging.js';
 import { MOCK_MODEL_NAME, DEFAULT_MODEL, type AgentProvider } from './types.js';
 import { getFormatter } from './formatters/index.js';
 import { verifySemgrepInstalled } from './semgrep-runner.js';
+import { verifyOpengrepInstalled } from './opengrep-runner.js';
 import { verifyOpenAntInstalled } from './openant-runner.js';
 import { MockAgentProvider } from './mock-agent-provider.js';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
@@ -560,6 +561,7 @@ export async function runScan(args: string[]): Promise<void> {
   // ─── Determine which prerequisites are needed ───
   const needsAI = checksWithDetails.some(c => getCheckType(c.check.checkTarget?.type).needsAI);
   const needsSemgrep = checksWithDetails.some(c => c.check.checkTarget?.discovery === 'semgrep');
+  const needsOpengrep = checksWithDetails.some(c => c.check.checkTarget?.discovery === 'opengrep');
   const needsOpenant = checksWithDetails.some(c => c.check.checkTarget?.discovery === 'openant');
 
   // ─── Resolve diff source ───
@@ -620,12 +622,24 @@ export async function runScan(args: string[]): Promise<void> {
     logProgress(TAG, `Using model: ${modelName}`);
   }
 
-  // ─── Conditional Semgrep verification (needed for semgrep discovery) ───
-  if (needsSemgrep && !process.env.AGHAST_MOCK_SEMGREP) {
+  // ─── Conditional Semgrep verification ───
+  // The mock-env check (AGHAST_MOCK_SARIF) is handled inside
+  // verifySarifScannerInstalled; no need to duplicate it here.
+  if (needsSemgrep) {
     try {
       await verifySemgrepInstalled();
     } catch (err) {
       console.error(formatError(ERROR_CODES.E5001, err instanceof Error ? err.message : String(err)));
+      process.exit(1);
+    }
+  }
+
+  // ─── Conditional Opengrep verification ───
+  if (needsOpengrep) {
+    try {
+      await verifyOpengrepInstalled();
+    } catch (err) {
+      console.error(formatError(ERROR_CODES.E5101, err instanceof Error ? err.message : String(err)));
       process.exit(1);
     }
   }

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -80,6 +80,7 @@ const CLI_FLAG_MAP: Record<string, keyof ParsedFlags> = {
   '--check-type': 'checkType',
   '--discovery': 'discovery',
   '--semgrep-rules': 'semgrepRules',
+  '--opengrep-rules': 'semgrepRules',
   '--sarif-file': 'sarifFile',
   '--analysis-mode': 'analysisMode',
   '--max-targets': 'maxTargets',
@@ -88,6 +89,13 @@ const CLI_FLAG_MAP: Record<string, keyof ParsedFlags> = {
 };
 
 function parseFlags(args: string[]): ParsedFlags {
+  if (args.includes('--semgrep-rules') && args.includes('--opengrep-rules')) {
+    console.error(formatError(
+      ERROR_CODES.E1001,
+      '--semgrep-rules and --opengrep-rules are aliases for the same option; pass only one',
+    ));
+    process.exit(1);
+  }
   const flags: ParsedFlags = {};
   for (let i = 0; i < args.length; i++) {
     const key = CLI_FLAG_MAP[args[i]];
@@ -188,7 +196,9 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
   result.checkType = await askChoice('Check type', getValidCheckTypes(), 'targeted', flags.checkType);
 
   if (result.checkType === 'targeted' || result.checkType === 'static') {
-    const discoveryChoices = result.checkType === 'targeted' ? ['semgrep', 'openant', 'sarif'] : ['semgrep'];
+    const discoveryChoices = result.checkType === 'targeted'
+      ? ['semgrep', 'opengrep', 'openant', 'sarif']
+      : ['semgrep', 'opengrep'];
     result.discovery = await askChoice('Discovery method', discoveryChoices, 'semgrep', flags.discovery);
     result.maxTargets = await askOptional('Max targets', flags.maxTargets);
 
@@ -199,10 +209,11 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
       result.analysisMode = await askChoice('Analysis mode', modeChoices, 'custom', flags.analysisMode);
     }
 
-    if (result.discovery === 'semgrep') {
+    if (result.discovery === 'semgrep' || result.discovery === 'opengrep') {
+      const toolLabel = result.discovery === 'opengrep' ? 'Opengrep' : 'Semgrep';
       result.semgrepRules = flags.semgrepRules !== undefined
         ? flags.semgrepRules
-        : await askOptional('Semgrep rule file paths (comma-separated, or press Enter to generate template)', undefined);
+        : await askOptional(`${toolLabel} rule file paths (comma-separated, or press Enter to generate template)`, undefined);
       if (!result.semgrepRules) {
         result.language = await askChoice('Language', LANGUAGE_CHOICES, 'javascript', flags.language);
       } else {
@@ -293,7 +304,9 @@ function validateInputs(
   }
 
   if ((inputs.checkType === 'targeted' || inputs.checkType === 'static') && inputs.checkType) {
-    const validDiscoveries = inputs.checkType === 'targeted' ? ['semgrep', 'openant', 'sarif'] : ['semgrep'];
+    const validDiscoveries = inputs.checkType === 'targeted'
+      ? ['semgrep', 'opengrep', 'openant', 'sarif']
+      : ['semgrep', 'opengrep'];
     if (!inputs.discovery || !validDiscoveries.includes(inputs.discovery)) {
       errors.push(`Invalid discovery "${inputs.discovery}" for check type "${inputs.checkType}". Must be one of: ${validDiscoveries.join(', ')}`);
     }
@@ -311,7 +324,7 @@ function validateInputs(
     }
   }
 
-  if (inputs.discovery === 'semgrep' && inputs.language && !SUPPORTED_LANGUAGES[inputs.language]) {
+  if ((inputs.discovery === 'semgrep' || inputs.discovery === 'opengrep') && inputs.language && !SUPPORTED_LANGUAGES[inputs.language]) {
     errors.push(`Invalid language "${inputs.language}". Must be one of: ${Object.keys(SUPPORTED_LANGUAGES).join(', ')}`);
   }
 
@@ -335,7 +348,7 @@ function generateSemgrepRule(checkId: string, language: string): string {
   return `rules:
   - id: ${checkId}
     pattern: |
-      # TODO: Replace with your Semgrep pattern
+      # TODO: Replace with your pattern (Semgrep/Opengrep syntax)
       ...
     message: >
       TODO: Describe the issue this rule detects.
@@ -431,7 +444,7 @@ function generateCheckDefinition(inputs: {
       type: inputs.checkType,
       discovery: inputs.discovery,
     };
-    if (inputs.discovery === 'semgrep') {
+    if (inputs.discovery === 'semgrep' || inputs.discovery === 'opengrep') {
       if (inputs.semgrepRules) {
         const rules = inputs.semgrepRules.split(',').map((r) => r.trim()).filter(Boolean);
         checkTarget.rules = rules.length === 1 ? rules[0] : rules;
@@ -491,11 +504,12 @@ Options:
   --flag-condition <text>    Condition for a FLAG result (optional)
   --check-type <type>        Check type (default: targeted). See 'Check types' below
   --discovery <name>         Discovery mechanism for targeted/static checks. See below
-  --semgrep-rules <paths>    Comma-separated Semgrep rule file paths (for semgrep discovery)
+  --semgrep-rules <paths>    Comma-separated rule file paths (for semgrep/opengrep discovery)
+  --opengrep-rules <paths>   Alias for --semgrep-rules; do not pass both (error)
   --sarif-file <path>        SARIF file path in check definition, relative to repo (for sarif discovery)
   --analysis-mode <mode>     Analysis mode for targeted checks (default: custom). See below
   --max-targets <n>          Maximum number of targets to analyze
-  --language <lang>          Language for Semgrep template: python, javascript, typescript
+  --language <lang>          Language for Semgrep/Opengrep template: python, javascript, typescript
   -h, --help                 Show this help message
 
 Environment variables:
@@ -508,12 +522,13 @@ Check types:
 
 Discovery mechanisms:
   semgrep     Semgrep rules find targets (targeted or static)
+  opengrep    Opengrep (Semgrep fork) rules find targets (targeted or static)
   openant     OpenAnt code analysis finds units (targeted only)
   sarif       External SARIF file provides findings (targeted only)
 
 Analysis modes (targeted checks only):
   custom                      Use a custom instructions markdown file (default)
-  false-positive-validation   AI validates each finding as true/false positive (semgrep, sarif)
+  false-positive-validation   AI validates each finding as true/false positive (semgrep, opengrep, sarif)
   general-vuln-discovery      AI scans each target for general security vulnerabilities (all)
 
 Examples:
@@ -588,8 +603,9 @@ export async function runNewCheck(args: string[]): Promise<void> {
     console.log(`Created: ${checkFolder}/${inputs.id}.md`);
   }
 
-  // Generate Semgrep rule template and test file if needed
-  if (inputs.discovery === 'semgrep' && !inputs.semgrepRules) {
+  // Generate Semgrep/Opengrep rule template and test file if needed
+  // (the rule file format is identical between the two tools)
+  if ((inputs.discovery === 'semgrep' || inputs.discovery === 'opengrep') && !inputs.semgrepRules) {
     const rulePath = resolve(checkFolder, `${inputs.id}.yaml`);
     await writeFile(rulePath, generateSemgrepRule(inputs.id, inputs.language), 'utf-8');
     console.log(`Created: ${checkFolder}/${inputs.id}.yaml (template — edit before running)`);

--- a/src/opengrep-runner.ts
+++ b/src/opengrep-runner.ts
@@ -1,0 +1,37 @@
+/**
+ * Opengrep runner.
+ * Executes Opengrep (https://github.com/opengrep/opengrep) against a repository
+ * and returns raw SARIF output. Opengrep is a community fork of Semgrep with
+ * a drop-in-compatible CLI and SARIF 2.1.0 output, so this module is a thin
+ * wrapper around the shared helpers in `./semgrep-runner.ts`.
+ */
+
+import type { SarifScannerTool, SemgrepOptions } from './semgrep-runner.js';
+import { runSarifScanner, verifySarifScannerInstalled } from './semgrep-runner.js';
+
+export type OpengrepOptions = SemgrepOptions;
+
+export const OPENGREP_TOOL: SarifScannerTool = {
+  binary: 'opengrep',
+  mockEnvVar: 'AGHAST_MOCK_SARIF',
+  tag: 'opengrep',
+  displayName: 'Opengrep',
+  installUrl: 'https://github.com/opengrep/opengrep',
+  tmpPrefix: 'aghast-opengrep-',
+};
+
+/**
+ * Verify that Opengrep is installed and available on PATH.
+ * Skips the check when AGHAST_MOCK_SARIF is set.
+ */
+export async function verifyOpengrepInstalled(): Promise<void> {
+  return verifySarifScannerInstalled(OPENGREP_TOOL);
+}
+
+/**
+ * Execute Opengrep and return raw SARIF string.
+ * If AGHAST_MOCK_SARIF env var is set, reads and returns that file instead.
+ */
+export async function runOpengrep(options: OpengrepOptions): Promise<string> {
+  return runSarifScanner(options, OPENGREP_TOOL);
+}

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -17,6 +17,7 @@ import { CHECK_TYPE } from './check-types.js';
 import { getDiscovery, registerDiscovery } from './discovery.js';
 import { DEFAULT_PROVIDER_NAME } from './provider-registry.js';
 import { semgrepDiscovery } from './discoveries/semgrep-discovery.js';
+import { opengrepDiscovery } from './discoveries/opengrep-discovery.js';
 import { openantDiscovery } from './discoveries/openant-discovery.js';
 import { sarifDiscovery } from './discoveries/sarif-discovery.js';
 import { applyDiffFilter } from './diff-filter.js';
@@ -50,6 +51,7 @@ const DEFAULT_TARGET_TIMEOUT_MS = 5 * 60 * 1000;
 
 // --- Register built-in discovery implementations ---
 registerDiscovery(semgrepDiscovery);
+registerDiscovery(opengrepDiscovery);
 registerDiscovery(openantDiscovery);
 registerDiscovery(sarifDiscovery);
 

--- a/src/semgrep-runner.ts
+++ b/src/semgrep-runner.ts
@@ -1,6 +1,12 @@
 /**
  * Semgrep runner.
  * Executes Semgrep against a repository and returns raw SARIF output.
+ *
+ * Shares core logic with the opengrep runner via the `runSarifScanner` and
+ * `verifySarifScannerInstalled` helpers exported from this module — both tools
+ * have the same CLI shape (`--config X --sarif --output FILE .`) and emit
+ * SARIF 2.1.0, so only the binary name, mock env var, and error messaging
+ * differ between them.
  */
 
 import { execFile } from 'node:child_process';
@@ -18,7 +24,46 @@ export interface SemgrepOptions {
 }
 
 /**
- * Build the Semgrep CLI arguments.
+ * Configuration describing a semgrep-compatible SARIF scanner binary
+ * (semgrep, opengrep, ...). Used by the shared runner helpers below.
+ */
+export interface SarifScannerTool {
+  /** Binary name on PATH (e.g. "semgrep", "opengrep"). */
+  binary: string;
+  /**
+   * Environment variable that, if set, short-circuits execution and reads SARIF from the named file.
+   *
+   * By design, both `SEMGREP_TOOL` and `OPENGREP_TOOL` set this to `AGHAST_MOCK_SARIF` —
+   * a single shared stub env var rather than per-tool vars. Consequence: setting
+   * `AGHAST_MOCK_SARIF` feeds the same SARIF fixture to every SARIF-producing tool
+   * in a mixed-discovery scan; there's no way to stub only one of the two. This is
+   * intentional (the SARIF format is identical, so one fixture serves both) and
+   * keeps the test surface minimal. If independent stubs are ever needed, introduce
+   * tool-specific env vars with `AGHAST_MOCK_SARIF` as a fallback.
+   */
+  mockEnvVar: string;
+  /** Log tag. */
+  tag: string;
+  /** User-facing display name used in progress/error messages. */
+  displayName: string;
+  /** URL users should visit to install the binary. */
+  installUrl: string;
+  /** Temp-directory prefix for output files. */
+  tmpPrefix: string;
+}
+
+export const SEMGREP_TOOL: SarifScannerTool = {
+  binary: 'semgrep',
+  mockEnvVar: 'AGHAST_MOCK_SARIF',
+  tag: TAG,
+  displayName: 'Semgrep',
+  installUrl: 'https://semgrep.dev/docs/getting-started/',
+  tmpPrefix: 'aghast-semgrep-',
+};
+
+/**
+ * Build the Semgrep CLI arguments. Opengrep uses the same argument shape,
+ * so `opengrep-runner.ts` reuses this builder directly.
  */
 export function buildSemgrepArgs(
   options: SemgrepOptions,
@@ -41,17 +86,23 @@ export function buildSemgrepArgs(
 }
 
 /**
- * Verify that Semgrep is installed and available on PATH.
+ * Verify that a SARIF scanner binary is installed and available on PATH.
  * Resolves if found, rejects with a user-friendly error if not.
- * Skips the check when AGHAST_MOCK_SEMGREP is set.
+ * Skips the check when the tool's mock env var is set.
  */
-export async function verifySemgrepInstalled(): Promise<void> {
-  if (process.env.AGHAST_MOCK_SEMGREP) return;
+export async function verifySarifScannerInstalled(tool: SarifScannerTool): Promise<void> {
+  if (process.env[tool.mockEnvVar]) return;
   return new Promise((resolve, reject) => {
-    execFile('semgrep', ['--version'], (error) => {
-      if (error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+    execFile(tool.binary, ['--version'], (error) => {
+      if (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          reject(new Error(
+            `${tool.displayName} is required for the configured checks but was not found. Install it from ${tool.installUrl}`,
+          ));
+          return;
+        }
         reject(new Error(
-          'Semgrep is required for the configured checks but was not found. Install it from https://semgrep.dev/docs/getting-started/',
+          `${tool.displayName} --version failed: ${error.message}. If the installation is broken, reinstall from ${tool.installUrl}`,
         ));
         return;
       }
@@ -61,35 +112,46 @@ export async function verifySemgrepInstalled(): Promise<void> {
 }
 
 /**
- * Execute Semgrep and return raw SARIF string.
- * If AGHAST_MOCK_SEMGREP env var is set, reads and returns that file instead.
+ * Verify that Semgrep is installed and available on PATH.
+ * Skips the check when AGHAST_MOCK_SARIF is set.
  */
-export async function runSemgrep(options: SemgrepOptions): Promise<string> {
-  const mockFile = process.env.AGHAST_MOCK_SEMGREP;
+export async function verifySemgrepInstalled(): Promise<void> {
+  return verifySarifScannerInstalled(SEMGREP_TOOL);
+}
+
+/**
+ * Execute a semgrep-compatible scanner and return raw SARIF string.
+ * If the tool's mock env var is set, reads and returns that file instead.
+ */
+export async function runSarifScanner(
+  options: SemgrepOptions,
+  tool: SarifScannerTool,
+): Promise<string> {
+  const mockFile = process.env[tool.mockEnvVar];
   if (mockFile) {
-    logDebug(TAG, `Mock mode: reading SARIF from ${mockFile}`);
+    logDebug(tool.tag, `Mock mode: reading SARIF from ${mockFile}`);
     try {
       return await readFile(mockFile, 'utf-8');
     } catch (err) {
       throw new Error(
-        `Failed to read AGHAST_MOCK_SEMGREP file: ${mockFile}`,
+        `Failed to read ${tool.mockEnvVar} file: ${mockFile}`,
         { cause: err },
       );
     }
   }
 
-  logProgress(TAG, 'Running Semgrep...');
+  logProgress(tool.tag, `Running ${tool.displayName}...`);
 
-  const tmpDir = await mkdtemp(join(tmpdir(), 'aghast-semgrep-'));
+  const tmpDir = await mkdtemp(join(tmpdir(), tool.tmpPrefix));
   const outputFile = join(tmpDir, 'results.sarif');
 
   try {
     const args = buildSemgrepArgs(options, outputFile);
-    logDebug(TAG, `Command: semgrep ${args.join(' ')}`);
+    logDebug(tool.tag, `Command: ${tool.binary} ${args.join(' ')}`);
 
     const { stderr: stderrContent, hadError } = await new Promise<{ stderr: string; hadError: boolean }>((resolve, reject) => {
       execFile(
-        'semgrep',
+        tool.binary,
         args,
         { cwd: options.repositoryPath, timeout: 300_000 },
         (error, _stdout, stderr) => {
@@ -97,14 +159,15 @@ export async function runSemgrep(options: SemgrepOptions): Promise<string> {
             if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
               reject(
                 new Error(
-                  'Semgrep not found. Install it from https://semgrep.dev/docs/getting-started/',
+                  `${tool.displayName} not found. Install it from ${tool.installUrl}`,
                 ),
               );
               return;
             }
-            // Semgrep >= 1.0: exit code 0 means success (with or without findings),
-            // exit code 1 means an error occurred. Resolve with stderr so the caller
-            // can check whether the output file was actually produced.
+            // Semgrep-compatible scanners: exit code 0 means success (with or
+            // without findings), exit code 1 means an error occurred. Resolve
+            // with stderr so the caller can check whether the output file was
+            // actually produced.
             resolve({ stderr, hadError: true });
             return;
           }
@@ -115,21 +178,29 @@ export async function runSemgrep(options: SemgrepOptions): Promise<string> {
 
     if (hadError) {
       throw new Error(
-        `Semgrep execution failed${stderrContent.trim() ? `: ${stderrContent.trim()}` : ''}`,
+        `${tool.displayName} execution failed${stderrContent.trim() ? `: ${stderrContent.trim()}` : ''}`,
       );
     }
 
     const outputFileExists = await access(outputFile).then(() => true, () => false);
     if (!outputFileExists) {
-      throw new Error('Semgrep did not produce output');
+      throw new Error(`${tool.displayName} did not produce output`);
     }
 
     const sarifContent = await readFile(outputFile, 'utf-8');
-    logDebug(TAG, `SARIF output: ${sarifContent.length} chars`);
+    logDebug(tool.tag, `SARIF output: ${sarifContent.length} chars`);
     return sarifContent;
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch((err) => {
-      logDebug(TAG, `Failed to clean up temp directory ${tmpDir}: ${err}`);
+      logDebug(tool.tag, `Failed to clean up temp directory ${tmpDir}: ${err}`);
     });
   }
+}
+
+/**
+ * Execute Semgrep and return raw SARIF string.
+ * If AGHAST_MOCK_SARIF env var is set, reads and returns that file instead.
+ */
+export async function runSemgrep(options: SemgrepOptions): Promise<string> {
+  return runSarifScanner(options, SEMGREP_TOOL);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface OpenAntFilterConfig {
 
 export interface CheckTargetDefinition {
   type: 'targeted' | 'static' | 'repository';
-  discovery?: 'semgrep' | 'openant' | 'sarif';
+  discovery?: 'semgrep' | 'opengrep' | 'openant' | 'sarif';
   rules?: string | string[];
   config?: string;
   sarifFile?: string;

--- a/tests/cli-diff-filter-check-config.test.ts
+++ b/tests/cli-diff-filter-check-config.test.ts
@@ -38,7 +38,7 @@ describe('CLI diff-filter: checkTarget.diffFilter: false opts a check out', () =
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
         // Unset any inherited env var so the test deterministically exercises
         // "runtime diff source present (via --diff-file), filter suppressed by
@@ -122,7 +122,7 @@ describe('CLI diff-filter: check-level diffRef activates the filter', () => {
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
         AGHAST_DIFF_REF: undefined,
       },

--- a/tests/cli-diff-filter-no-openant.test.ts
+++ b/tests/cli-diff-filter-no-openant.test.ts
@@ -32,7 +32,7 @@ describe('CLI diff-filter fallback when OpenAnt is unavailable', () => {
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_TESTING_OPENANT_UNAVAILABLE: 'true',
         // Note: no AGHAST_OPENANT_DATASET, so the install check runs and fails.
       },
@@ -65,7 +65,7 @@ describe('CLI diff-filter fallback when OpenAnt is unavailable', () => {
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_TESTING_OPENANT_UNAVAILABLE: 'true',
       },
       [fixtureRepo, '--config-dir', semgrepDiffFilterConfigDir, '--diff-file', diffFile],
@@ -98,7 +98,7 @@ describe('CLI diff-filter fallback when OpenAnt is unavailable', () => {
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_TESTING_OPENANT_UNAVAILABLE: 'true',
         AGHAST_DIFF_REF: undefined,
       },

--- a/tests/cli-diff-filter-semgrep.test.ts
+++ b/tests/cli-diff-filter-semgrep.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for diff filtering applied to Semgrep discovery.
  *
  * Spawns the actual CLI process with AGHAST_MOCK_AI=true,
- * AGHAST_MOCK_SEMGREP, AGHAST_OPENANT_DATASET, and --diff-file
+ * AGHAST_MOCK_SARIF, AGHAST_OPENANT_DATASET, and --diff-file
  * to verify the full discovery + diff-filter pipeline end-to-end.
  * Acts as the behaviour-preservation gate for the refactor from the
  * former diff-semgrep discovery to the diffFilter cross-cutting flag.
@@ -37,7 +37,7 @@ describe('CLI diff-filter (semgrep): PASS scenarios', () => {
     const { exitCode, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
       },
       [
@@ -57,7 +57,7 @@ describe('CLI diff-filter (semgrep): PASS scenarios', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
       },
       [
@@ -93,7 +93,7 @@ describe('CLI diff-filter (semgrep): filtering', () => {
     const { exitCode, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
       },
       [
@@ -113,7 +113,7 @@ describe('CLI diff-filter (semgrep): filtering', () => {
     const { stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
       },
       [
@@ -151,7 +151,7 @@ describe('CLI diff-filter (semgrep): fallback and error scenarios', () => {
     const { exitCode, stdout, stderr } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
         AGHAST_DIFF_REF: undefined,
       },
@@ -175,7 +175,7 @@ describe('CLI diff-filter (semgrep): fallback and error scenarios', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: 'true',
-        AGHAST_MOCK_SEMGREP: diffSemgrepSarif,
+        AGHAST_MOCK_SARIF: diffSemgrepSarif,
         AGHAST_OPENANT_DATASET: diffSemgrepDataset,
       },
       [

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -224,7 +224,7 @@ describe('CLI mock mode: ERROR and FLAG scenarios', () => {
 
   it('FLAG multi-target: all targets flag → check status FLAG, flaggedChecks=1', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: flagResponseFixture, AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: flagResponseFixture, AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -325,7 +325,7 @@ describe('CLI mock mode: ERROR and FLAG scenarios (continued)', () => {
 
   it('partial results: Semgrep error + repo-wide PASS → 2 checks, errorChecks=1, exit 0', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: '/nonexistent/mock-semgrep.sarif' },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: '/nonexistent/mock-semgrep.sarif' },
       [fixtureRepo, '--config-dir', mixedResultsConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -356,7 +356,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('PASS: empty SARIF → PASS, 0 issues', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -376,7 +376,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('FAIL: 3 SARIF findings → FAIL, issues mapped with correct fields', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -406,7 +406,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('severity and confidence from check config appear on issues', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -422,7 +422,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('ERROR: bad mock SARIF path → ERROR status', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: '/nonexistent/bad.sarif' },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: '/nonexistent/bad.sarif' },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -438,7 +438,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('summary banner shows ISSUES DETECTED when a check fails', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     const combined = stdout + stderr;
@@ -447,7 +447,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('summary banner shows NO ISSUES DETECTED for empty SARIF', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     const combined = stdout + stderr;
@@ -456,7 +456,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('mixed config: semgrep-only + AI check both processed', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', mixedWithSemgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -487,7 +487,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('semgrep-only scan does not log "Using model"', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     const combined = stdout + stderr;
@@ -496,7 +496,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('semgrep-only scan sets agentProvider.name to "none" in results', async () => {
     await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
 
@@ -508,7 +508,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('mixed scan (AI + semgrep-only) still logs "Using model"', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', mixedWithSemgrepOnlyConfigDir],
     );
     const combined = stdout + stderr;
@@ -517,7 +517,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('SARIF output format includes semgrep-only findings', async () => {
     const { exitCode } = await runCLISarif(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir, '--output-format', 'sarif'],
     );
     assert.equal(exitCode, 0);
@@ -535,7 +535,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('--fail-on-check-failure exits 1 on FAIL', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir, '--fail-on-check-failure'],
     );
     assert.equal(exitCode, 1);
@@ -543,7 +543,7 @@ describe('CLI mock mode: semgrep-only checks', () => {
 
   it('codeSnippet is extracted for semgrep-only findings', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -814,7 +814,7 @@ describe('CLI: --generic-prompt with mixed discovery types', () => {
 
   it('errors when --generic-prompt is used with checks having different discovery types', async () => {
     const { exitCode, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', mixedDiscoveryConfigDir, '--generic-prompt', 'custom-prompt.md'],
     );
     assert.notEqual(exitCode, 0, 'Should exit with error');

--- a/tests/cli-mock-mode-opengrep.test.ts
+++ b/tests/cli-mock-mode-opengrep.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration tests for opengrep discovery through the CLI.
+ *
+ * Spawns the actual CLI process with AGHAST_MOCK_SARIF pointing at a SARIF
+ * fixture and AGHAST_MOCK_AI=true so the full pipeline runs end-to-end without
+ * an opengrep binary or an AI provider. Opengrep emits the same SARIF 2.1.0
+ * format as Semgrep, so the semgrep SARIF fixtures are reused.
+ *
+ * Uses scoped output paths (createScopedHelpers) so this file can run in
+ * parallel with cli-mock-mode.test.ts without racing on the shared fixture
+ * repo's security_checks_results.json.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fixtureRepo,
+  opengrepOnlyConfigDir,
+  cli3TargetsSarif,
+  emptyResultsSarif,
+  createScopedHelpers,
+} from './cli-test-helpers.js';
+
+const { runCLI, cleanupOutput, readResults, outputFile } = createScopedHelpers('opengrep');
+
+// ─── Static check: PASS when no findings ─────────────────────────────────────
+
+describe('CLI mock mode (opengrep): static-check PASS', () => {
+  afterEach(cleanupOutput);
+
+  it('empty SARIF results produce PASS', async () => {
+    const { exitCode, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
+      [fixtureRepo, '--config-dir', opengrepOnlyConfigDir, '--output', outputFile],
+    );
+    assert.equal(exitCode, 0, `Expected exit 0 but got ${exitCode}. stderr: ${stderr}`);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks.length, 1);
+    assert.equal(checks[0].checkId, 'aghast-opengrep-only');
+    assert.equal(checks[0].status, 'PASS');
+    assert.equal(checks[0].issuesFound, 0);
+  });
+});
+
+// ─── Static check: FAIL when findings present ────────────────────────────────
+
+describe('CLI mock mode (opengrep): static-check FAIL', () => {
+  afterEach(cleanupOutput);
+
+  it('SARIF with 3 findings produces FAIL with 3 issues', async () => {
+    const { exitCode, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
+      [fixtureRepo, '--config-dir', opengrepOnlyConfigDir, '--output', outputFile],
+    );
+    assert.equal(exitCode, 0, `Expected exit 0 but got ${exitCode}. stderr: ${stderr}`);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].checkId, 'aghast-opengrep-only');
+    assert.equal(checks[0].status, 'FAIL');
+    assert.equal(checks[0].issuesFound, 3);
+  });
+
+  it('--fail-on-check-failure flips exit code when findings present', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
+      [fixtureRepo, '--config-dir', opengrepOnlyConfigDir, '--fail-on-check-failure', '--output', outputFile],
+    );
+    assert.equal(exitCode, 1);
+  });
+});
+
+// ─── ERROR: AGHAST_MOCK_SARIF points to non-existent SARIF ───────────────
+
+describe('CLI mock mode (opengrep): ERROR scenarios', () => {
+  afterEach(cleanupOutput);
+
+  it('missing mock SARIF file produces ERROR status with AGHAST_MOCK_SARIF in error', async () => {
+    await runCLI(
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: '/does/not/exist/results.sarif' },
+      [fixtureRepo, '--config-dir', opengrepOnlyConfigDir, '--output', outputFile],
+    );
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].checkId, 'aghast-opengrep-only');
+    assert.equal(checks[0].status, 'ERROR');
+    assert.ok(
+      (checks[0].error as string | undefined)?.includes('AGHAST_MOCK_SARIF'),
+      `Expected check error to reference AGHAST_MOCK_SARIF, got: ${String(checks[0].error)}`,
+    );
+  });
+});
+
+// ─── Prerequisite validation: static checks don't require ANTHROPIC_API_KEY ──
+
+describe('CLI mock mode (opengrep): conditional prerequisite validation', () => {
+  afterEach(cleanupOutput);
+
+  it('static opengrep checks succeed without ANTHROPIC_API_KEY', async () => {
+    const { exitCode, stderr } = await runCLI(
+      {
+        ANTHROPIC_API_KEY: '',
+        AGHAST_LOCAL_CLAUDE: '',
+        AGHAST_MOCK_AI: '',
+        AGHAST_MOCK_SARIF: emptyResultsSarif,
+      },
+      [fixtureRepo, '--config-dir', opengrepOnlyConfigDir, '--output', outputFile],
+    );
+    assert.equal(exitCode, 0, `Expected exit 0 but got ${exitCode}. stderr: ${stderr}`);
+    assert.ok(!stderr.includes('ANTHROPIC_API_KEY'), 'Should not require API key for static checks');
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'PASS');
+    assert.equal(checks[0].checkId, 'aghast-opengrep-only');
+  });
+});

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -788,7 +788,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('PASS: default mock response with 3 targets → PASS, targetsAnalyzed: 3', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -809,7 +809,7 @@ describe('CLI mock mode: multi-target checks', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: failFixtureRepo,
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
@@ -841,7 +841,7 @@ describe('CLI mock mode: multi-target checks', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: multiIssueFixture,
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', multiTargetCappedConfigDir],
     );
@@ -867,7 +867,7 @@ describe('CLI mock mode: multi-target checks', () => {
     await runCLI(
       {
         AGHAST_MOCK_AI: multiIssueFixture,
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
@@ -879,7 +879,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('empty SARIF: 0 targets → PASS, targetsAnalyzed: 0', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: emptyResultsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: emptyResultsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -908,7 +908,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('repository-wide check in mixed config still works (no regression)', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', mixedChecksConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -934,7 +934,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('targetsAnalyzed present in check summary output', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -950,7 +950,7 @@ describe('CLI mock mode: multi-target checks', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: failFixtureRepo,
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
@@ -971,7 +971,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('stdout shows PASS in summary banner for multi-target', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     const combined = stdout + stderr;
@@ -980,7 +980,7 @@ describe('CLI mock mode: multi-target checks', () => {
 
   it('SARIF result without endLine is processed (endLine defaults to startLine)', async () => {
     const { exitCode } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: noEndlineSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: noEndlineSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     assert.equal(exitCode, 0);
@@ -1001,7 +1001,7 @@ describe('CLI mock mode: concurrency progress output', () => {
 
   it('stdout/stderr contains concurrency and progress messages', async () => {
     const { stdout, stderr } = await runCLI(
-      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SEMGREP: cli3TargetsSarif },
+      { AGHAST_MOCK_AI: 'true', AGHAST_MOCK_SARIF: cli3TargetsSarif },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
     const combined = stdout + stderr;
@@ -1019,7 +1019,7 @@ describe('CLI mock mode: concurrency progress output', () => {
     const { exitCode } = await runCLI(
       {
         AGHAST_MOCK_AI: failFixtureRepo,
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', multiTargetConfigDir],
     );
@@ -1053,7 +1053,7 @@ describe('CLI: conditional prerequisite validation', () => {
         ANTHROPIC_API_KEY: '',
         AGHAST_LOCAL_CLAUDE: '',
         AGHAST_MOCK_AI: '',
-        AGHAST_MOCK_SEMGREP: emptyResultsSarif,
+        AGHAST_MOCK_SARIF: emptyResultsSarif,
       },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );
@@ -1072,7 +1072,7 @@ describe('CLI: conditional prerequisite validation', () => {
         ANTHROPIC_API_KEY: '',
         AGHAST_LOCAL_CLAUDE: '',
         AGHAST_MOCK_AI: '',
-        AGHAST_MOCK_SEMGREP: cli3TargetsSarif,
+        AGHAST_MOCK_SARIF: cli3TargetsSarif,
       },
       [fixtureRepo, '--config-dir', semgrepOnlyConfigDir],
     );

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -57,6 +57,7 @@ export const mixedChecksConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 
 export const flagCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'flag-check');
 export const mixedResultsConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'mixed-results');
 export const semgrepOnlyConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'semgrep-only');
+export const opengrepOnlyConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'opengrep-only');
 export const mixedWithSemgrepOnlyConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'mixed-with-semgrep-only');
 export const sarifVerifyConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'sarif-verify');
 export const sarifVerifyEmptyConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'sarif-verify-empty');

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -101,11 +101,12 @@ describe('Built-in discoveries (loaded via scan-runner)', () => {
   // Import scan-runner to trigger the side-effect registration of built-in discoveries.
   // This must be a dynamic import so the registry is populated after clearDiscoveryRegistry()
   // in the beforeEach above doesn't interfere.
-  it('semgrep, openant, and sarif are registered after scan-runner loads', async () => {
+  it('semgrep, opengrep, openant, and sarif are registered after scan-runner loads', async () => {
     // Dynamic import triggers the registerDiscovery() calls in scan-runner.ts
     await import('../src/scan-runner.js');
     const names = getRegisteredDiscoveries();
     assert.ok(names.includes('semgrep'), 'semgrep should be registered');
+    assert.ok(names.includes('opengrep'), 'opengrep should be registered');
     assert.ok(names.includes('openant'), 'openant should be registered');
     assert.ok(names.includes('sarif'), 'sarif should be registered');
     assert.ok(!names.includes('diff-semgrep'), 'diff-semgrep is no longer a discovery');

--- a/tests/fixtures/cli-configs/opengrep-only/checks-config.json
+++ b/tests/fixtures/cli-configs/opengrep-only/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-opengrep-only",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/opengrep-only/checks/aghast-opengrep-only/aghast-opengrep-only.json
+++ b/tests/fixtures/cli-configs/opengrep-only/checks/aghast-opengrep-only/aghast-opengrep-only.json
@@ -1,0 +1,7 @@
+{
+  "id": "aghast-opengrep-only",
+  "name": "Opengrep-Only Check",
+  "severity": "high",
+  "confidence": "high",
+  "checkTarget": { "type": "static", "discovery": "opengrep", "rules": "unused-in-mock.yaml" }
+}

--- a/tests/fixtures/cli-configs/opengrep-only/prompts/generic-instructions.md
+++ b/tests/fixtures/cli-configs/opengrep-only/prompts/generic-instructions.md
@@ -1,0 +1,56 @@
+GENERIC INSTRUCTIONS:
+
+You are performing a SPECIFIC security check as defined in the CHECK INSTRUCTIONS below.
+
+IMPORTANT:
+- Focus ONLY on what the CHECK INSTRUCTIONS ask you to validate
+- Do NOT perform general security testing or look for unrelated vulnerabilities
+- Do NOT report issues outside the scope of the specific check
+- Follow the CHECK INSTRUCTIONS exactly as written
+
+OUTPUT FORMAT:
+
+Return your findings in the following JSON format:
+
+{
+  "issues": [
+    {
+      "file": "relative/path/to/file.ts",
+      "startLine": 40,
+      "endLine": 45,
+      "description": "Detailed explanation (see requirements below)",
+      "dataFlow": [
+        { "file": "src/routes/handler.ts", "lineNumber": 12, "label": "User input received from request parameter" },
+        { "file": "src/services/query.ts", "lineNumber": 38, "label": "Input passed to SQL query without sanitization" }
+      ]
+    }
+  ]
+}
+
+DESCRIPTION FORMATTING REQUIREMENTS:
+
+Your description field MUST be detailed and well-structured:
+- Use markdown formatting with headings (## Heading), bullet points, code blocks
+- Use \n for line breaks to create structured, readable content
+- Include an "Attack Scenario" section demonstrating exploitation
+- Include a "Recommendation" section with specific remediation steps
+
+DATA FLOW REQUIREMENTS:
+
+When the issue involves data flowing through multiple locations (e.g., user input reaching a dangerous sink), include a "dataFlow" array. Each step represents a point in the call stack or data flow:
+- "file": relative path to the source file
+- "lineNumber": the line number at that step
+- "label": a short description of what happens at this point (e.g., "User input received", "Passed to database query")
+- Order steps from source (e.g., user input) to sink (e.g., SQL execution)
+- Omit "dataFlow" entirely if the issue is localized to a single location
+
+CRITICAL: Return ONLY valid JSON. No markdown code blocks, no explanations outside the JSON.
+
+If no issues found for this SPECIFIC check, return: {"issues": []}
+
+If a TARGET LOCATION section appears at the end of this prompt, you must analyze ONLY that specific code location.
+
+---
+
+CHECK INSTRUCTIONS:
+

--- a/tests/new-check.test.ts
+++ b/tests/new-check.test.ts
@@ -560,6 +560,78 @@ describe('new-check utility', () => {
     assert.ok(testContent.includes('# ruleid: aghast-test'), 'Test file should use Python comment syntax');
   });
 
+  // ─── Opengrep discovery (parallel to semgrep) ────────────────────────────
+
+  it('creates checkTarget in check.json for targeted/opengrep type with explicit rules', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'opengrep',
+      '--semgrep-rules': 'rules/sql.yaml',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.deepEqual(checkDef.checkTarget, {
+      type: 'targeted',
+      discovery: 'opengrep',
+      rules: 'rules/sql.yaml',
+    });
+  });
+
+  it('generates <id>.yaml inside check folder when type is targeted/opengrep and no rules provided', async () => {
+    const flags = allFlags({ '--check-type': 'targeted', '--discovery': 'opengrep', '--language': 'python' });
+
+    const result = await runNewCheck(flags);
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    // Rule template is generated with identical format — opengrep and semgrep share rule syntax.
+    const ruleFile = resolve(checksDir, 'aghast-test', 'aghast-test.yaml');
+    const ruleContent = await readFile(ruleFile, 'utf-8');
+    assert.ok(ruleContent.includes('id: aghast-test'));
+    assert.ok(ruleContent.includes('languages: [python]'));
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.type, 'targeted');
+    assert.equal(checkDef.checkTarget.discovery, 'opengrep');
+    assert.equal(checkDef.checkTarget.rules, 'aghast-test.yaml');
+  });
+
+  it('static/opengrep creates checkTarget with no instructionsFile', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'static',
+      '--discovery': 'opengrep',
+      '--semgrep-rules': 'rules/detect.yaml',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.type, 'static');
+    assert.equal(checkDef.checkTarget.discovery, 'opengrep');
+    assert.equal(checkDef.checkTarget.rules, 'rules/detect.yaml');
+    assert.equal(checkDef.instructionsFile, undefined);
+  });
+
+  it('rejects when both --semgrep-rules and --opengrep-rules are passed', async () => {
+    const result = await runNewCheck([
+      '--config-dir', configDir,
+      '--id', 'aghast-test',
+      '--name', 'Test',
+      '--check-type', 'targeted',
+      '--discovery', 'opengrep',
+      '--semgrep-rules', 'rules/a.yaml',
+      '--opengrep-rules', 'rules/b.yaml',
+    ]);
+
+    assert.notEqual(result.exitCode, 0, 'Expected non-zero exit when both rules flags are passed');
+    assert.ok(
+      result.stderr.includes('--semgrep-rules and --opengrep-rules'),
+      `Expected stderr to mention the conflict, got: ${result.stderr}`,
+    );
+  });
+
   // ─── Interactive retry tests ──────────────────────────────────────────────
 
   it('retries up to 3 times for required fields before exiting', async () => {

--- a/tests/opengrep-integration.itest.ts
+++ b/tests/opengrep-integration.itest.ts
@@ -1,7 +1,10 @@
 /**
- * Real Semgrep integration tests.
- * These tests actually invoke the `semgrep` binary.
- * Skip by setting AGHAST_SKIP_SEMGREP_TESTS=true.
+ * Real Opengrep integration tests.
+ * These tests actually invoke the `opengrep` binary.
+ * Skip by setting AGHAST_SKIP_OPENGREP_TESTS=true.
+ *
+ * Reuses the Semgrep fixture codebase and rules — rule syntax and SARIF output
+ * are identical between the two tools.
  */
 
 import { describe, it, before, after, afterEach } from 'node:test';
@@ -9,7 +12,7 @@ import assert from 'node:assert/strict';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { unlink, writeFile } from 'node:fs/promises';
-import { runSemgrep } from '../src/semgrep-runner.js';
+import { runOpengrep } from '../src/opengrep-runner.js';
 import { parseSARIF } from '../src/sarif-parser.js';
 import { runMultiScan } from '../src/scan-runner.js';
 import { MockAgentProvider } from './mocks/mock-agent-provider.js';
@@ -20,15 +23,15 @@ const testCodebase = resolve(__dirname, 'fixtures', 'semgrep-target');
 const sqlConcatRule = resolve(__dirname, 'fixtures', 'semgrep-rules', 'sql-concat.yaml');
 const fixtureRepo = resolve(__dirname, 'fixtures', 'git-repo');
 const outputFile = resolve(fixtureRepo, 'security_checks_results.json');
-const skip = !!process.env.AGHAST_SKIP_SEMGREP_TESTS;
+const skip = !!process.env.AGHAST_SKIP_OPENGREP_TESTS;
 
-// Semgrep's default ignore list skips tests/ directories. Since the test codebase
-// lives under tests/fixtures/, we create an empty .semgrepignore at the repo root
-// (where Semgrep looks for it) to override those defaults during integration tests.
+// Opengrep inherits Semgrep's default ignore list which skips tests/ directories.
+// Since the fixture codebase lives under tests/fixtures/, create an empty
+// .semgrepignore at the repo root to override those defaults during integration tests.
 const repoRoot = resolve(__dirname, '..');
 const semgrepIgnorePath = join(repoRoot, '.semgrepignore');
 
-describe('Semgrep integration tests', { skip }, () => {
+describe('Opengrep integration tests', { skip }, () => {
   before(async () => {
     await writeFile(semgrepIgnorePath, '');
   });
@@ -37,19 +40,17 @@ describe('Semgrep integration tests', { skip }, () => {
     try { await unlink(semgrepIgnorePath); } catch { /* may not exist */ }
   });
 
-  describe('runSemgrep', () => {
+  describe('runOpengrep', () => {
     it('executes against test codebase and returns valid SARIF', async () => {
-      // Make sure AGHAST_MOCK_SARIF is not set
       const origMock = process.env.AGHAST_MOCK_SARIF;
       delete process.env.AGHAST_MOCK_SARIF;
 
       try {
-        const sarifContent = await runSemgrep({
+        const sarifContent = await runOpengrep({
           repositoryPath: testCodebase,
           rules: sqlConcatRule,
         });
 
-        // Should be valid JSON
         const parsed = JSON.parse(sarifContent);
         assert.equal(parsed.version, '2.1.0');
         assert.ok(parsed.runs, 'SARIF should have runs');
@@ -68,7 +69,7 @@ describe('Semgrep integration tests', { skip }, () => {
       delete process.env.AGHAST_MOCK_SARIF;
 
       try {
-        const sarifContent = await runSemgrep({
+        const sarifContent = await runOpengrep({
           repositoryPath: testCodebase,
           rules: sqlConcatRule,
         });
@@ -76,7 +77,6 @@ describe('Semgrep integration tests', { skip }, () => {
         const targets = parseSARIF(sarifContent);
         assert.ok(targets.length >= 1, `Expected at least 1 target, got ${targets.length}`);
 
-        // All targets should reference files in the test codebase
         for (const target of targets) {
           assert.ok(target.file, 'Target should have a file path');
           assert.ok(target.startLine > 0, 'Target should have startLine > 0');
@@ -95,7 +95,7 @@ describe('Semgrep integration tests', { skip }, () => {
       try { await unlink(outputFile); } catch { /* may not exist */ }
     });
 
-    it('config with semgrep check + real semgrep + mock AI → results with targetsAnalyzed > 0', async () => {
+    it('config with opengrep check + real opengrep + mock AI → results with targetsAnalyzed > 0', async () => {
       const origMock = process.env.AGHAST_MOCK_SARIF;
       delete process.env.AGHAST_MOCK_SARIF;
 
@@ -103,20 +103,20 @@ describe('Semgrep integration tests', { skip }, () => {
         const provider = new MockAgentProvider({ response: { issues: [] } });
 
         const check: SecurityCheck = {
-          id: 'integ-sqli',
-          name: 'Integration SQL Check',
+          id: 'integ-sqli-opengrep',
+          name: 'Integration SQL Check (Opengrep)',
           repositories: [],
           instructionsFile: 'unused.md',
           checkTarget: {
             type: 'targeted',
-            discovery: 'semgrep',
+            discovery: 'opengrep',
             rules: sqlConcatRule,
           },
         };
 
         const details: CheckDetails = {
-          id: 'integ-sqli',
-          name: 'Integration SQL Check',
+          id: 'integ-sqli-opengrep',
+          name: 'Integration SQL Check (Opengrep)',
           overview: 'Integration test check.',
           content: '### Integration SQL Check\n\n#### Overview\nTest.\n',
         };
@@ -142,17 +142,17 @@ describe('Semgrep integration tests', { skip }, () => {
   });
 
   describe('error handling', () => {
-    it('invalid rule file → error from Semgrep execution', async () => {
+    it('invalid rule file → error from Opengrep execution', async () => {
       const origMock = process.env.AGHAST_MOCK_SARIF;
       delete process.env.AGHAST_MOCK_SARIF;
 
       try {
         await assert.rejects(
-          () => runSemgrep({
+          () => runOpengrep({
             repositoryPath: testCodebase,
             rules: '/nonexistent/rule.yaml',
           }),
-          /Semgrep execution failed/,
+          /Opengrep execution failed/,
         );
       } finally {
         if (origMock !== undefined) {

--- a/tests/opengrep-runner.test.ts
+++ b/tests/opengrep-runner.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runOpengrep } from '../src/opengrep-runner.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = resolve(__dirname, 'fixtures', 'sarif');
+const fixtureRepo = resolve(__dirname, 'fixtures', 'git-repo');
+
+describe('runOpengrep (mock mode)', () => {
+  const origEnv = process.env.AGHAST_MOCK_SARIF;
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env.AGHAST_MOCK_SARIF;
+    } else {
+      process.env.AGHAST_MOCK_SARIF = origEnv;
+    }
+  });
+
+  it('returns fixture file content when AGHAST_MOCK_SARIF is set', async () => {
+    // Opengrep emits the same SARIF 2.1.0 format as Semgrep, so the semgrep
+    // fixture is reused.
+    const fixturePath = resolve(fixtureDir, 'semgrep-results.sarif');
+    process.env.AGHAST_MOCK_SARIF = fixturePath;
+
+    const result = await runOpengrep({ repositoryPath: fixtureRepo });
+    const parsed = JSON.parse(result);
+    assert.equal(parsed.version, '2.1.0');
+    assert.equal(parsed.runs[0].results.length, 3);
+  });
+
+  it('throws when AGHAST_MOCK_SARIF points to non-existent file', async () => {
+    process.env.AGHAST_MOCK_SARIF = '/does/not/exist/results.sarif';
+
+    await assert.rejects(
+      () => runOpengrep({ repositoryPath: fixtureRepo }),
+      /Failed to read AGHAST_MOCK_SARIF file/,
+    );
+  });
+});

--- a/tests/scan-runner.test.ts
+++ b/tests/scan-runner.test.ts
@@ -499,18 +499,18 @@ function makeMultiTargetCheck(
 }
 
 describe('runMultiScan (multi-target checks)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSemgrep = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSemgrep;
     }
   });
 
   it('3 targets all pass → PASS with targetsAnalyzed: 3', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -526,7 +526,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('3 targets, 1 has issues → FAIL with enriched issues', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // target 1: pass
@@ -561,7 +561,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('3 targets, 1 AI error → ERROR', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [] }, // target 1: pass
@@ -581,7 +581,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('some targets error AND others find issues → FAIL (not ERROR)', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     // Custom provider: call 0 finds an issue, call 1 passes, call 2 throws
     let callCount = 0;
@@ -622,7 +622,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('0 targets → PASS with targetsAnalyzed: 0', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = emptySarif;
+    process.env.AGHAST_MOCK_SARIF = emptySarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -638,7 +638,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('maxTargets limiting applied via checkTarget.maxTargets', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -654,7 +654,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('checkTarget.maxTargets=2 limits to 2 targets', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -670,7 +670,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('target location embedded in prompt sent to agent provider', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     await runMultiScan({
@@ -742,7 +742,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('issues include codeSnippet from fixture file', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider({
       response: {
         issues: [{
@@ -769,7 +769,7 @@ describe('runMultiScan (multi-target checks)', () => {
   });
 
   it('severity and confidence propagated in multi-target mode', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider({
       response: {
         issues: [{
@@ -824,13 +824,13 @@ function makeFpValidationCheck(
 }
 
 describe('runMultiScan (false-positive-validation)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSarif = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
-    if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+    if (origMockSarif === undefined) {
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSarif;
     }
   });
 
@@ -839,7 +839,7 @@ describe('runMultiScan (false-positive-validation)', () => {
     // targets 0 and 2 (→ global issues 0,1); check B confirms only target 1
     // (→ global issue 2). The TP record from check B must have its issueIndex
     // offset by check A's issue count, i.e. point at index 2, not 0.
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     const tp = (desc: string): CheckResponse => ({
       issues: [{ file: 'src/example.ts', startLine: 4, endLine: 4, description: desc }],
@@ -908,7 +908,7 @@ describe('runMultiScan (false-positive-validation)', () => {
     // AI returns issues but labels the target a false positive. Issues are the
     // source of truth, so the record must be filed as a true positive and the
     // issue must still appear in results.issues.
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     const provider = new MockAgentProvider();
     provider.setResponseQueue([
@@ -937,7 +937,7 @@ describe('runMultiScan (false-positive-validation)', () => {
   });
 
   it('substitutes a sentinel rationale when the AI omits one', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     const provider = new MockAgentProvider();
     provider.setResponseQueue([
@@ -996,18 +996,18 @@ function createTrackingProvider(
 }
 
 describe('runMultiScan (concurrency)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSemgrep = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSemgrep;
     }
   });
 
   it('concurrency limit respected (10 targets, concurrency 3)', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTarget10Sarif;
+    process.env.AGHAST_MOCK_SARIF = multiTarget10Sarif;
     const { provider, getMaxActive } = createTrackingProvider(50);
 
     const results = await runMultiScan({
@@ -1024,7 +1024,7 @@ describe('runMultiScan (concurrency)', () => {
   });
 
   it('default concurrency is 5 (10 targets, no concurrency specified)', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTarget10Sarif;
+    process.env.AGHAST_MOCK_SARIF = multiTarget10Sarif;
     const { provider, getMaxActive } = createTrackingProvider(50);
 
     const results = await runMultiScan({
@@ -1040,7 +1040,7 @@ describe('runMultiScan (concurrency)', () => {
   });
 
   it('per-check concurrency overrides MultiScanOptions concurrency', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTarget10Sarif;
+    process.env.AGHAST_MOCK_SARIF = multiTarget10Sarif;
     const { provider, getMaxActive } = createTrackingProvider(50);
 
     const results = await runMultiScan({
@@ -1058,7 +1058,7 @@ describe('runMultiScan (concurrency)', () => {
   });
 
   it('result ordering preserved with variable delays', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif; // 3 targets
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif; // 3 targets
     const delays = [100, 10, 50];
     let callIdx = 0;
 
@@ -1097,7 +1097,7 @@ describe('runMultiScan (concurrency)', () => {
 
   it('single target works with concurrency 5', async () => {
     // Use multiTarget10Sarif with maxTargets: 1 to get a single target
-    process.env.AGHAST_MOCK_SEMGREP = multiTarget10Sarif;
+    process.env.AGHAST_MOCK_SARIF = multiTarget10Sarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1116,13 +1116,13 @@ describe('runMultiScan (concurrency)', () => {
 // --- runMultiScan tests (FLAG status) ---
 
 describe('runMultiScan (FLAG status)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSemgrep = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSemgrep;
     }
   });
 
@@ -1165,7 +1165,7 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('multi-target: all 3 targets flag → check status FLAG', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider({
       response: { issues: [], flagged: true },
     });
@@ -1182,7 +1182,7 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('multi-target: FLAG priority over ERROR (some flag, some error, no issues) → FLAG', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     // Calls 0 and 1 return flagged, call 2 throws
     let flagErrCallCount = 0;
@@ -1211,7 +1211,7 @@ describe('runMultiScan (FLAG status)', () => {
   });
 
   it('multi-target: FAIL overrides FLAG (some flag, one has issues) → FAIL', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = new MockAgentProvider();
     provider.setResponseQueue([
       { issues: [], flagged: true }, // target 1: flag
@@ -1331,13 +1331,13 @@ describe('runMultiScan (FLAG status)', () => {
 // --- runMultiScan tests (token usage) ---
 
 describe('runMultiScan (token usage)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSemgrep = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSemgrep;
     }
   });
 
@@ -1391,7 +1391,7 @@ describe('runMultiScan (token usage)', () => {
   });
 
   it('multi-target: token usage aggregated across targets', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProviderWithTokens({ inputTokens: 50, outputTokens: 25, totalTokens: 75 });
 
     const results = await runMultiScan({
@@ -1452,18 +1452,18 @@ function makeSemgrepOnlyCheck(
 }
 
 describe('runMultiScan (semgrep-only checks)', () => {
-  const origMockSemgrep = process.env.AGHAST_MOCK_SEMGREP;
+  const origMockSemgrep = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origMockSemgrep === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origMockSemgrep;
+      process.env.AGHAST_MOCK_SARIF = origMockSemgrep;
     }
   });
 
   it('0 findings → PASS, targetsAnalyzed: 0, no AI calls', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = emptySarif;
+    process.env.AGHAST_MOCK_SARIF = emptySarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1480,7 +1480,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('3 findings → FAIL with correct SecurityIssue mapping', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1510,7 +1510,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('severity and confidence from check config', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1526,7 +1526,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('maxTargets limiting', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1543,8 +1543,8 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('Semgrep failure → ERROR status', async () => {
-    // No AGHAST_MOCK_SEMGREP set and no real semgrep → error
-    delete process.env.AGHAST_MOCK_SEMGREP;
+    // No AGHAST_MOCK_SARIF set and no real semgrep → error
+    delete process.env.AGHAST_MOCK_SARIF;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1560,7 +1560,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('no tokenUsage on summary', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProviderWithTokens({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
 
     const results = await runMultiScan({
@@ -1574,7 +1574,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
   });
 
   it('mixed check: semgrep-only + AI check both produce correct results', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
     const provider = createPassProvider();
 
     const results = await runMultiScan({
@@ -1607,7 +1607,7 @@ describe('runMultiScan (semgrep-only checks)', () => {
 
 describe('runMultiScan (fatal error abort)', () => {
   afterEach(() => {
-    delete process.env.AGHAST_MOCK_SEMGREP;
+    delete process.env.AGHAST_MOCK_SARIF;
   });
 
   it('FatalProviderError aborts remaining checks', async () => {
@@ -1702,7 +1702,7 @@ describe('runMultiScan (fatal error abort)', () => {
   });
 
   it('FatalProviderError in multi-target check aborts remaining checks', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = multiTargetSarif;
+    process.env.AGHAST_MOCK_SARIF = multiTargetSarif;
 
     const fatalProvider: AgentProvider = {
       async initialize() {},

--- a/tests/semgrep-runner.test.ts
+++ b/tests/semgrep-runner.test.ts
@@ -47,19 +47,19 @@ describe('buildSemgrepArgs', () => {
 });
 
 describe('runSemgrep (mock mode)', () => {
-  const origEnv = process.env.AGHAST_MOCK_SEMGREP;
+  const origEnv = process.env.AGHAST_MOCK_SARIF;
 
   afterEach(() => {
     if (origEnv === undefined) {
-      delete process.env.AGHAST_MOCK_SEMGREP;
+      delete process.env.AGHAST_MOCK_SARIF;
     } else {
-      process.env.AGHAST_MOCK_SEMGREP = origEnv;
+      process.env.AGHAST_MOCK_SARIF = origEnv;
     }
   });
 
-  it('returns fixture file content when AGHAST_MOCK_SEMGREP is set', async () => {
+  it('returns fixture file content when AGHAST_MOCK_SARIF is set', async () => {
     const fixturePath = resolve(fixtureDir, 'semgrep-results.sarif');
-    process.env.AGHAST_MOCK_SEMGREP = fixturePath;
+    process.env.AGHAST_MOCK_SARIF = fixturePath;
 
     const result = await runSemgrep({ repositoryPath: fixtureRepo });
     const parsed = JSON.parse(result);
@@ -67,12 +67,12 @@ describe('runSemgrep (mock mode)', () => {
     assert.equal(parsed.runs[0].results.length, 3);
   });
 
-  it('throws when AGHAST_MOCK_SEMGREP points to non-existent file', async () => {
-    process.env.AGHAST_MOCK_SEMGREP = '/does/not/exist/results.sarif';
+  it('throws when AGHAST_MOCK_SARIF points to non-existent file', async () => {
+    process.env.AGHAST_MOCK_SARIF = '/does/not/exist/results.sarif';
 
     await assert.rejects(
       () => runSemgrep({ repositoryPath: fixtureRepo }),
-      /Failed to read AGHAST_MOCK_SEMGREP file/,
+      /Failed to read AGHAST_MOCK_SARIF file/,
     );
   });
 });


### PR DESCRIPTION
- Add OpenGrep discovery support and shared SARIF target enrichment.
- Extend diff-filter coverage and CLI/tests for OpenGrep and Semgrep paths.
- Update docs, CI, and package metadata to ship the new discovery mode.

Validation:
- npm --prefix ..\aghast install
- npm --prefix ..\aghast test
