### PR TITLE
Add HTML and CSV output formatters, fix CI merged-PR detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
           fi
 
           # ── Push path ────────────────────────────────────────────────────
-          # Find the merged PR that produced this commit
-          PR_NUM=$(gh pr list --state merged --json number,mergeCommit \
-            --jq ".[] | select(.mergeCommit.oid == \"$COMMIT_SHA\") | .number")
+          # Find the merged PR that produced this commit.  Query the commit
+          # association directly: `gh pr list` defaults to 30 results, so it
+          # can miss a PR that has been open for a while before merging.
+          PR_NUM=$(gh api "repos/$GH_REPO/commits/$COMMIT_SHA/pulls" \
+            --jq '.[] | select(.merged_at != null) | .number')
 
           if [ -z "$PR_NUM" ]; then
             # Direct push: skip if only markdown files changed and last CI run passed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,7 +335,7 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | `agentProvider.name`            | `string`   | `claude-code` | Agent provider name (`claude-code` or `opencode`) |
 | `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/nemotron-3-super-free`) |
 | `reporting.outputDirectory`     | `string`   | (target repo) | Directory for result files |
-| `reporting.outputFormat`        | `string`   | `json` | Output format: `json` or `sarif` |
+| `reporting.outputFormat`        | `string`   | `json` | Output format: `json`, `sarif`, `csv`, or `html` (see [Scanning › Output Formats](scanning.md#output-formats)) |
 | `logging.logFile`               | `string`   | (none) | Path to log file. When set, all log output is written to this file |
 | `logging.logType`               | `string`   | `file` | Log file handler type. Pluggable; currently only `file` is supported |
 | `logging.level`                 | `string`   | `info` | Console log level: `error`, `warn`, `info`, `debug`, `trace` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,7 @@ This guide walks you through installing aghast and setting up your environment.
 
   See [Scanning → Agent Providers](scanning.md#agent-providers) for the full comparison.
 - For checks that use `semgrep` discovery: **[Semgrep Community Edition](https://semgrep.dev/docs/getting-started/)** (LGPL-2.1)
+- For checks that use `opengrep` discovery: **[Opengrep](https://github.com/opengrep/opengrep)**
 - For checks that use `openant` discovery: **[OpenAnt](https://github.com/knostic/OpenAnt)** (Apache-2.0) + **Python 3.11+** + **Go** (for building CLI)
 
 ## 1. Install aghast

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -19,7 +19,7 @@ aghast scan <repo-path> --config-dir <path> [options]
 |--------|-------------|
 | `--config-dir <path>` | **(Required)** Config directory containing `checks-config.json` and `checks/` folder |
 | `--output <path>` | Output file path (default: `<repo-path>/security_checks_results.<ext>`) |
-| `--output-format json\|sarif` | Output format (default: `json`) |
+| `--output-format <fmt>` | Output format: `json`, `sarif`, `csv`, `html` (default: `json`) |
 | `--fail-on-check-failure` | Exit with code 1 if any check FAILs or ERRORs |
 | `--debug` | Shorthand for `--log-level debug` |
 | `--log-level <level>` | Console log level: `error`, `warn`, `info`, `debug`, `trace` (default: `info`) |
@@ -89,6 +89,8 @@ Results are written to `security_checks_results.<ext>` in the target repo by def
 
 - **JSON** (default) - structured results with summary, per-check details, issues, and token usage
 - **SARIF** - SARIF 2.1.0 output compatible with GitHub Code Scanning and other SARIF viewers
+- **CSV** - one row per issue (plus one row per `ERROR` check) for spreadsheet analysis. UTF-8 encoded, no BOM, RFC 4180 quoting, CRLF line endings. Descriptions are flattened to a single line and truncated to 500 chars. The structured `dataFlow` taint trace is omitted; use SARIF or JSON for the full trace.
+- **HTML** - self-contained interactive report with inline CSS/JS and the full `ScanResults` embedded as a JSON island. Includes filterable issues table, severity/status badges, expandable per-check sections, and code snippets. No external resources, so the file can be emailed or hosted as-is.
 
 ## Check Types
 

--- a/docs/trying-it-out.md
+++ b/docs/trying-it-out.md
@@ -61,7 +61,7 @@ The repo includes six example checks demonstrating the three check types (`repos
 |---|---------|------------|-----------|---------------|----------|
 | 1 | [Business Logic Bypass](#example-1-business-logic-bypass-repository-check) | repository | — | — | API key |
 | 2 | [Important Validations before AI Queries](#example-2-important-validations-before-ai-queries-targeted-check-semgrep-discovery) | targeted | Semgrep | custom | API key, Semgrep |
-| 3 | [Missing API Token Decorator](#example-3-missing-api-token-decorator-static-check-semgrep-discovery) | static | Semgrep | — | Semgrep |
+| 3 | [Missing API Token Decorator](#example-3-missing-api-token-decorator-static-check-opengrep-discovery) | static | Opengrep | — | Opengrep |
 | 4 | [SAST Finding Verification](#example-4-sast-finding-verification-targeted-check-sarif-input-false-positive-validation) | targeted | SARIF input | false-positive validation | API key |
 | 5 | [Various Security Vulnerabilities](#example-5-various-security-vulnerabilities-targeted-check-openant-discovery-general-vulnerability-analysis) | targeted | OpenAnt | general vulnerability discovery | API key, OpenAnt |
 | 6 | [Diff-Scoped Validation Scanning](#example-6-diff-scoped-validation-scanning-targeted-check-semgrep-discovery-with-diff-filtering) | targeted | Semgrep | custom | API key, Semgrep |
@@ -179,13 +179,11 @@ FAIL with 2 issues: Semgrep finds 3 targets (endpoints calling `send_ai_query()`
 
 ---
 
-### Example 3: Missing API Token Decorator (static check, Semgrep discovery)
-
-[Click for a video walkthrough of running this example.](https://youtu.be/2P8yAWRJSLk)
+### Example 3: Missing API Token Decorator (static check, Opengrep discovery)
 
 #### Check type
 
-`static` with `semgrep` discovery. Semgrep findings are mapped directly to issues with no AI involvement.
+`static` with `opengrep` discovery. Opengrep findings are mapped directly to issues with no AI involvement.
 
 #### What it does
 
@@ -201,13 +199,13 @@ Detects Flask route handlers that are missing the `@require_api_token` decorator
   "confidence": "high",
   "checkTarget": {
     "type": "static",
-    "discovery": "semgrep",
+    "discovery": "opengrep",
     "rules": "aghast-py-missing-token-decorator.yaml"
   }
 }
 ```
 
-With `checkTarget.type` set to `static`, there is no instructions file. The Semgrep rule does all the work:
+With `checkTarget.type` set to `static`, there is no instructions file. The Opengrep rule does all the work. Opengrep uses the same rule syntax as Semgrep:
 
 ```yaml
 rules:
@@ -232,13 +230,13 @@ rules:
     severity: ERROR
 ```
 
-Each Semgrep match is mapped directly to a `SecurityIssue`. No API key needed.
+Each Opengrep match is mapped directly to a `SecurityIssue`. No API key needed.
 
 #### Test codebase
 
 `test-codebases/test-7-missing-token-decorator/` - a Python Flask app with several route handlers, some missing the required decorator.
 
-#### Run it (requires Semgrep, no API key):
+#### Run it (requires Opengrep, no API key):
 
 ```bash
 aghast scan ./aghast-bounce-checks-public/test-codebases/test-7-missing-token-decorator \
@@ -248,7 +246,7 @@ aghast scan ./aghast-bounce-checks-public/test-codebases/test-7-missing-token-de
 
 #### Expected result
 
-FAIL with 4 issues: four endpoints across three route files are missing the `@require_api_token` decorator. Health and readiness endpoints are correctly excluded by the Semgrep rule's regex filter.
+FAIL with 4 issues: four endpoints across three route files are missing the `@require_api_token` decorator. Health and readiness endpoints are correctly excluded by the Opengrep rule's regex filter.
 
 ---
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -143,7 +143,7 @@ Field flags (any value provided here skips its prompt; closed lists are validate
   --model <id>                  Model ID. Must be one returned by the provider's
                                 listModels() (skip flag and use interactive mode to
                                 browse the live list).
-  --output-format <fmt>         Output format: json | sarif
+  --output-format <fmt>         Output format: json | sarif | csv | html
   --output-directory <path>     Default output directory for results
   --log-level <level>           Console log level: error | warn | info | debug | trace
   --log-file <path>             Log file path (omit to disable)

--- a/src/formatters/csv-formatter.ts
+++ b/src/formatters/csv-formatter.ts
@@ -1,0 +1,127 @@
+/**
+ * CSV output formatter — one row per SecurityIssue (plus a row per ERROR check)
+ * for spreadsheet analysis (Excel, Google Sheets, etc.).
+ *
+ * Output contract:
+ *   - Encoding: UTF-8, no BOM. Excel-on-Windows may render non-ASCII bytes as
+ *     mojibake when a CSV is opened directly without an encoding hint; consumers
+ *     that need Excel auto-detection should use the JSON or SARIF output instead,
+ *     or import the CSV via Excel's "From Text/CSV" wizard which lets you pick
+ *     UTF-8 explicitly.
+ *   - Line terminator: CRLF (RFC 4180). Final row is also CRLF-terminated.
+ *   - Quoting: RFC 4180 — fields containing `,`, `"`, CR, or LF are wrapped in
+ *     double quotes; embedded `"` is doubled.
+ *   - Description: flattened to a single line (CR/LF/CRLF → single space) and
+ *     truncated to {@link DESCRIPTION_MAX_LENGTH} chars with a U+2026 ellipsis.
+ *   - The structured `dataFlow` taint trace on `SecurityIssue` is intentionally
+ *     omitted — flat per-issue rows can't represent a list well; SARIF/JSON
+ *     output keeps the full trace.
+ */
+
+import type { ScanResults, SecurityIssue, CheckExecutionSummary } from '../types.js';
+import type { OutputFormatter } from './types.js';
+
+/** Maximum length of the description field in CSV output (longer values are truncated with an ellipsis). */
+const DESCRIPTION_MAX_LENGTH = 500;
+
+const CSV_HEADERS = [
+  'checkId',
+  'checkName',
+  'status',
+  'file',
+  'startLine',
+  'endLine',
+  'severity',
+  'confidence',
+  'description',
+  'recommendation',
+] as const;
+
+/** Escapes a single CSV field per RFC 4180. */
+export function escapeCsvField(value: string | number | undefined): string {
+  if (value === undefined || value === null) return '';
+  const str = String(value);
+  // Wrap in quotes if it contains a comma, quote, CR, or LF.
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Truncates a description to fit within the CSV column and replaces newlines
+ * with spaces so each issue stays on a single row.
+ */
+export function normalizeDescription(description: string): string {
+  // Replace any sequence of CR/LF with a single space so the cell stays on one line
+  // (CSV viewers do support multi-line cells via quoting, but flattening keeps spreadsheets readable).
+  const flattened = description.replace(/\r\n|\r|\n/g, ' ').replace(/\s+/g, ' ').trim();
+  if (flattened.length <= DESCRIPTION_MAX_LENGTH) return flattened;
+  return flattened.slice(0, DESCRIPTION_MAX_LENGTH - 1) + '…'; // ellipsis
+}
+
+function statusForIssue(issue: SecurityIssue, checkStatusByCheckId: Map<string, string>): string {
+  // Fall back to 'UNKNOWN' (not 'FAIL') for orphaned issues so a row in the
+  // spreadsheet doesn't claim a check status that wasn't actually reported.
+  return checkStatusByCheckId.get(issue.checkId) ?? 'UNKNOWN';
+}
+
+function issueRow(issue: SecurityIssue, checkStatus: string): string {
+  return [
+    escapeCsvField(issue.checkId),
+    escapeCsvField(issue.checkName),
+    escapeCsvField(checkStatus),
+    escapeCsvField(issue.file),
+    escapeCsvField(issue.startLine),
+    escapeCsvField(issue.endLine),
+    escapeCsvField(issue.severity),
+    escapeCsvField(issue.confidence),
+    escapeCsvField(normalizeDescription(issue.description)),
+    escapeCsvField(issue.recommendation),
+  ].join(',');
+}
+
+function errorCheckRow(check: CheckExecutionSummary): string {
+  // Surface execution errors so they show up alongside issues in spreadsheets.
+  // No file/line/severity/confidence/recommendation — just the error in the description column.
+  const description = normalizeDescription(check.error ? `Check execution error: ${check.error}` : 'Check execution error');
+  return [
+    escapeCsvField(check.checkId),
+    escapeCsvField(check.checkName),
+    escapeCsvField(check.status),
+    '', // file
+    '', // startLine
+    '', // endLine
+    '', // severity
+    '', // confidence
+    escapeCsvField(description),
+    '', // recommendation
+  ].join(',');
+}
+
+export class CsvFormatter implements OutputFormatter {
+  readonly id = 'csv';
+  readonly fileExtension = '.csv';
+
+  format(results: ScanResults): string {
+    const checkStatusByCheckId = new Map<string, string>();
+    for (const check of results.checks) {
+      checkStatusByCheckId.set(check.checkId, check.status);
+    }
+
+    const lines: string[] = [CSV_HEADERS.join(',')];
+
+    for (const issue of results.issues) {
+      lines.push(issueRow(issue, statusForIssue(issue, checkStatusByCheckId)));
+    }
+
+    for (const check of results.checks) {
+      if (check.status === 'ERROR') {
+        lines.push(errorCheckRow(check));
+      }
+    }
+
+    // RFC 4180 specifies CRLF line endings.
+    return lines.join('\r\n') + '\r\n';
+  }
+}

--- a/src/formatters/html-formatter.ts
+++ b/src/formatters/html-formatter.ts
@@ -1,0 +1,411 @@
+/**
+ * HTML output formatter — self-contained interactive report.
+ *
+ * Emits a single .html file with inline CSS + JS. Includes:
+ *   - Header with title, scan timestamp, repository info
+ *   - Summary statistics (totals + per-status counters)
+ *   - Filterable, severity-badged issues table
+ *   - Expandable per-check sections with optional code snippets
+ *   - The full `ScanResults` embedded as a JSON island for client-side filtering
+ *
+ * All user-controlled strings are HTML-escaped via `escapeHtml`. The embedded
+ * JSON has `</` sequences neutralised so an attacker-controlled string cannot
+ * break out of the `<script type="application/json">` tag.
+ */
+
+import type {
+  ScanResults,
+  SecurityIssue,
+  CheckExecutionSummary,
+  RepositoryInfo,
+  ScanSummary,
+} from '../types.js';
+import type { OutputFormatter } from './types.js';
+
+/** Escapes the five HTML special characters. */
+export function escapeHtml(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  const str = String(value);
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Embeds JSON inside a `<script type="application/json">` block safely.
+ *
+ * Two patterns matter for HTML's script-data tokenizer:
+ *   1. `</` — replaced with `<\/` so a stray `</script>` cannot terminate the
+ *      script element early. `\/` is valid JSON for `/`, so JSON.parse
+ *      round-trips faithfully.
+ *   2. `<!--` — the script-data tokenizer enters a "script data escaped"
+ *      state on `<!--`, in which a nested `<script>...</script>` pair can
+ *      terminate the outer element ahead of the literal closing tag we control.
+ *      Encoding `<` as the Unicode escape `<` is unambiguous JSON
+ *      (parses back to `<`) and prevents the tokenizer from ever entering the
+ *      escaped state.
+ */
+export function escapeJsonForScriptTag(json: string): string {
+  return json
+    .replace(/<\//g, '<\\/')
+    .replace(/<!--/g, '\\u003c!--');
+}
+
+function severityClass(severity: string | undefined): string {
+  switch (severity) {
+    case 'critical':
+    case 'high':
+      return 'sev-high';
+    case 'medium':
+      return 'sev-medium';
+    case 'low':
+    case 'informational':
+      return 'sev-low';
+    default:
+      return 'sev-unknown';
+  }
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case 'PASS':
+      return 'status-pass';
+    case 'FAIL':
+      return 'status-fail';
+    case 'FLAG':
+      return 'status-flag';
+    case 'ERROR':
+      return 'status-error';
+    default:
+      return 'status-unknown';
+  }
+}
+
+const CSS = `
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --fg: #1f2329;
+  --muted: #6a7280;
+  --card: #ffffff;
+  --border: #e2e5ea;
+  --pass: #15803d;
+  --fail: #b91c1c;
+  --flag: #b45309;
+  --error: #6b21a8;
+  --sev-high: #b91c1c;
+  --sev-medium: #b45309;
+  --sev-low: #2563eb;
+  --sev-unknown: #6a7280;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14171c;
+    --fg: #e6e8eb;
+    --muted: #9ba1aa;
+    --card: #1c2026;
+    --border: #2a2f37;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+}
+.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+header { margin-bottom: 24px; }
+header h1 { margin: 0 0 4px; font-size: 1.6rem; }
+header .meta { color: var(--muted); font-size: 0.9rem; }
+.muted { color: var(--muted); }
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+.stat {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  text-align: center;
+}
+.stat .num { font-size: 1.6rem; font-weight: 600; }
+.stat .label { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fff;
+}
+.badge.sev-high { background: var(--sev-high); }
+.badge.sev-medium { background: var(--sev-medium); }
+.badge.sev-low { background: var(--sev-low); }
+.badge.sev-unknown { background: var(--sev-unknown); }
+.badge.status-pass { background: var(--pass); }
+.badge.status-fail { background: var(--fail); }
+.badge.status-flag { background: var(--flag); }
+.badge.status-error { background: var(--error); }
+.badge.status-unknown { background: var(--sev-unknown); }
+.controls { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+.controls input, .controls select {
+  background: var(--card);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font: inherit;
+}
+table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+th, td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+th { background: var(--card); font-weight: 600; }
+tr.hidden { display: none; }
+details { margin-top: 8px; }
+details summary { cursor: pointer; font-weight: 600; }
+pre.snippet {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  margin: 8px 0 0;
+}
+.empty { color: var(--muted); font-style: italic; }
+footer { color: var(--muted); font-size: 0.8rem; text-align: center; margin: 32px 0 16px; }
+`;
+
+const CLIENT_JS = `
+(function () {
+  var data;
+  try {
+    data = JSON.parse(document.getElementById('aghast-results').textContent);
+  } catch (e) {
+    return;
+  }
+  var search = document.getElementById('filter-search');
+  var severity = document.getElementById('filter-severity');
+  var status = document.getElementById('filter-status');
+  var rows = Array.prototype.slice.call(document.querySelectorAll('#issues-table tbody tr'));
+
+  function applyFilters() {
+    var q = (search.value || '').toLowerCase();
+    var sev = severity.value;
+    var st = status.value;
+    rows.forEach(function (row) {
+      var text = row.getAttribute('data-search') || '';
+      var rowSev = row.getAttribute('data-severity') || '';
+      var rowStatus = row.getAttribute('data-status') || '';
+      var matches = (!q || text.indexOf(q) !== -1)
+        && (!sev || rowSev === sev)
+        && (!st || rowStatus === st);
+      row.classList.toggle('hidden', !matches);
+    });
+  }
+
+  if (search) search.addEventListener('input', applyFilters);
+  if (severity) severity.addEventListener('change', applyFilters);
+  if (status) status.addEventListener('change', applyFilters);
+
+  // Expose data for debugging / extensibility.
+  window.aghastResults = data;
+})();
+`;
+
+function renderHeader(results: ScanResults): string {
+  const repo = results.repository;
+  const repoLabel = repo.remoteUrl
+    ? `${escapeHtml(repo.remoteUrl)}`
+    : escapeHtml(repo.path);
+  const branch = repo.branch ? ` <span class="muted">on ${escapeHtml(repo.branch)}</span>` : '';
+  const commit = repo.commit ? ` <span class="muted">@ ${escapeHtml(repo.commit.slice(0, 12))}</span>` : '';
+  return `
+    <header>
+      <h1>aghast Security Scan Report</h1>
+      <div class="meta">
+        Scan ID: <code>${escapeHtml(results.scanId)}</code> &middot;
+        Generated: ${escapeHtml(results.timestamp)} &middot;
+        Provider: ${escapeHtml(results.agentProvider.name)}
+      </div>
+      <div class="meta">
+        Repository: ${repoLabel}${branch}${commit}
+      </div>
+    </header>
+  `;
+}
+
+function renderSummary(summary: ScanSummary, _repo: RepositoryInfo): string {
+  return `
+    <section class="summary-grid">
+      <div class="stat"><div class="num">${summary.totalChecks}</div><div class="label">Checks</div></div>
+      <div class="stat"><div class="num">${summary.passedChecks}</div><div class="label">Passed</div></div>
+      <div class="stat"><div class="num">${summary.failedChecks}</div><div class="label">Failed</div></div>
+      <div class="stat"><div class="num">${summary.flaggedChecks}</div><div class="label">Flagged</div></div>
+      <div class="stat"><div class="num">${summary.errorChecks}</div><div class="label">Errors</div></div>
+      <div class="stat"><div class="num">${summary.totalIssues}</div><div class="label">Issues</div></div>
+    </section>
+  `;
+}
+
+function renderIssuesTable(issues: SecurityIssue[], statusByCheck: Map<string, string>): string {
+  if (issues.length === 0) {
+    return `<section class="card"><h2>Issues</h2><p class="empty">No issues detected.</p></section>`;
+  }
+  const rows = issues.map((issue) => {
+    const sev = issue.severity ?? '';
+    const sevCls = severityClass(issue.severity);
+    const sevBadge = `<span class="badge ${sevCls}">${escapeHtml(sev || 'unknown')}</span>`;
+    // Fall back to 'UNKNOWN' (not 'FAIL') for orphaned issues so the row's
+    // status badge and the data-status filter don't lie when an issue
+    // references a checkId that isn't in the checks list.
+    const status = statusByCheck.get(issue.checkId) ?? 'UNKNOWN';
+    const statusCls = statusClass(status);
+    const statusBadge = `<span class="badge ${statusCls}">${escapeHtml(status)}</span>`;
+    const searchBlob = `${issue.checkId} ${issue.checkName} ${issue.file} ${issue.description}`.toLowerCase();
+    return `
+      <tr data-severity="${escapeHtml(sev)}" data-status="${escapeHtml(status)}" data-search="${escapeHtml(searchBlob)}">
+        <td>${escapeHtml(issue.checkId)}</td>
+        <td>${escapeHtml(issue.checkName)}</td>
+        <td>${statusBadge}</td>
+        <td>${sevBadge}</td>
+        <td><code>${escapeHtml(issue.file)}</code>:${escapeHtml(issue.startLine)}-${escapeHtml(issue.endLine)}</td>
+        <td>${escapeHtml(issue.description)}</td>
+      </tr>
+    `;
+  }).join('');
+  return `
+    <section class="card">
+      <h2>Issues</h2>
+      <div class="controls">
+        <input id="filter-search" type="search" placeholder="Filter by text..." />
+        <select id="filter-severity">
+          <option value="">All severities</option>
+          <option value="critical">Critical</option>
+          <option value="high">High</option>
+          <option value="medium">Medium</option>
+          <option value="low">Low</option>
+          <option value="informational">Informational</option>
+        </select>
+        <select id="filter-status">
+          <option value="">All statuses</option>
+          <option value="PASS">Pass</option>
+          <option value="FAIL">Fail</option>
+          <option value="FLAG">Flag</option>
+          <option value="ERROR">Error</option>
+        </select>
+      </div>
+      <table id="issues-table" aria-label="Security issues">
+        <thead>
+          <tr><th>Check ID</th><th>Check</th><th>Status</th><th>Severity</th><th>Location</th><th>Description</th></tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </section>
+  `;
+}
+
+function renderCheckDetails(checks: CheckExecutionSummary[], issuesByCheck: Map<string, SecurityIssue[]>): string {
+  if (checks.length === 0) {
+    return '';
+  }
+  const sections = checks.map((check) => {
+    const checkIssues = issuesByCheck.get(check.checkId) ?? [];
+    const statusBadge = `<span class="badge ${statusClass(check.status)}">${escapeHtml(check.status)}</span>`;
+    const errorBlock = check.error
+      ? `<p><strong>Error:</strong> ${escapeHtml(check.error)}</p>`
+      : '';
+    const issuesBlock = checkIssues.length === 0
+      ? '<p class="empty">No issues for this check.</p>'
+      : checkIssues.map((issue) => {
+        const snippet = issue.codeSnippet
+          ? `<pre class="snippet">${escapeHtml(issue.codeSnippet)}</pre>`
+          : '';
+        const recommendation = issue.recommendation
+          ? `<p><strong>Recommendation:</strong> ${escapeHtml(issue.recommendation)}</p>`
+          : '';
+        return `
+          <div class="card">
+            <div><strong><code>${escapeHtml(issue.file)}</code>:${escapeHtml(issue.startLine)}-${escapeHtml(issue.endLine)}</strong>
+              ${issue.severity ? `<span class="badge ${severityClass(issue.severity)}">${escapeHtml(issue.severity)}</span>` : ''}
+            </div>
+            <p>${escapeHtml(issue.description)}</p>
+            ${recommendation}
+            ${snippet}
+          </div>
+        `;
+      }).join('');
+    return `
+      <details>
+        <summary>${escapeHtml(check.checkName)} (${escapeHtml(check.checkId)}) ${statusBadge} &middot; ${check.issuesFound} issue(s)</summary>
+        ${errorBlock}
+        ${issuesBlock}
+      </details>
+    `;
+  }).join('');
+  return `<section class="card"><h2>Checks</h2>${sections}</section>`;
+}
+
+export class HtmlFormatter implements OutputFormatter {
+  readonly id = 'html';
+  readonly fileExtension = '.html';
+
+  format(results: ScanResults): string {
+    const statusByCheck = new Map<string, string>();
+    const issuesByCheck = new Map<string, SecurityIssue[]>();
+    for (const check of results.checks) {
+      statusByCheck.set(check.checkId, check.status);
+      issuesByCheck.set(check.checkId, []);
+    }
+    for (const issue of results.issues) {
+      const arr = issuesByCheck.get(issue.checkId);
+      if (arr) arr.push(issue);
+      else issuesByCheck.set(issue.checkId, [issue]);
+    }
+
+    const embeddedJson = escapeJsonForScriptTag(JSON.stringify(results));
+    const title = `aghast scan ${escapeHtml(results.scanId)}`;
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+  <style>${CSS}</style>
+</head>
+<body>
+  <div class="container">
+    ${renderHeader(results)}
+    ${renderSummary(results.summary, results.repository)}
+    ${renderIssuesTable(results.issues, statusByCheck)}
+    ${renderCheckDetails(results.checks, issuesByCheck)}
+    <footer>Generated by aghast v${escapeHtml(results.version)}</footer>
+  </div>
+  <script id="aghast-results" type="application/json">${embeddedJson}</script>
+  <script>${CLIENT_JS}</script>
+</body>
+</html>
+`;
+  }
+}

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -5,12 +5,16 @@
 import type { OutputFormatter } from './types.js';
 import { JsonFormatter } from './json-formatter.js';
 import { SarifFormatter } from './sarif-formatter.js';
+import { CsvFormatter } from './csv-formatter.js';
+import { HtmlFormatter } from './html-formatter.js';
 
 export type { OutputFormatter } from './types.js';
 
 const formatters = new Map<string, OutputFormatter>([
   ['json', new JsonFormatter()],
   ['sarif', new SarifFormatter()],
+  ['csv', new CsvFormatter()],
+  ['html', new HtmlFormatter()],
 ]);
 
 /** Returns the formatter for the given ID, or throws listing available formats. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ General options:
                              Required unless AGHAST_CONFIG_DIR is set.
   --output <path>            Output file path for results
                              (default: <repo-path>/security_checks_results.<ext>)
-  --output-format json|sarif Output format (default: json)
+  --output-format <fmt>      Output format: json, sarif, csv, html (default: json)
   --fail-on-check-failure    Exit with code 1 if any check FAILs or ERRORs
   --debug                    Shorthand for --log-level debug
   --log-level <level>        Console log level: error, warn, info, debug, trace

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -21,6 +21,8 @@ import {
   fixtureRepo,
   outputFile,
   sarifOutputFile,
+  csvOutputFile,
+  htmlOutputFile,
   singleCheckConfigDir,
   multiCheckConfigDir,
   repoFilteredConfigDir,
@@ -738,6 +740,117 @@ describe('CLI mock mode: output format', () => {
     );
     const combined = stdout + stderr;
     assert.ok(combined.includes('.sarif'), 'Summary should show .sarif path');
+  });
+});
+
+// ─── Output format: CSV ──────────────────────────────────────────────────────
+
+describe('CLI mock mode: CSV output format', () => {
+  afterEach(cleanupOutput);
+
+  it('--output-format csv with PASS writes a .csv with header row only', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
+    );
+    assert.equal(exitCode, 0);
+    await access(csvOutputFile);
+
+    const raw = await readFile(csvOutputFile, 'utf-8');
+    const lines = raw.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 1, 'PASS scan should have header row only');
+    assert.ok(lines[0].startsWith('checkId,checkName,status,'));
+  });
+
+  it('--output-format csv with FAIL writes one row per issue', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: failFixtureRepo },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
+    );
+    assert.equal(exitCode, 0);
+    await access(csvOutputFile);
+
+    const raw = await readFile(csvOutputFile, 'utf-8');
+    const lines = raw.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2, 'FAIL scan with 1 issue: header + 1 issue row');
+    assert.ok(lines[1].includes('aghast-sql-injection'));
+    assert.ok(lines[1].includes('FAIL'));
+  });
+
+  it('CSV format does not write .json file', async () => {
+    await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
+    );
+    await assert.rejects(
+      access(outputFile),
+      'Should NOT create .json file when using csv format',
+    );
+  });
+
+  it('summary banner shows correct .csv path', async () => {
+    const { stdout, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
+    );
+    const combined = stdout + stderr;
+    assert.ok(combined.includes('.csv'), 'Summary should show .csv path');
+  });
+});
+
+// ─── Output format: HTML ─────────────────────────────────────────────────────
+
+describe('CLI mock mode: HTML output format', () => {
+  afterEach(cleanupOutput);
+
+  it('--output-format html with PASS writes a self-contained HTML file', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
+    );
+    assert.equal(exitCode, 0);
+    await access(htmlOutputFile);
+
+    const raw = await readFile(htmlOutputFile, 'utf-8');
+    assert.ok(raw.startsWith('<!DOCTYPE html>'), 'should start with DOCTYPE');
+    assert.ok(raw.includes('<style>'), 'should include inline CSS');
+    assert.ok(raw.includes('<script id="aghast-results"'), 'should include embedded JSON');
+    assert.ok(raw.includes('No issues detected'), 'PASS scan should show empty-state message');
+  });
+
+  it('--output-format html with FAIL embeds issue data in the HTML', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: failFixtureRepo },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
+    );
+    assert.equal(exitCode, 0);
+    await access(htmlOutputFile);
+
+    const raw = await readFile(htmlOutputFile, 'utf-8');
+    assert.ok(raw.includes('aghast-sql-injection'));
+    assert.ok(raw.includes('SQL Injection Prevention'));
+    // Expect a <details> block per check
+    assert.ok(raw.includes('<details>'));
+  });
+
+  it('HTML format does not write .json file', async () => {
+    await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
+    );
+    await assert.rejects(
+      access(outputFile),
+      'Should NOT create .json file when using html format',
+    );
+  });
+
+  it('summary banner shows correct .html path', async () => {
+    const { stdout, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
+    );
+    const combined = stdout + stderr;
+    assert.ok(combined.includes('.html'), 'Summary should show .html path');
   });
 });
 

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -44,6 +44,8 @@ export const entryPoint = resolve(testDir, '..', 'src', 'index.ts');
 // Default output paths (used by cli-mock-mode.test.ts part 1)
 export const outputFile = resolve(fixtureRepo, 'security_checks_results.json');
 export const sarifOutputFile = resolve(fixtureRepo, 'security_checks_results.sarif');
+export const csvOutputFile = resolve(fixtureRepo, 'security_checks_results.csv');
+export const htmlOutputFile = resolve(fixtureRepo, 'security_checks_results.html');
 
 // Per-scenario config dirs (each contains checks-config.json and checks/ subfolder)
 export const singleCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'single-check');
@@ -165,7 +167,7 @@ export async function runCLI(
 }
 
 export async function cleanupOutput(): Promise<void> {
-  for (const f of [outputFile, sarifOutputFile]) {
+  for (const f of [outputFile, sarifOutputFile, csvOutputFile, htmlOutputFile]) {
     try {
       await unlink(f);
     } catch {

--- a/tests/csv-formatter.test.ts
+++ b/tests/csv-formatter.test.ts
@@ -1,0 +1,255 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CsvFormatter,
+  escapeCsvField,
+  normalizeDescription,
+} from '../src/formatters/csv-formatter.js';
+import type { ScanResults } from '../src/types.js';
+
+function makeResults(overrides: Partial<ScanResults> = {}): ScanResults {
+  return {
+    scanId: 'scan-20260101120000-abc123',
+    timestamp: '2026-01-01T12:00:00.000Z',
+    version: '0.1.0',
+    repository: { path: '/tmp/repo', isGitRepository: true },
+    issues: [],
+    checks: [],
+    summary: { totalChecks: 0, passedChecks: 0, failedChecks: 0, flaggedChecks: 0, errorChecks: 0, totalIssues: 0 },
+    executionTime: 100,
+    startTime: '2026-01-01T12:00:00.000Z',
+    endTime: '2026-01-01T12:00:00.100Z',
+    agentProvider: { name: 'mock', models: ['mock'] },
+    ...overrides,
+  };
+}
+
+describe('CsvFormatter', () => {
+  const formatter = new CsvFormatter();
+
+  it('id is "csv"', () => {
+    assert.equal(formatter.id, 'csv');
+  });
+
+  it('fileExtension is ".csv"', () => {
+    assert.equal(formatter.fileExtension, '.csv');
+  });
+
+  it('empty results emits header row only', () => {
+    const out = formatter.format(makeResults());
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 1);
+    assert.equal(
+      lines[0],
+      'checkId,checkName,status,file,startLine,endLine,severity,confidence,description,recommendation',
+    );
+  });
+
+  it('all-pass scan (no issues, no errors) emits header row only', () => {
+    const results = makeResults({
+      checks: [
+        { checkId: 'c1', checkName: 'Check 1', status: 'PASS', issuesFound: 0, executionTime: 10 },
+        { checkId: 'c2', checkName: 'Check 2', status: 'PASS', issuesFound: 0, executionTime: 10 },
+      ],
+      summary: { totalChecks: 2, passedChecks: 2, failedChecks: 0, flaggedChecks: 0, errorChecks: 0, totalIssues: 0 },
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 1, 'only header row');
+  });
+
+  it('single issue produces a header + issue row with correct columns', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'src/app.ts', startLine: 10, endLine: 15,
+        description: 'SQL injection', severity: 'high', confidence: 'medium',
+        recommendation: 'Use parameterized queries',
+      }],
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2);
+    assert.equal(
+      lines[1],
+      'c1,C1,FAIL,src/app.ts,10,15,high,medium,SQL injection,Use parameterized queries',
+    );
+  });
+
+  it('mix of pass and fail checks: only fail issues + error rows are emitted', () => {
+    const results = makeResults({
+      checks: [
+        { checkId: 'c1', checkName: 'Pass One', status: 'PASS', issuesFound: 0, executionTime: 10 },
+        { checkId: 'c2', checkName: 'Fail One', status: 'FAIL', issuesFound: 1, executionTime: 10 },
+      ],
+      issues: [{
+        checkId: 'c2', checkName: 'Fail One',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'bad',
+      }],
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2);
+    assert.ok(lines[1].startsWith('c2,Fail One,FAIL,a.ts,'));
+  });
+
+  it('ERROR-status check produces a row even with no issues', () => {
+    const results = makeResults({
+      checks: [{
+        checkId: 'broken', checkName: 'Broken Check', status: 'ERROR',
+        issuesFound: 0, executionTime: 5, error: 'Provider failed',
+      }],
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2);
+    assert.ok(lines[1].includes('broken'));
+    assert.ok(lines[1].includes('ERROR'));
+    assert.ok(lines[1].includes('Provider failed'));
+  });
+
+  it('output ends with CRLF', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{ checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x' }],
+    });
+    const out = formatter.format(results);
+    assert.ok(out.endsWith('\r\n'));
+  });
+
+  it('description containing comma is wrapped in quotes', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'Found, multiple, issues',
+      }],
+    });
+    const out = formatter.format(results);
+    assert.ok(out.includes('"Found, multiple, issues"'));
+  });
+
+  it('description containing double quotes has them doubled', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'Bad "user input"',
+      }],
+    });
+    const out = formatter.format(results);
+    assert.ok(out.includes('"Bad ""user input"""'));
+  });
+
+  it('description containing newlines is flattened to spaces', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'Line one\nLine two\r\nLine three',
+      }],
+    });
+    const out = formatter.format(results);
+    // Newlines in the description should be collapsed; the cell stays a single line
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2, 'header + one issue row only');
+    assert.ok(lines[1].includes('Line one Line two Line three'));
+  });
+
+  it('description longer than 500 chars is truncated with an ellipsis', () => {
+    const long = 'a'.repeat(2000);
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1, description: long,
+      }],
+    });
+    const out = formatter.format(results);
+    // Find the truncated form (last char should be the ellipsis)
+    assert.ok(out.includes('a…'), 'truncated description should end in ellipsis');
+    assert.ok(!out.includes('a'.repeat(600)), 'should not contain the full long description');
+  });
+
+  it('undefined optional fields render as empty cells', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+        // severity/confidence/recommendation absent
+      }],
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines[1], 'c1,C1,FAIL,a.ts,1,1,,,x,');
+  });
+
+  it('orphaned issue (no matching checks entry) gets status UNKNOWN', () => {
+    // Defence-in-depth: if an issue references a checkId that isn't in the
+    // checks list, the row should not be silently labelled FAIL — it should
+    // surface the data inconsistency as UNKNOWN.
+    const results = makeResults({
+      checks: [],
+      issues: [{
+        checkId: 'orphan', checkName: 'Orphan',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+      }],
+    });
+    const out = formatter.format(results);
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 2);
+    assert.ok(lines[1].startsWith('orphan,Orphan,UNKNOWN,'));
+  });
+
+  it('checkName with comma is properly escaped', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'Tricky, Check', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'Tricky, Check',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+      }],
+    });
+    const out = formatter.format(results);
+    assert.ok(out.includes('"Tricky, Check"'));
+  });
+});
+
+describe('escapeCsvField', () => {
+  it('plain string passes through', () => {
+    assert.equal(escapeCsvField('hello'), 'hello');
+  });
+  it('number is stringified', () => {
+    assert.equal(escapeCsvField(42), '42');
+  });
+  it('undefined → empty', () => {
+    assert.equal(escapeCsvField(undefined), '');
+  });
+  it('comma → quoted', () => {
+    assert.equal(escapeCsvField('a,b'), '"a,b"');
+  });
+  it('quote → quoted+doubled', () => {
+    assert.equal(escapeCsvField('a"b'), '"a""b"');
+  });
+  it('newline → quoted', () => {
+    assert.equal(escapeCsvField('a\nb'), '"a\nb"');
+  });
+});
+
+describe('normalizeDescription', () => {
+  it('preserves short single-line input', () => {
+    assert.equal(normalizeDescription('hello world'), 'hello world');
+  });
+  it('collapses CRLF/LF/CR sequences to single space', () => {
+    assert.equal(normalizeDescription('a\r\nb\nc\rd'), 'a b c d');
+  });
+  it('truncates input longer than 500 chars and appends ellipsis', () => {
+    const out = normalizeDescription('x'.repeat(600));
+    assert.equal(out.length, 500);
+    assert.ok(out.endsWith('…'));
+  });
+});

--- a/tests/formatter-registry.test.ts
+++ b/tests/formatter-registry.test.ts
@@ -13,6 +13,16 @@ describe('Formatter registry', () => {
     assert.equal(f.id, 'sarif');
   });
 
+  it('getFormatter("csv") returns a formatter with id "csv"', () => {
+    const f = getFormatter('csv');
+    assert.equal(f.id, 'csv');
+  });
+
+  it('getFormatter("html") returns a formatter with id "html"', () => {
+    const f = getFormatter('html');
+    assert.equal(f.id, 'html');
+  });
+
   it('getFormatter("unknown") throws with descriptive error', () => {
     assert.throws(
       () => getFormatter('unknown'),
@@ -20,15 +30,19 @@ describe('Formatter registry', () => {
         assert.ok(err.message.includes('Unknown output format "unknown"'));
         assert.ok(err.message.includes('json'));
         assert.ok(err.message.includes('sarif'));
+        assert.ok(err.message.includes('csv'));
+        assert.ok(err.message.includes('html'));
         return true;
       },
     );
   });
 
-  it('getAvailableFormats() returns both formats', () => {
+  it('getAvailableFormats() returns all four formats', () => {
     const formats = getAvailableFormats();
     assert.ok(formats.includes('json'));
     assert.ok(formats.includes('sarif'));
-    assert.equal(formats.length, 2);
+    assert.ok(formats.includes('csv'));
+    assert.ok(formats.includes('html'));
+    assert.equal(formats.length, 4);
   });
 });

--- a/tests/html-formatter.test.ts
+++ b/tests/html-formatter.test.ts
@@ -1,0 +1,312 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  HtmlFormatter,
+  escapeHtml,
+  escapeJsonForScriptTag,
+} from '../src/formatters/html-formatter.js';
+import type { ScanResults } from '../src/types.js';
+
+function makeResults(overrides: Partial<ScanResults> = {}): ScanResults {
+  return {
+    scanId: 'scan-20260101120000-abc123',
+    timestamp: '2026-01-01T12:00:00.000Z',
+    version: '0.1.0',
+    repository: { path: '/tmp/repo', isGitRepository: true },
+    issues: [],
+    checks: [],
+    summary: { totalChecks: 0, passedChecks: 0, failedChecks: 0, flaggedChecks: 0, errorChecks: 0, totalIssues: 0 },
+    executionTime: 100,
+    startTime: '2026-01-01T12:00:00.000Z',
+    endTime: '2026-01-01T12:00:00.100Z',
+    agentProvider: { name: 'mock', models: ['mock'] },
+    ...overrides,
+  };
+}
+
+describe('HtmlFormatter', () => {
+  const formatter = new HtmlFormatter();
+
+  it('id is "html"', () => {
+    assert.equal(formatter.id, 'html');
+  });
+
+  it('fileExtension is ".html"', () => {
+    assert.equal(formatter.fileExtension, '.html');
+  });
+
+  it('output starts with <!DOCTYPE html>', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.startsWith('<!DOCTYPE html>'));
+  });
+
+  it('output is self-contained (inline <style> + inline <script>)', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.includes('<style>'));
+    assert.ok(out.includes('</style>'));
+    assert.ok(out.includes('<script>'));
+    assert.ok(out.includes('</script>'));
+    // No external resources
+    assert.ok(!out.includes('<link rel="stylesheet"'));
+    assert.ok(!/<script[^>]*src=/.test(out));
+  });
+
+  it('includes a <meta charset="utf-8">', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.includes('<meta charset="utf-8"'));
+  });
+
+  it('includes scanId and timestamp in the header', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.includes('scan-20260101120000-abc123'));
+    assert.ok(out.includes('2026-01-01T12:00:00.000Z'));
+  });
+
+  it('includes summary stats', () => {
+    const out = formatter.format(makeResults({
+      summary: { totalChecks: 5, passedChecks: 3, failedChecks: 1, flaggedChecks: 0, errorChecks: 1, totalIssues: 7 },
+    }));
+    // "Checks", "Passed", "Failed", etc. labels appear
+    assert.ok(out.includes('Checks'));
+    assert.ok(out.includes('Passed'));
+    assert.ok(out.includes('Failed'));
+    assert.ok(out.includes('Issues'));
+  });
+
+  it('empty issues set shows "No issues detected" message', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.includes('No issues detected'));
+  });
+
+  it('includes embedded JSON in <script type="application/json">', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(out.includes('<script id="aghast-results" type="application/json">'));
+  });
+
+  it('embedded JSON parses back to the original ScanResults', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{ checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x' }],
+    });
+    const out = formatter.format(results);
+    // Extract embedded JSON. Use matchAll + assert exactly one tag so a future
+    // change that adds another application/json script doesn't silently break
+    // the assumption that this regex picks the right one (F8).
+    const matches = Array.from(
+      out.matchAll(/<script id="aghast-results" type="application\/json">([\s\S]*?)<\/script>/g),
+    );
+    assert.equal(matches.length, 1, 'exactly one aghast-results script tag');
+    const embedded = matches[0][1];
+    // The </ → <\/ and <!-- → <!-- escapes are valid JSON: `\/` decodes
+    // to `/` and `<` decodes to `<`, so JSON.parse handles them directly.
+    const parsed = JSON.parse(embedded) as ScanResults;
+    assert.equal(parsed.scanId, results.scanId);
+    assert.equal(parsed.issues.length, 1);
+    assert.equal(parsed.issues[0].file, 'a.ts');
+  });
+
+  it('includes a row per issue in the issues table', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 2, executionTime: 10 }],
+      issues: [
+        { checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'first' },
+        { checkId: 'c1', checkName: 'C1', file: 'b.ts', startLine: 2, endLine: 2, description: 'second' },
+      ],
+    }));
+    assert.ok(out.includes('a.ts'));
+    assert.ok(out.includes('b.ts'));
+    assert.ok(out.includes('first'));
+    assert.ok(out.includes('second'));
+  });
+
+  it('renders severity badges', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x', severity: 'high',
+      }],
+    }));
+    assert.ok(out.includes('class="badge sev-high"'));
+    assert.ok(out.includes('>high<'));
+  });
+
+  it('renders code snippets in expandable check sections', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+        codeSnippet: 'const x = 1;',
+      }],
+    }));
+    assert.ok(out.includes('<details>'));
+    assert.ok(out.includes('<pre class="snippet">const x = 1;</pre>'));
+  });
+
+  it('escapes HTML in description fields', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: '<script>alert("xss")</script>',
+      }],
+    }));
+    // The escaped form must appear in the rendered HTML body
+    assert.ok(out.includes('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'));
+    // Strip the JSON island (which intentionally contains the raw string, but is inert
+    // because of type="application/json") and ensure no executable <script>alert tag survives.
+    const htmlBody = out.replace(
+      /<script id="aghast-results" type="application\/json">[\s\S]*?<\/script>/,
+      '',
+    );
+    assert.ok(!htmlBody.includes('<script>alert'), 'unescaped alert script tag must not appear in rendered body');
+  });
+
+  it('escapes HTML in file names', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: '<img src=x onerror=alert(1)>.ts', startLine: 1, endLine: 1, description: 'x',
+      }],
+    }));
+    // Escaped form must appear in the rendered HTML body
+    assert.ok(out.includes('&lt;img src=x onerror=alert(1)&gt;.ts'));
+    // Strip JSON island (raw string is inert there) and ensure no live <img ... onerror tag survives.
+    const htmlBody = out.replace(
+      /<script id="aghast-results" type="application\/json">[\s\S]*?<\/script>/,
+      '',
+    );
+    assert.ok(!htmlBody.includes('<img src=x onerror=alert(1)>'));
+  });
+
+  it('escapes HTML in code snippets', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+        codeSnippet: '<script>steal()</script>',
+      }],
+    }));
+    assert.ok(!out.includes('<pre class="snippet"><script>steal()</script>'));
+    assert.ok(out.includes('&lt;script&gt;steal()&lt;/script&gt;'));
+  });
+
+  it('embedded JSON with </script> in attacker-controlled string is neutralised', () => {
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: '</script><script>alert(1)</script>',
+      }],
+    });
+    const out = formatter.format(results);
+    // Extract the JSON island; ensure it contains the escaped form, not the raw closing tag.
+    const match = out.match(/<script id="aghast-results" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(match, 'should find aghast-results script tag');
+    const island = match![1];
+    // The raw closing-script-tag pattern must not appear inside the JSON island
+    assert.ok(!island.includes('</script>'), 'raw </script> must not appear in JSON island');
+    assert.ok(island.includes('<\\/script>'), 'escaped form </ → <\\/ must appear');
+  });
+
+  it('embedded JSON with <!-- + nested </script> in attacker-controlled string is neutralised', () => {
+    // Without escaping <!--, HTML's script-data-escaped state would let a nested
+    // <script>...</script> pair terminate the outer <script type=application/json>
+    // before the closing </script> tag we control.
+    const results = makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1',
+        file: 'a.ts', startLine: 1, endLine: 1,
+        description: '<!--<script>x</script>-->',
+      }],
+    });
+    const out = formatter.format(results);
+    const match = out.match(/<script id="aghast-results" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(match, 'should find aghast-results script tag');
+    const island = match![1];
+    assert.ok(!island.includes('<!--'), 'raw <!-- must not appear in JSON island');
+    assert.ok(island.includes('\\u003c!--'), 'escaped <!-- → \\u003c!-- must appear');
+  });
+
+  it('orphaned issue (no matching checks entry) gets status UNKNOWN', () => {
+    // Defence-in-depth: if an issue references a checkId that isn't in the
+    // checks list, the table row should not be silently labelled FAIL — it
+    // should surface the data inconsistency as UNKNOWN.
+    const out = formatter.format(makeResults({
+      checks: [],
+      issues: [{
+        checkId: 'orphan', checkName: 'Orphan',
+        file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+      }],
+    }));
+    assert.ok(out.includes('class="badge status-unknown"'), 'should use status-unknown badge class');
+    assert.ok(out.includes('>UNKNOWN<'), 'should render the UNKNOWN status text');
+    assert.ok(!out.includes('class="badge status-fail">FAIL<'), 'must not silently render as FAIL');
+  });
+
+  it('multi-check report renders one <details> per check', () => {
+    const out = formatter.format(makeResults({
+      checks: [
+        { checkId: 'c1', checkName: 'Check One', status: 'PASS', issuesFound: 0, executionTime: 10 },
+        { checkId: 'c2', checkName: 'Check Two', status: 'FAIL', issuesFound: 1, executionTime: 10 },
+      ],
+      issues: [{ checkId: 'c2', checkName: 'Check Two', file: 'b.ts', startLine: 1, endLine: 1, description: 'x' }],
+    }));
+    const detailsCount = (out.match(/<details>/g) ?? []).length;
+    assert.equal(detailsCount, 2);
+  });
+
+  it('ERROR check renders error message in details', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'ERROR', issuesFound: 0, executionTime: 5, error: 'boom' }],
+    }));
+    assert.ok(out.includes('class="badge status-error"'));
+    assert.ok(out.includes('boom'));
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes &, <, >, ", \'', () => {
+    assert.equal(escapeHtml('<a href="x">\'&\'</a>'), '&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;');
+  });
+  it('undefined → empty string', () => {
+    assert.equal(escapeHtml(undefined), '');
+  });
+  it('null → empty string', () => {
+    assert.equal(escapeHtml(null), '');
+  });
+  it('numbers stringify', () => {
+    assert.equal(escapeHtml(42), '42');
+  });
+});
+
+describe('escapeJsonForScriptTag', () => {
+  it('replaces </ with <\\/', () => {
+    assert.equal(escapeJsonForScriptTag('a</script>b'), 'a<\\/script>b');
+  });
+  it('plain JSON passes through', () => {
+    assert.equal(escapeJsonForScriptTag('{"a":1}'), '{"a":1}');
+  });
+  it('replaces <!-- with \\u003c!-- so HTML script-data-escaped state cannot trigger', () => {
+    // <!-- + a nested </script> pair can otherwise close the outer <script> early
+    // in HTML's script-data tokenizer. Replacing < with its JSON unicode
+    // escape < keeps JSON.parse round-trip-safe.
+    assert.equal(
+      escapeJsonForScriptTag('foo <!-- <script>x</script>--> bar'),
+      'foo \\u003c!-- <script>x<\\/script>--> bar',
+    );
+  });
+  it('output round-trips through JSON.parse', () => {
+    const original = 'a</b><!--c-->d';
+    const json = JSON.stringify({ x: original });
+    const escaped = escapeJsonForScriptTag(json);
+    const parsed = JSON.parse(escaped) as { x: string };
+    assert.equal(parsed.x, original);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `html` and `csv` report output formatters alongside JSON/SARIF
- Fix CI skip-gate logic to find a merged PR by commit association, correcting cases where older merged PRs were missed

## Test plan
- [x] `npm install` in public repo
- [x] `npm test` — 974 passing, 0 failing