### PR TITLE
fix: Show every scan option in command help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ Arguments:
   <repo-path>                Path to the repository to scan
 
 General options:
+  -h, --help                 Show this help message
   --config-dir <path>        Config directory containing checks-config.json,
                              checks/ folder, and optionally runtime-config.json.
                              Required unless AGHAST_CONFIG_DIR is set.
@@ -105,6 +106,7 @@ General options:
   --model <model>            AI model override (e.g. claude-sonnet-4-20250514)
   --agent-provider <name>    Agent provider name (default: claude-code)
   --generic-prompt <file>    Generic prompt template filename in prompts/ dir
+  --runtime-config <path>    Path to runtime config file
   --diff-ref <ref>           Git ref to diff against (e.g. HEAD~1, main, SHA).
                              Auto-activates diff filtering on every check whose
                              discovery supports it, unless the check opts out
@@ -126,7 +128,11 @@ Environment variables:
   AGHAST_LOG_LEVEL            Console log level (CLI --log-level takes precedence)
   AGHAST_LOG_FILE             Log file path (CLI --log-file takes precedence)
   AGHAST_LOG_TYPE             Log file handler type (CLI --log-type takes precedence)
+  AGHAST_MOCK_SARIF           Use a SARIF file instead of running Semgrep or Opengrep
+                              (test/development use only)
+  AGHAST_OPENANT_DATASET      Use a pre-generated OpenAnt dataset JSON file
   AGHAST_DIFF_REF             Git ref to diff against (CLI --diff-ref takes precedence)
+  NO_COLOR                    Set to "1" to disable colored output
 
 Examples:
   aghast scan ./my-repo --config-dir ./my-checks
@@ -154,7 +160,7 @@ function parseArgs(args: string[]): {
   budgetLimitCost?: number;
   budgetLimitTokens?: number;
 } {
-  if (args.length < 1 || args[0] === '--help' || args[0] === '-h') {
+  if (args.length < 1 || args.includes('--help') || args.includes('-h')) {
     console.log(SCAN_HELP);
     process.exit(0);
   }

--- a/tests/cli-subcommands.test.ts
+++ b/tests/cli-subcommands.test.ts
@@ -177,8 +177,57 @@ describe('CLI subcommands: scan delegation', () => {
     );
     assert.equal(exitCode, 0);
     assert.ok(stdout.includes('Usage: aghast scan'), 'Should show scan help');
-    assert.ok(stdout.includes('--config-dir'), 'Should describe --config-dir flag');
-    assert.ok(stdout.includes('--debug'), 'Should describe --debug flag');
+    const scanOptions = [
+      '--help',
+      '--config-dir',
+      '--output',
+      '--output-format',
+      '--fail-on-check-failure',
+      '--debug',
+      '--log-level',
+      '--log-file',
+      '--log-type',
+      '--model',
+      '--agent-provider',
+      '--generic-prompt',
+      '--runtime-config',
+      '--diff-ref',
+      '--diff-file',
+      '--budget-limit-cost',
+      '--budget-limit-tokens',
+    ];
+    for (const option of scanOptions) {
+      assert.ok(stdout.includes(option), `Should describe ${option} flag`);
+    }
+    const environmentVariables = [
+      'ANTHROPIC_API_KEY',
+      'AGHAST_CONFIG_DIR',
+      'AGHAST_AI_MODEL',
+      'AGHAST_GENERIC_PROMPT',
+      'AGHAST_DEBUG',
+      'AGHAST_LOG_LEVEL',
+      'AGHAST_LOG_FILE',
+      'AGHAST_LOG_TYPE',
+      'AGHAST_MOCK_SARIF',
+      'AGHAST_OPENANT_DATASET',
+      'AGHAST_DIFF_REF',
+      'NO_COLOR',
+    ];
+    for (const variable of environmentVariables) {
+      assert.ok(stdout.includes(variable), `Should describe ${variable}`);
+    }
+  });
+
+  it('scan help works after the repository path', async () => {
+    for (const helpFlag of ['--help', '-h']) {
+      const { exitCode, stdout, stderr } = await runCLI(
+        ['scan', fixtureRepo, helpFlag],
+        { AGHAST_MOCK_AI: 'true' },
+      );
+      assert.equal(exitCode, 0, `${helpFlag} should exit successfully`);
+      assert.ok(stdout.includes('Usage: aghast scan'), `${helpFlag} should show scan help`);
+      assert.equal(stderr, '', `${helpFlag} should not report an unknown option`);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- list `--runtime-config` and the help flags in `aghast scan --help`
- document the remaining public scan environment variables
- allow `--help` and `-h` after the repository path
- add CLI integration coverage for every supported scan option and documented environment variable

## Verification

- `npm test` (907 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`

Fixes #95