### PR TITLE
fix: Reject unsupported Claude Code models before scans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_HISTORY_FILE` — Override the scan history file path (default: `~/.aghast/history.json`)
 - `AGHAST_MOCK_TOKENS` — Format `<input>,<output>`; injects token usage into the mock agent provider for cost/budget tests
 - `AGHAST_MOCK_LOCAL_LOGIN` — Test hook for the Claude Code provider's local-login probe: `true` reports a logged-in session, `false` reports not-logged-in, both without spawning the agent SDK (keeps CLI auth tests hermetic)
+- `AGHAST_MOCK_CLAUDE_MODELS` — Test hook for the Claude Code provider's supported-model list: comma-separated model IDs, used to keep CLI model-validation tests hermetic
 - `AGHAST_DEBUG_PRINTPROMPT` — Print full prompts (requires `--debug`)
 - `NO_COLOR` — Set to `1` to disable colored CLI output (standard; respected automatically by `picocolors`)
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -62,6 +62,8 @@ aghast supports multiple agent providers via the `--agent-provider` flag or `age
 | Claude Code (default) | `claude-code` | Model name (e.g. `haiku`, `sonnet`) | `ANTHROPIC_API_KEY` env var, or a logged-in local Claude session |
 | OpenCode | `opencode` | `providerID/modelID` (e.g. `opencode/nemotron-3-super-free`, `cursor-acp/composer-2-fast`) | [OpenCode CLI](https://opencode.ai) installed and configured |
 
+When an explicit Claude Code model is configured, aghast validates it before scanning and prints the models available to the active credentials if it is unsupported. Use `aghast build-config` interactively to select from the same list.
+
 ### Using OpenCode
 
 [Click for a video introduction to OpenCode support.](https://youtu.be/NkOc6pLanmQ)

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -224,6 +224,14 @@ export class ClaudeCodeProvider implements AgentProvider {
     if (this._listSupportedModelsFn) {
       return await this._listSupportedModelsFn();
     }
+    const mockModels = process.env.AGHAST_MOCK_CLAUDE_MODELS;
+    if (mockModels !== undefined) {
+      return mockModels
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean)
+        .map((id) => ({ id }));
+    }
     return await listModelsViaAgentSdk();
   }
 

--- a/src/claude-code-provider.ts
+++ b/src/claude-code-provider.ts
@@ -6,7 +6,7 @@
 import type { AgentProvider, AgentResponse, ProviderConfig, CheckResponse, ProviderModelInfo, TokenUsage } from './types.js';
 import { DEFAULT_MODEL, FatalProviderError } from './types.js';
 // import { parseAgentResponse } from './response-parser.js';
-import { logProgress, logDebug, logDebugFull, createTimer, getLogLevel } from './logging.js';
+import { logProgress, logDebug, logDebugFull, logWarn, createTimer, getLogLevel } from './logging.js';
 import { OUTPUT_SCHEMA } from './provider-utils.js';
 
 const TAG = 'agent-provider';
@@ -64,6 +64,10 @@ async function listModelsViaAgentSdk(): Promise<readonly ProviderModelInfo[]> {
 const HEARTBEAT_INTERVAL_MS = 15000; // Log heartbeat every 15s if no activity
 const MAX_API_ERROR_RETRIES = 3; // Fail after this many consecutive API errors
 const MAX_ERROR_DETECTION_LENGTH = 200; // Only check short text chunks for SDK error patterns — longer text is AI analysis content
+
+function isInvalidModelError(message: string): boolean {
+  return /\bmodel\b.*\b(not found|invalid|unsupported|does not exist)\b|\b(not found|invalid|unsupported)\b.*\bmodel\b/i.test(message);
+}
 
 /** Type for the SDK query function — injectable for testing. */
 export type QueryFn = (params: {
@@ -129,9 +133,18 @@ export class ClaudeCodeProvider implements AgentProvider {
   private useLocalClaude: boolean = false;
   private model: string = DEFAULT_MODEL;
   private _queryFn: QueryFn | undefined;
+  private _listModelsFn: (() => Promise<readonly ProviderModelInfo[]>) | undefined;
+  private _listSupportedModelsFn: (() => Promise<readonly ProviderModelInfo[]>) | undefined;
   private _detectLocalLogin: () => Promise<boolean>;
-  constructor(options?: { _queryFn?: QueryFn; _detectLocalLogin?: () => Promise<boolean> }) {
+  constructor(options?: {
+    _queryFn?: QueryFn;
+    _listModelsFn?: () => Promise<readonly ProviderModelInfo[]>;
+    _listSupportedModelsFn?: () => Promise<readonly ProviderModelInfo[]>;
+    _detectLocalLogin?: () => Promise<boolean>;
+  }) {
     this._queryFn = options?._queryFn;
+    this._listModelsFn = options?._listModelsFn;
+    this._listSupportedModelsFn = options?._listSupportedModelsFn;
     this._detectLocalLogin = options?._detectLocalLogin ?? detectLocalLogin;
   }
 
@@ -166,6 +179,9 @@ export class ClaudeCodeProvider implements AgentProvider {
         'ANTHROPIC_API_KEY is required, or log in to a local Claude session (run `claude` and use /login).',
       );
     }
+    if (config.model) {
+      await this.validateConfiguredModel(config.model);
+    }
     if (this.useLocalClaude) {
       logProgress(TAG, 'Using local Claude Code session for authentication');
     } else {
@@ -188,6 +204,9 @@ export class ClaudeCodeProvider implements AgentProvider {
   }
 
   async listModels(): Promise<readonly ProviderModelInfo[]> {
+    if (this._listModelsFn) {
+      return await this._listModelsFn();
+    }
     // Tier 1: if ANTHROPIC_API_KEY is set, hit /v1/models for the full canonical list.
     const apiKey = this.apiKey ?? process.env.ANTHROPIC_API_KEY;
     if (apiKey) {
@@ -199,6 +218,54 @@ export class ClaudeCodeProvider implements AgentProvider {
     }
     // Tier 2: ask the Claude Code agent SDK for its curated list (works with local Claude auth).
     return await listModelsViaAgentSdk();
+  }
+
+  private async listSupportedModels(): Promise<readonly ProviderModelInfo[]> {
+    if (this._listSupportedModelsFn) {
+      return await this._listSupportedModelsFn();
+    }
+    return await listModelsViaAgentSdk();
+  }
+
+  private async validateConfiguredModel(model: string): Promise<void> {
+    let supportedModels: readonly ProviderModelInfo[];
+    try {
+      supportedModels = await this.listSupportedModels();
+    } catch (err) {
+      logWarn(TAG, `Could not validate configured model "${model}" before scanning: ${err instanceof Error ? err.message : String(err)}. Continuing without preflight validation.`);
+      return;
+    }
+
+    if (supportedModels.length === 0) {
+      logWarn(TAG, `Could not validate configured model "${model}" before scanning because Claude Code returned no supported models. Continuing without preflight validation.`);
+      return;
+    }
+
+    if (!supportedModels.some((supported) => supported.id === model)) {
+      throw new FatalProviderError(
+        `Claude Code does not support configured model "${model}". Available models: ${supportedModels.map((supported) => supported.id).join(', ')}.`,
+      );
+    }
+  }
+
+  private async invalidModelError(detail: string): Promise<FatalProviderError> {
+    try {
+      const models = await this.listModels();
+      const available = models.map((model) => model.id);
+      if (available.length > 0) {
+        return new FatalProviderError(
+          `Agent provider rejected model "${this.model}": ${detail}. Available models: ${available.join(', ')}.`,
+        );
+      }
+      return new FatalProviderError(
+        `Agent provider rejected model "${this.model}": ${detail}. The provider returned no available models.`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return new FatalProviderError(
+        `Agent provider rejected model "${this.model}": ${detail}. Could not retrieve available models: ${reason}`,
+      );
+    }
   }
 
   async executeCheck(
@@ -339,6 +406,9 @@ export class ClaudeCodeProvider implements AgentProvider {
             // Detect API errors surfaced as assistant text by the SDK
             const apiErrorMatch = shortChunks.find((t: string) => t.includes('API Error:'));
             if (apiErrorMatch) {
+              if (isInvalidModelError(apiErrorMatch)) {
+                throw await this.invalidModelError(apiErrorMatch);
+              }
               consecutiveApiErrors++;
               if (consecutiveApiErrors >= MAX_API_ERROR_RETRIES) {
                 throw new Error(`Agent provider API error (after ${MAX_API_ERROR_RETRIES} attempts): ${apiErrorMatch}`);
@@ -436,6 +506,9 @@ export class ClaudeCodeProvider implements AgentProvider {
         } else {
           const errorResult = message as { subtype: string; errors?: string[] };
           errorMessage = errorResult.errors?.join('; ') ?? `Agent provider error: ${errorResult.subtype}`;
+          if (isInvalidModelError(errorMessage)) {
+            throw await this.invalidModelError(errorMessage);
+          }
           logProgress(TAG, `${prefix}Failed: ${errorResult.subtype} (${timer.elapsedStr()})`);
         }
       }

--- a/tests/claude-code-provider.test.ts
+++ b/tests/claude-code-provider.test.ts
@@ -33,6 +33,112 @@ function successResult(): Record<string, unknown> {
 }
 
 describe('ClaudeCodeProvider: API error handling', () => {
+  it('rejects an unsupported configured model before executing a check', async () => {
+    const provider = new ClaudeCodeProvider({
+      _listSupportedModelsFn: async () => [{ id: 'haiku' }, { id: 'sonnet' }],
+    });
+
+    await assert.rejects(
+      () => provider.initialize({ apiKey: 'test-key', model: 'not-a-model' }),
+      (err: Error) => {
+        assert.ok(err instanceof FatalProviderError, 'Should be FatalProviderError');
+        assert.match(err.message, /does not support configured model "not-a-model"/);
+        assert.match(err.message, /Available models: haiku, sonnet/);
+        return true;
+      },
+    );
+  });
+
+  it('skips preflight validation when Claude Code cannot list supported models', async () => {
+    const provider = new ClaudeCodeProvider({
+      _listSupportedModelsFn: async () => {
+        throw new Error('model endpoint unavailable');
+      },
+    });
+
+    await provider.initialize({ apiKey: 'test-key', model: 'not-a-model' });
+  });
+
+  it('does not list models when no model override is configured', async () => {
+    let modelListCalls = 0;
+    const provider = new ClaudeCodeProvider({
+      _listSupportedModelsFn: async () => {
+        modelListCalls++;
+        return [{ id: 'haiku' }];
+      },
+    });
+
+    await provider.initialize({ apiKey: 'test-key' });
+    assert.equal(modelListCalls, 0);
+  });
+
+  it('lists available models when the SDK rejects the configured model', async () => {
+    const provider = new ClaudeCodeProvider({
+      _queryFn: createFakeQueryFn([
+        {
+          type: 'result',
+          subtype: 'error',
+          errors: ['Invalid model "not-a-model"'],
+        },
+      ]),
+      _listModelsFn: async () => [
+        { id: 'haiku' },
+        { id: 'sonnet' },
+        { id: 'opus' },
+      ],
+      _listSupportedModelsFn: async () => [{ id: 'not-a-model' }],
+    });
+    await provider.initialize({ apiKey: 'test-key', model: 'not-a-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test prompt', '/tmp/repo'),
+      (err: Error) => {
+        assert.ok(err instanceof FatalProviderError, 'Should be FatalProviderError');
+        assert.match(err.message, /rejected model "not-a-model"/i);
+        assert.match(err.message, /Available models: haiku, sonnet, opus/);
+        return true;
+      },
+    );
+  });
+
+  it('preserves an invalid-model error when listing models fails', async () => {
+    const provider = new ClaudeCodeProvider({
+      _queryFn: createFakeQueryFn([
+        {
+          type: 'result',
+          subtype: 'error',
+          errors: ['Model not found: not-a-model'],
+        },
+      ]),
+      _listModelsFn: async () => {
+        throw new Error('model endpoint unavailable');
+      },
+      _listSupportedModelsFn: async () => [{ id: 'not-a-model' }],
+    });
+    await provider.initialize({ apiKey: 'test-key', model: 'not-a-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test prompt', '/tmp/repo'),
+      /Could not retrieve available models: model endpoint unavailable/,
+    );
+  });
+
+  it('lists available models for invalid-model API error messages', async () => {
+    const provider = new ClaudeCodeProvider({
+      _queryFn: createFakeQueryFn([
+        assistantMsg('API Error: 400 invalid model "not-a-model"'),
+      ]),
+      _listModelsFn: async () => [{ id: 'haiku' }, { id: 'sonnet' }],
+      _listSupportedModelsFn: async () => [{ id: 'not-a-model' }],
+    });
+    await provider.initialize({ apiKey: 'test-key', model: 'not-a-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test prompt', '/tmp/repo'),
+      /Available models: haiku, sonnet/,
+    );
+  });
+
   it('throws after 3 consecutive API error turns', async () => {
     const errorText =
       'API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"workspace limits reached"}}';
@@ -709,4 +815,3 @@ describe('ClaudeCodeProvider: authentication resolution', () => {
     });
   });
 });
-

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -185,6 +185,20 @@ describe('CLI: --runtime-config flag', () => {
     }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--runtime-config', absentPath]);
     assert.equal(exitCode, 0);
   });
+
+  it('invalid Claude Code model in runtime config exits before scanning', async () => {
+    const invalidModelPath = resolve(__dirname, 'fixtures', 'runtime-config', 'invalid-claude-model.json');
+    const { exitCode, stdout, stderr } = await runCLI({
+      AGHAST_MOCK_AI: undefined,
+      AGHAST_MOCK_LOCAL_LOGIN: 'true',
+      AGHAST_MOCK_CLAUDE_MODELS: 'haiku,sonnet',
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--runtime-config', invalidModelPath]);
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /does not support configured model "claude-code\/junk"/);
+    assert.match(stderr, /Available models: haiku, sonnet/);
+    assert.ok(!stdout.includes('Starting scan'), 'scan should not start with an invalid model');
+  });
 });
 
 // ─── Iteration 7: ERROR and FLAG scenarios ───────────────────────────────────

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -130,6 +130,7 @@ export async function runCLI(
   const dotenvDefaults: Record<string, string | undefined> = {
     AGHAST_LOCAL_CLAUDE: undefined,
     AGHAST_MOCK_AI: undefined,
+    AGHAST_MOCK_CLAUDE_MODELS: undefined,
     CLAUDE_CONFIG_DIR: undefined,
     AGHAST_CONFIG_DIR: '',
     AGHAST_GENERIC_PROMPT: undefined,

--- a/tests/fixtures/runtime-config/invalid-claude-model.json
+++ b/tests/fixtures/runtime-config/invalid-claude-model.json
@@ -1,0 +1,6 @@
+{
+  "agentProvider": {
+    "name": "claude-code",
+    "model": "claude-code/junk"
+  }
+}

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -143,7 +143,9 @@ describe('AgentProvider interface compliance — ClaudeCodeProvider', () => {
   });
 
   it('initialize() stores model correctly (getModelName returns configured model)', async () => {
-    const provider = new ClaudeCodeProvider();
+    const provider = new ClaudeCodeProvider({
+      _listSupportedModelsFn: async () => [{ id: 'claude-opus-4-6' }],
+    });
     await provider.initialize({ apiKey: 'test-key', model: 'claude-opus-4-6' });
     assert.equal(provider.getModelName(), 'claude-opus-4-6');
   });


### PR DESCRIPTION
## Summary
- Validate explicit Claude Code model overrides before a scan starts, including models supplied through `runtime-config.json`.
- Fail with the unsupported model and list the models available to the active Claude Code credentials instead of silently falling through to the SDK default.
- Detect and report model-rejection errors returned during execution as a fallback.
- Continue with a warning if the SDK cannot retrieve its supported-model list for preflight validation.
- Add a hermetic real-CLI regression test for the runtime-config scenario reported in #93.
- Document the model-validation and available-model behavior for users.

Fixes #92.
Fixes #93.

## Validation
- `node --import tsx --test tests\claude-code-provider.test.ts tests\cli-mock-mode-2.test.ts tests\provider-registry.test.ts` — 112 passed
- `npm test` — 910 passed
- `npm run lint`
- `npm run build`