### PR TITLE
fix: Reject unknown scan options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -326,7 +326,18 @@ function parseArgs(args: string[]): {
         i++;
         break;
       }
-      // --fail-on-check-failure and --debug are handled above via includes()
+      case '--fail-on-check-failure':
+      case '--debug':
+        // Boolean flags are handled above via includes().
+        break;
+      default: {
+        const arg = args[i];
+        if (arg?.startsWith('--')) {
+          const suggestion = arg === '--provider' ? ' Did you mean --agent-provider?' : '';
+          console.error(formatError(ERROR_CODES.E1002, `Unknown option: ${arg}.${suggestion}`));
+          process.exit(1);
+        }
+      }
     }
   }
 

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -150,6 +150,42 @@ describe('CLI: ANTHROPIC_API_KEY and --agent-provider flag', () => {
     assert.equal(exitCode, 0);
   });
 
+  it('--agent-provider takes precedence over the provider from runtime config', async () => {
+    const runtimeConfig = resolve(__dirname, 'fixtures', 'runtime-config', 'opencode.json');
+    const { exitCode, stderr } = await runCLI({
+      ANTHROPIC_API_KEY: '',
+      AGHAST_LOCAL_CLAUDE: '',
+      AGHAST_MOCK_AI: undefined,
+      AGHAST_MOCK_LOCAL_LOGIN: 'false',
+    }, [
+      fixtureRepo,
+      '--config-dir', singleCheckConfigDir,
+      '--runtime-config', runtimeConfig,
+      '--agent-provider', 'claude-code',
+      '--model', 'sonnet',
+    ]);
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes('ANTHROPIC_API_KEY'));
+    assert.ok(!stderr.includes('Invalid model format "sonnet" for opencode provider'));
+  });
+
+  it('rejects --provider with a hint to use --agent-provider', async () => {
+    const { exitCode, stderr } = await runCLI({
+      AGHAST_MOCK_AI: 'true',
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--provider', 'claude-code']);
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes('Unknown option: --provider'));
+    assert.ok(stderr.includes('Did you mean --agent-provider?'));
+  });
+
+  it('rejects unknown scan options', async () => {
+    const { exitCode, stderr } = await runCLI({
+      AGHAST_MOCK_AI: 'true',
+    }, [fixtureRepo, '--config-dir', singleCheckConfigDir, '--modle', 'sonnet']);
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes('Unknown option: --modle'));
+  });
+
   it('--model flag is accepted (no error)', async () => {
     const { exitCode } = await runCLI({
       AGHAST_MOCK_AI: 'true',

--- a/tests/fixtures/runtime-config/opencode.json
+++ b/tests/fixtures/runtime-config/opencode.json
@@ -1,0 +1,6 @@
+{
+  "agentProvider": {
+    "name": "opencode",
+    "model": "test-provider/test-model"
+  }
+}


### PR DESCRIPTION
Fixes #94.

## Summary

- Reject unknown options passed to `aghast scan` instead of silently ignoring them.
- Suggest `--agent-provider` when a user passes the build-config-only `--provider` flag.
- Verify that the documented `--agent-provider` flag takes precedence over `agentProvider.name` in runtime configuration.

## Verification

- `npm test` (906 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`
