### PR TITLE
fix: Create missing check files for registered checks

### DIFF
--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -269,16 +269,11 @@ async function loadExistingRegistry(registryPath: string): Promise<RegistryFile>
 
 function validateInputs(
   inputs: { id: string; severity: string; confidence: string; checkType: string; discovery: string; analysisMode: string; maxTargets: string; language: string; sarifFile: string },
-  registry: RegistryFile,
 ): string[] {
   const errors: string[] = [];
 
   if (!inputs.id) {
     errors.push('Check ID is required');
-  }
-
-  if (registry.checks.some((c) => c.id === inputs.id)) {
-    errors.push(`Check ID "${inputs.id}" already exists in config`);
   }
 
   const validSeverities = ['critical', 'high', 'medium', 'low', 'informational'];
@@ -573,7 +568,7 @@ export async function runNewCheck(args: string[]): Promise<void> {
     registry = emptyRegistry;
   }
 
-  const validationErrors = validateInputs(inputs, registry);
+  const validationErrors = validateInputs(inputs);
   if (validationErrors.length > 0) {
     for (const err of validationErrors) {
       console.error(formatError(ERROR_CODES.E2004, err));
@@ -587,6 +582,14 @@ export async function runNewCheck(args: string[]): Promise<void> {
     console.error(formatError(ERROR_CODES.E2004, `Check folder already exists: ${checkFolder}`));
     process.exit(1);
   }
+
+  const isAlreadyRegistered = registry.checks.some((check) => check.id === inputs.id);
+  if (isAlreadyRegistered) {
+    console.warn(
+      `Check ID "${inputs.id}" already exists in checks-config.json; creating the missing check files without changing its registry entry.`,
+    );
+  }
+
   await mkdir(checkFolder, { recursive: true });
 
   // Generate and write check.json (Layer 2)
@@ -623,10 +626,12 @@ export async function runNewCheck(args: string[]): Promise<void> {
   }
 
   // Update registry (Layer 1)
-  const registryEntry = generateRegistryEntry(inputs);
-  registry.checks.push(registryEntry as RegistryFile['checks'][number]);
-  await writeFile(registryPath, JSON.stringify(registry, null, 2) + '\n', 'utf-8');
-  console.log(`Updated: ${registryPath}`);
+  if (!isAlreadyRegistered) {
+    const registryEntry = generateRegistryEntry(inputs);
+    registry.checks.push(registryEntry as RegistryFile['checks'][number]);
+    await writeFile(registryPath, JSON.stringify(registry, null, 2) + '\n', 'utf-8');
+    console.log(`Updated: ${registryPath}`);
+  }
 
   console.log(`\nNew check "${inputs.id}" created successfully.`);
 }

--- a/tests/cli-subcommands.test.ts
+++ b/tests/cli-subcommands.test.ts
@@ -8,7 +8,8 @@ import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { unlink, access, readFile } from 'node:fs/promises';
+import { unlink, access, readFile, mkdir, writeFile, rm } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliEntry = resolve(__dirname, '..', 'src', 'cli.ts');
@@ -251,6 +252,51 @@ describe('CLI subcommands: new-check delegation', () => {
     assert.ok(stdout.includes('Usage: aghast new-check'), 'Should show new-check help');
     assert.ok(stdout.includes('--id'), 'Should describe --id flag');
     assert.ok(stdout.includes('--check-type'), 'Should describe --check-type flag');
+  });
+
+  it('new-check creates missing files for an ID already present in checks-config.json', async () => {
+    const configDir = resolve(__dirname, '..', `.tmp-cli-new-check-${randomUUID().slice(0, 8)}`);
+    const registryPath = resolve(configDir, 'checks-config.json');
+    const existingRegistry = {
+      checks: [{
+        id: 'aghast-existing',
+        repositories: ['https://github.com/example/repo'],
+        enabled: false,
+      }],
+    };
+
+    try {
+      await mkdir(resolve(configDir, 'checks'), { recursive: true });
+      await writeFile(registryPath, JSON.stringify(existingRegistry, null, 2), 'utf-8');
+
+      const { exitCode, stderr } = await runCLI([
+        'new-check',
+        '--config-dir', configDir,
+        '--id', 'aghast-existing',
+        '--name', 'Existing Check',
+        '--check-type', 'repository',
+        '--check-overview', 'Checks existing configuration',
+        '--check-items', 'Existing registry entry',
+        '--pass-condition', 'Configuration is valid',
+        '--fail-condition', 'Configuration is invalid',
+      ]);
+
+      assert.equal(exitCode, 0, `CLI failed: ${stderr}`);
+      assert.ok(stderr.includes('already exists in checks-config.json'));
+
+      const checkDefinition = JSON.parse(
+        await readFile(
+          resolve(configDir, 'checks', 'aghast-existing', 'aghast-existing.json'),
+          'utf-8',
+        ),
+      );
+      assert.equal(checkDefinition.id, 'aghast-existing');
+
+      const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+      assert.deepEqual(registry, existingRegistry);
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/new-check.test.ts
+++ b/tests/new-check.test.ts
@@ -262,20 +262,31 @@ describe('new-check utility', () => {
     assert.ok(!mdContent.includes('**FLAG**'), 'FLAG line should not be present');
   });
 
-  it('rejects duplicate check ID', async () => {
-    // Seed registry with an existing check
+  it('creates missing check files without duplicating an existing registry entry', async () => {
+    // Seed registry with an existing check whose folder is missing
     const existingRegistry = {
-      checks: [{ id: 'aghast-test', repositories: [], enabled: true }],
+      checks: [{
+        id: 'aghast-test',
+        repositories: ['https://github.com/example/repo'],
+        enabled: false,
+      }],
     };
     await writeFile(registryPath, JSON.stringify(existingRegistry, null, 2), 'utf-8');
 
     const result = await runNewCheck(allFlags());
 
-    assert.notEqual(result.exitCode, 0, 'Should have failed for duplicate ID');
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
     assert.ok(
-      result.stderr.includes('already exists'),
-      `Expected duplicate error, got: ${result.stderr}`,
+      result.stderr.includes('already exists in checks-config.json'),
+      `Expected existing-registry warning, got: ${result.stderr}`,
     );
+
+    const checkJsonPath = resolve(checksDir, 'aghast-test', 'aghast-test.json');
+    const checkDef = JSON.parse(await readFile(checkJsonPath, 'utf-8'));
+    assert.equal(checkDef.id, 'aghast-test');
+
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    assert.deepEqual(registry, existingRegistry, 'Existing registry entry should remain unchanged');
   });
 
   it('rejects when check folder already exists', async () => {


### PR DESCRIPTION
## Summary

- create check scaffold files when the ID already exists only in `checks-config.json`
- preserve the existing registry entry and avoid adding a duplicate
- continue refusing to overwrite any existing check folder
- add utility-level and unified CLI regression coverage

Fixes #97.

## Verification

- `npm test` (910 tests passed before the final CLI regression addition)
- `node --import tsx --test tests/new-check.test.ts tests/cli-subcommands.test.ts` (62 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`