### PR TITLE
fix: Update Claude pricing for current models

### DIFF
--- a/config/pricing.json
+++ b/config/pricing.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "AI provider pricing in USD per 1,000,000 tokens. Prices change over time and may need updates. Last verified: 2026-05. Cache rates: reads ~10% of input rate, writes ~125% of input rate (Anthropic published multipliers).",
+  "_comment": "AI provider pricing in USD per 1,000,000 tokens. Prices change over time and may need updates. Last verified: 2026-07. Cache rates: reads ~10% of input rate, writes ~125% of input rate (Anthropic published multipliers).",
   "currency": "USD",
   "models": {
     "claude-haiku-4-5": {
@@ -8,6 +8,18 @@
       "cacheReadPerMillion": 0.1,
       "cacheWritePerMillion": 1.25
     },
+    "claude-haiku-4-5-20251001": {
+      "inputPerMillion": 1.0,
+      "outputPerMillion": 5.0,
+      "cacheReadPerMillion": 0.1,
+      "cacheWritePerMillion": 1.25
+    },
+    "claude-sonnet-5": {
+      "inputPerMillion": 2.0,
+      "outputPerMillion": 10.0,
+      "cacheReadPerMillion": 0.2,
+      "cacheWritePerMillion": 2.5
+    },
     "claude-sonnet-4-6": {
       "inputPerMillion": 3.0,
       "outputPerMillion": 15.0,
@@ -15,10 +27,28 @@
       "cacheWritePerMillion": 3.75
     },
     "claude-opus-4-7": {
-      "inputPerMillion": 15.0,
-      "outputPerMillion": 75.0,
-      "cacheReadPerMillion": 1.5,
-      "cacheWritePerMillion": 18.75
+      "inputPerMillion": 5.0,
+      "outputPerMillion": 25.0,
+      "cacheReadPerMillion": 0.5,
+      "cacheWritePerMillion": 6.25
+    },
+    "claude-opus-4-8": {
+      "inputPerMillion": 5.0,
+      "outputPerMillion": 25.0,
+      "cacheReadPerMillion": 0.5,
+      "cacheWritePerMillion": 6.25
+    },
+    "claude-fable-5": {
+      "inputPerMillion": 10.0,
+      "outputPerMillion": 50.0,
+      "cacheReadPerMillion": 1.0,
+      "cacheWritePerMillion": 12.5
+    },
+    "claude-mythos-5": {
+      "inputPerMillion": 10.0,
+      "outputPerMillion": 50.0,
+      "cacheReadPerMillion": 1.0,
+      "cacheWritePerMillion": 12.5
     },
     "haiku": {
       "inputPerMillion": 1.0,
@@ -33,10 +63,10 @@
       "cacheWritePerMillion": 3.75
     },
     "opus": {
-      "inputPerMillion": 15.0,
-      "outputPerMillion": 75.0,
-      "cacheReadPerMillion": 1.5,
-      "cacheWritePerMillion": 18.75
+      "inputPerMillion": 5.0,
+      "outputPerMillion": 25.0,
+      "cacheReadPerMillion": 0.5,
+      "cacheWritePerMillion": 6.25
     }
   }
 }

--- a/tests/cost-calculator.test.ts
+++ b/tests/cost-calculator.test.ts
@@ -108,15 +108,32 @@ describe('sumCosts', () => {
 });
 
 describe('loadDefaultPricing', () => {
-  it('loads built-in config/pricing.json with seed models', async () => {
+  it('loads built-in config/pricing.json with current Claude models', async () => {
     const pricing = await loadDefaultPricing();
     assert.equal(pricing.currency, 'USD');
-    // Seed models documented in the issue
+    // Current generally available models, plus the limited-availability Mythos 5.
     assert.ok(pricing.models['claude-haiku-4-5'], 'haiku entry exists');
-    assert.ok(pricing.models['claude-sonnet-4-6'], 'sonnet entry exists');
-    assert.ok(pricing.models['claude-opus-4-7'], 'opus entry exists');
+    assert.ok(pricing.models['claude-haiku-4-5-20251001'], 'pinned haiku entry exists');
+    assert.ok(pricing.models['claude-sonnet-5'], 'sonnet entry exists');
+    assert.ok(pricing.models['claude-opus-4-8'], 'latest opus entry exists');
+    assert.ok(pricing.models['claude-fable-5'], 'fable entry exists');
+    assert.ok(pricing.models['claude-mythos-5'], 'mythos entry exists');
     assert.equal(typeof pricing.models['claude-haiku-4-5'].inputPerMillion, 'number');
     assert.equal(typeof pricing.models['claude-haiku-4-5'].outputPerMillion, 'number');
+  });
+
+  it('prices Opus 4.8 and the opus alias at current published rates', async () => {
+    const pricing = await loadDefaultPricing();
+    const opus48 = pricing.models['claude-opus-4-8'];
+    const opusAlias = pricing.models.opus;
+
+    assert.deepEqual(opus48, {
+      inputPerMillion: 5,
+      outputPerMillion: 25,
+      cacheReadPerMillion: 0.5,
+      cacheWritePerMillion: 6.25,
+    });
+    assert.deepEqual(opusAlias, opus48);
   });
 
   it('cost matches expected for default haiku pricing', async () => {


### PR DESCRIPTION
## Summary
- add current Claude API pricing for Opus 4.8, Sonnet 5, Fable 5, Mythos 5, and the Haiku 4.5 snapshot
- correct Opus 4.7 pricing and align the `opus` alias with Opus 4.8
- cover the current model catalog and Opus 4.8 rates with cost-calculator regression tests

Closes #91

## Validation
- verified pricing JSON structure and required model entries
- `npm test`, `npm run lint`, and `npm run build` could not run because Node/npm are unavailable in this environment