### PR TITLE
feat: capture CI/CD pipeline metadata in scan results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ listed instead of its contents.
 - `src/scan-runner.ts` — Security Scanner orchestrator (`runMultiScan` for config-based multi-check; `executeTargetedCheck` for discovery-based checks with concurrent target analysis via `mapWithConcurrency`)
 - `src/check-library.ts` — Check Library: two-layer config loading (`loadCheckRegistry`, `loadCheckDefinition`, `discoverCheckFolders`, `resolveChecks`), validation, repository matching, markdown parsing, path filtering
 - `src/check-types.ts` — Check type descriptor system; each type (`repository`, `targeted`, `static`) declares its characteristics (needsAI, needsDiscovery, needsInstructions, etc.) in one place
-- `src/types.ts` — Shared type definitions (`ScanResults`, `RepositoryInfo`, `SecurityIssue`, `RuntimeConfig`, …)
+- `src/types.ts` — Shared type definitions (`ScanResults`, `RepositoryInfo`, `SecurityIssue`, `RuntimeConfig`, …). `ScanMetadata` is deliberately a **closed** type — add explicit fields rather than widening it, so typos fail at compile time
+- `src/ci-metadata.ts` — CI/CD pipeline detection (spec E.4): reads platform env vars for GitHub Actions, GitLab CI and CircleCI into `ScanResults.metadata.ciMetadata`. Read-only and never throws; adding a platform means adding one collector function
 
 **Subsystems** — each is a registry plus interchangeable implementations; read the named file for the interface, then the sibling directory for the implementations
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -94,6 +94,26 @@ Results are written to `security_checks_results.<ext>` in the target repo by def
 - **CSV** - one row per issue (plus one row per `ERROR` check) for spreadsheet analysis. UTF-8 encoded, no BOM, RFC 4180 quoting, CRLF line endings. Descriptions are flattened to a single line and truncated to 500 chars. The structured `dataFlow` taint trace is omitted; use SARIF or JSON for the full trace.
 - **HTML** - self-contained interactive report with inline CSS/JS and the full `ScanResults` embedded as a JSON island. Includes filterable issues table, severity/status badges, expandable per-check sections, and code snippets. No external resources, so the file can be emailed or hosted as-is.
 
+## CI/CD Metadata
+
+When aghast detects it is running inside a supported CI/CD environment, scan results include a `metadata.ciMetadata` object so downstream tooling can correlate findings with the pipeline run that produced them. In SARIF output the same fields appear under the run's `invocations[0].properties` bag (keys prefixed `aghast.`). Detection is automatic and read-only — aghast never sets or modifies CI environment variables.
+
+Supported platforms and the env vars consulted:
+
+| Field | GitHub Actions | GitLab CI | CircleCI |
+|-------|----------------|-----------|----------|
+| `jobUrl` | `GITHUB_SERVER_URL` + `GITHUB_REPOSITORY` + `GITHUB_RUN_ID` | `CI_JOB_URL` | `CIRCLE_BUILD_URL` |
+| `branch` | `GITHUB_REF_NAME` | `CI_COMMIT_REF_NAME` | `CIRCLE_BRANCH` |
+| `pipelineSource` | `GITHUB_EVENT_NAME` | `CI_PIPELINE_SOURCE` | _(not set)_ |
+| `jobStartedAt` | `GITHUB_RUN_STARTED_AT` | `CI_JOB_STARTED_AT` | _(not set)_ |
+
+Detection looks for `CI=true` (or `CI=1`) plus a platform-specific signal (`GITHUB_ACTIONS`, `GITLAB_CI`, or `CIRCLECI`); each flag accepts the literal string `'true'` or `'1'`. When running locally, no `ciMetadata` is emitted.
+
+A few caveats for downstream consumers:
+
+- **`branch` may not be a branch name.** It comes from the platform's ref env var verbatim — that's a tag name on tag pushes, and on GitHub Actions `pull_request` events it's the PR merge ref (e.g. `123/merge`). Check `pipelineSource` to disambiguate.
+- **`pipelineSource` vocabularies differ across platforms.** GitHub Actions emits values like `push`, `pull_request`, `schedule`, `workflow_dispatch`; GitLab CI emits `push`, `merge_request_event`, `schedule`, `web`, `api`, etc.; CircleCI does not set this field. Treat the value as an opaque, platform-specific string.
+
 ## Check Types
 
 aghast supports three check types with pluggable discovery methods:

--- a/src/ci-metadata.ts
+++ b/src/ci-metadata.ts
@@ -1,0 +1,132 @@
+/**
+ * CI/CD pipeline metadata detection (spec E.4).
+ *
+ * Detects whether aghast is running inside a known CI/CD platform and
+ * collects pipeline context (job URL, branch, trigger, start time) from
+ * platform-specific environment variables.
+ *
+ * Supported platforms: GitHub Actions, GitLab CI, CircleCI. Extending to
+ * new platforms means adding another collector function below.
+ *
+ * The functions only read from a supplied env object (defaulting to
+ * `process.env`); they never mutate it and never throw.
+ */
+
+import type { CIMetadata } from './types.js';
+
+/** Read-only env shape (process.env compatible). */
+export type EnvLike = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Every CI/CD environment variable this module consults. Exported so test
+ * helpers can scrub these vars in one place and stay in sync with this
+ * module — adding a new var here automatically updates the hermetic test
+ * scrub list.
+ */
+export const CI_ENV_VAR_NAMES: readonly string[] = [
+  // Generic
+  'CI',
+  // GitHub Actions
+  'GITHUB_ACTIONS',
+  'GITHUB_SERVER_URL',
+  'GITHUB_REPOSITORY',
+  'GITHUB_RUN_ID',
+  'GITHUB_REF_NAME',
+  'GITHUB_EVENT_NAME',
+  'GITHUB_RUN_STARTED_AT',
+  // GitLab CI
+  'GITLAB_CI',
+  'CI_JOB_URL',
+  'CI_COMMIT_REF_NAME',
+  'CI_PIPELINE_SOURCE',
+  'CI_JOB_STARTED_AT',
+  // CircleCI
+  'CIRCLECI',
+  'CIRCLE_BUILD_URL',
+  'CIRCLE_BRANCH',
+];
+
+/** Returns true when the env var holds a recognised truthy CI flag value. */
+function isTrueFlag(value: string | undefined): boolean {
+  return value === 'true' || value === '1';
+}
+
+/**
+ * Returns true when aghast appears to be running inside a CI/CD environment.
+ *
+ * Most CI providers set `CI=true`; we also accept platform-specific signals
+ * (`GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`) to cover edge cases where the
+ * generic `CI` flag is unset but the platform-specific flag is present. All
+ * flags accept the literal strings `'true'` or `'1'` for parity.
+ */
+export function detectCI(env: EnvLike = process.env): boolean {
+  return (
+    isTrueFlag(env.CI) ||
+    isTrueFlag(env.GITHUB_ACTIONS) ||
+    isTrueFlag(env.GITLAB_CI) ||
+    isTrueFlag(env.CIRCLECI)
+  );
+}
+
+/**
+ * Collect CI/CD metadata from the environment. Returns `undefined` when no
+ * CI signals are present, or when no platform-specific fields could be
+ * resolved (i.e. nothing useful to report).
+ *
+ * Platform precedence: GitHub Actions → GitLab CI → CircleCI. If multiple
+ * sets of variables somehow coexist, the first matched platform wins.
+ */
+export function collectCIMetadata(env: EnvLike = process.env): CIMetadata | undefined {
+  if (!detectCI(env)) return undefined;
+
+  const collectors: Array<(env: EnvLike) => CIMetadata | undefined> = [
+    collectGitHubActions,
+    collectGitLabCI,
+    collectCircleCI,
+  ];
+  for (const collect of collectors) {
+    const meta = collect(env);
+    if (meta && hasAnyField(meta)) return meta;
+  }
+  return undefined;
+}
+
+function hasAnyField(meta: CIMetadata): boolean {
+  return Boolean(meta.jobUrl ?? meta.branch ?? meta.pipelineSource ?? meta.jobStartedAt);
+}
+
+/** GitHub Actions: builds job URL from server/repo/run-id; reads ref + event + start time. */
+function collectGitHubActions(env: EnvLike): CIMetadata | undefined {
+  if (!isTrueFlag(env.GITHUB_ACTIONS)) return undefined;
+  const meta: CIMetadata = {};
+  const server = env.GITHUB_SERVER_URL;
+  const repo = env.GITHUB_REPOSITORY;
+  const runId = env.GITHUB_RUN_ID;
+  if (server && repo && runId) {
+    meta.jobUrl = `${server}/${repo}/actions/runs/${runId}`;
+  }
+  if (env.GITHUB_REF_NAME) meta.branch = env.GITHUB_REF_NAME;
+  if (env.GITHUB_EVENT_NAME) meta.pipelineSource = env.GITHUB_EVENT_NAME;
+  if (env.GITHUB_RUN_STARTED_AT) meta.jobStartedAt = env.GITHUB_RUN_STARTED_AT;
+  return meta;
+}
+
+/** GitLab CI: native fields cover all four metadata slots directly. */
+function collectGitLabCI(env: EnvLike): CIMetadata | undefined {
+  if (!isTrueFlag(env.GITLAB_CI)) return undefined;
+  const meta: CIMetadata = {};
+  if (env.CI_JOB_URL) meta.jobUrl = env.CI_JOB_URL;
+  if (env.CI_COMMIT_REF_NAME) meta.branch = env.CI_COMMIT_REF_NAME;
+  if (env.CI_PIPELINE_SOURCE) meta.pipelineSource = env.CI_PIPELINE_SOURCE;
+  if (env.CI_JOB_STARTED_AT) meta.jobStartedAt = env.CI_JOB_STARTED_AT;
+  return meta;
+}
+
+/** CircleCI: only job URL + branch are exposed; trigger/start time are not standard. */
+function collectCircleCI(env: EnvLike): CIMetadata | undefined {
+  if (!isTrueFlag(env.CIRCLECI)) return undefined;
+  const meta: CIMetadata = {};
+  if (env.CIRCLE_BUILD_URL) meta.jobUrl = env.CIRCLE_BUILD_URL;
+  if (env.CIRCLE_BRANCH) meta.branch = env.CIRCLE_BRANCH;
+  return meta;
+}

--- a/src/formatters/sarif-formatter.ts
+++ b/src/formatters/sarif-formatter.ts
@@ -4,7 +4,7 @@
  * code scanning UIs (e.g. GitHub Code Scanning) and SARIF viewers.
  */
 
-import type { ScanResults, SecurityIssue, DataFlowStep, ValidationRecord } from '../types.js';
+import type { ScanResults, SecurityIssue, DataFlowStep, ValidationRecord, CIMetadata } from '../types.js';
 import type { OutputFormatter } from './types.js';
 
 /** Maps aghast severity to SARIF result level. */
@@ -70,6 +70,15 @@ interface SarifResult {
   suppressions?: SarifSuppression[];
 }
 
+/**
+ * SARIF invocation entry. We only populate it when CI metadata is available
+ * (spec E.4) so SARIF output stays minimal for local runs.
+ */
+interface SarifInvocation {
+  executionSuccessful: boolean;
+  properties?: Record<string, string>;
+}
+
 interface SarifLog {
   $schema: string;
   version: string;
@@ -81,6 +90,7 @@ interface SarifLog {
         rules: SarifRule[];
       };
     };
+    invocations?: SarifInvocation[];
     results: SarifResult[];
   }>;
 }
@@ -98,6 +108,7 @@ export class SarifFormatter implements OutputFormatter {
     if (results.validations) {
       sarifResults.push(...this.buildValidationResults(results.validations));
     }
+    const invocations = this.buildInvocations(results);
 
     const sarif: SarifLog = {
       $schema: 'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json',
@@ -111,12 +122,31 @@ export class SarifFormatter implements OutputFormatter {
               rules,
             },
           },
+          ...(invocations ? { invocations } : {}),
           results: sarifResults,
         },
       ],
     };
 
     return JSON.stringify(sarif, null, 2);
+  }
+
+  /**
+   * Map CI/CD metadata (spec E.4) to a single SARIF invocation entry. The
+   * `properties` bag is the conventional location for non-standard run
+   * context in SARIF; we use stable, namespaced keys (`aghast.<field>`) so
+   * downstream consumers can rely on the shape.
+   */
+  private buildInvocations(results: ScanResults): SarifInvocation[] | undefined {
+    const ci: CIMetadata | undefined = results.metadata?.ciMetadata;
+    if (!ci) return undefined;
+    const properties: Record<string, string> = {};
+    if (ci.jobUrl) properties['aghast.ciJobUrl'] = ci.jobUrl;
+    if (ci.branch) properties['aghast.ciBranch'] = ci.branch;
+    if (ci.pipelineSource) properties['aghast.ciPipelineSource'] = ci.pipelineSource;
+    if (ci.jobStartedAt) properties['aghast.ciJobStartedAt'] = ci.jobStartedAt;
+    if (Object.keys(properties).length === 0) return undefined;
+    return [{ executionSuccessful: true, properties }];
   }
 
   private buildRules(results: ScanResults): SarifRule[] {

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -34,6 +34,7 @@ import {
   type CheckDetails,
   type SecurityCheck,
   type ScanResults,
+  type ScanMetadata,
   type ScanSummary,
   type TokenUsage,
   type ValidationRecord,
@@ -41,6 +42,7 @@ import {
 import { calculateCost, type PricingConfig, type CostBreakdown } from './cost-calculator.js';
 import { checkBudget, BudgetExceededError, type BudgetLimits } from './budget.js';
 import type { ScanRecord } from './scan-history.js';
+import { collectCIMetadata } from './ci-metadata.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TAG = 'scan';
@@ -1330,6 +1332,11 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
   // Aggregate token usage across all checks
   const aggregateTokenUsage = sumTokenUsage(allCheckSummaries.map((c) => c.tokenUsage));
 
+  // Spec E.4: capture CI/CD pipeline context when running in a supported CI
+  // environment. Returns undefined locally so we omit `metadata` entirely.
+  const ciMetadata = collectCIMetadata();
+  const metadata: ScanMetadata | undefined = ciMetadata ? { ciMetadata } : undefined;
+
   const results: ScanResults = {
     scanId,
     timestamp: startTime.toISOString(),
@@ -1346,6 +1353,7 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
       ? { name: agentProviderName ?? DEFAULT_PROVIDER_NAME, models: modelsUsed.size > 0 ? [...modelsUsed] : [DEFAULT_MODEL] }
       : { name: 'none', models: [] },
     tokenUsage: aggregateTokenUsage,
+    ...(metadata ? { metadata } : {}),
   };
 
   // Attach cost metadata when pricing was provided.

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,37 @@ export interface CheckExecutionSummary {
   validationsCount?: { truePositive: number; falsePositive: number };
 }
 
+// --- A.5a CI/CD Metadata (spec E.4) ---
+
+/**
+ * CI/CD pipeline context captured during a scan run. Populated automatically
+ * from environment variables when aghast detects it is running inside a
+ * supported CI/CD platform (GitHub Actions, GitLab CI, CircleCI). All fields
+ * are optional in case detection is partial.
+ */
+export interface CIMetadata {
+  /** URL of the CI/CD job that produced this scan. */
+  jobUrl?: string;
+  /**
+   * Ref that was scanned. On GitHub Actions this is `GITHUB_REF_NAME` —
+   * a branch name on `push` to a branch, the tag name on a tag push, or
+   * the PR merge ref (e.g. `123/merge`) on `pull_request` events. Consult
+   * `pipelineSource` to disambiguate.
+   */
+  branch?: string;
+  /**
+   * Platform-specific trigger string verbatim. Vocabularies differ:
+   * GitHub Actions emits `push`, `pull_request`, `schedule`, `workflow_dispatch`,
+   * `repository_dispatch`, etc.; GitLab CI emits `push`, `merge_request_event`,
+   * `schedule`, `web`, `api`, `external`, etc.; CircleCI does not set this
+   * field. Consumers should treat the value as an opaque string and not
+   * assume a unified vocabulary across platforms.
+   */
+  pipelineSource?: string;
+  /** ISO-8601 timestamp for when the CI/CD job started. */
+  jobStartedAt?: string;
+}
+
 // --- A.5 Complete Scan Results ---
 
 export interface ScanResults {
@@ -257,7 +288,25 @@ export interface ScanResults {
     models: string[];
   };
   tokenUsage?: TokenUsage;
-  metadata?: Record<string, unknown>;
+  metadata?: ScanMetadata;
+}
+
+/**
+ * Additional metadata about the scan environment. Currently carries CI/CD
+ * pipeline context (spec E.4) when running in a supported CI environment.
+ * Extend by adding explicit fields here when new metadata is introduced —
+ * keeping the type closed surfaces typos at compile time.
+ */
+export interface ScanMetadata {
+  ciMetadata?: CIMetadata;
+  /**
+   * Cost summary, attached by `runMultiScan` when pricing config is available.
+   * See `src/cost-calculator.ts`.
+   */
+  cost?: {
+    totalCostUsd: number;
+    currency: string;
+  };
 }
 
 export interface RepositoryInfo {

--- a/tests/ci-metadata.test.ts
+++ b/tests/ci-metadata.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for CI/CD metadata detection (src/ci-metadata.ts, spec E.4).
+ *
+ * Each test passes a synthetic env object so process.env stays untouched.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { collectCIMetadata, detectCI } from '../src/ci-metadata.js';
+
+describe('detectCI', () => {
+  it('returns false on an empty env', () => {
+    assert.equal(detectCI({}), false);
+  });
+
+  it('returns true when CI=true', () => {
+    assert.equal(detectCI({ CI: 'true' }), true);
+  });
+
+  it('returns true when CI=1', () => {
+    assert.equal(detectCI({ CI: '1' }), true);
+  });
+
+  it('returns false when CI is set to a falsy-ish value', () => {
+    assert.equal(detectCI({ CI: 'false' }), false);
+    assert.equal(detectCI({ CI: '' }), false);
+  });
+
+  it('returns true when GITHUB_ACTIONS=true even without CI', () => {
+    assert.equal(detectCI({ GITHUB_ACTIONS: 'true' }), true);
+  });
+
+  it('returns true when GITLAB_CI=true even without CI', () => {
+    assert.equal(detectCI({ GITLAB_CI: 'true' }), true);
+  });
+
+  it('returns true when CIRCLECI=true even without CI', () => {
+    assert.equal(detectCI({ CIRCLECI: 'true' }), true);
+  });
+});
+
+describe('collectCIMetadata', () => {
+  it('returns undefined outside CI', () => {
+    assert.equal(collectCIMetadata({}), undefined);
+  });
+
+  it('returns undefined when CI=true but no platform-specific signals exist', () => {
+    // detectCI returns true (CI=true), but no per-platform collector matches,
+    // so there's nothing useful to report.
+    assert.equal(collectCIMetadata({ CI: 'true' }), undefined);
+  });
+
+  it('maps GitHub Actions env vars correctly', () => {
+    const meta = collectCIMetadata({
+      CI: 'true',
+      GITHUB_ACTIONS: 'true',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '12345',
+      GITHUB_REF_NAME: 'feature/auth-fix',
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_RUN_STARTED_AT: '2026-01-18T10:00:00Z',
+    });
+    assert.deepEqual(meta, {
+      jobUrl: 'https://github.com/org/repo/actions/runs/12345',
+      branch: 'feature/auth-fix',
+      pipelineSource: 'push',
+      jobStartedAt: '2026-01-18T10:00:00Z',
+    });
+  });
+
+  it('handles partial GitHub Actions env (missing run-id leaves jobUrl unset)', () => {
+    const meta = collectCIMetadata({
+      GITHUB_ACTIONS: 'true',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: 'org/repo',
+      // no GITHUB_RUN_ID
+      GITHUB_REF_NAME: 'main',
+    });
+    assert.ok(meta);
+    assert.equal(meta.jobUrl, undefined);
+    assert.equal(meta.branch, 'main');
+  });
+
+  it('maps GitLab CI env vars correctly', () => {
+    const meta = collectCIMetadata({
+      CI: 'true',
+      GITLAB_CI: 'true',
+      CI_JOB_URL: 'https://gitlab.com/org/repo/-/jobs/789',
+      CI_COMMIT_REF_NAME: 'develop',
+      CI_PIPELINE_SOURCE: 'merge_request_event',
+      CI_JOB_STARTED_AT: '2026-02-03T08:30:00Z',
+    });
+    assert.deepEqual(meta, {
+      jobUrl: 'https://gitlab.com/org/repo/-/jobs/789',
+      branch: 'develop',
+      pipelineSource: 'merge_request_event',
+      jobStartedAt: '2026-02-03T08:30:00Z',
+    });
+  });
+
+  it('maps CircleCI env vars correctly (only jobUrl + branch)', () => {
+    const meta = collectCIMetadata({
+      CI: 'true',
+      CIRCLECI: 'true',
+      CIRCLE_BUILD_URL: 'https://circleci.com/gh/org/repo/42',
+      CIRCLE_BRANCH: 'main',
+    });
+    assert.deepEqual(meta, {
+      jobUrl: 'https://circleci.com/gh/org/repo/42',
+      branch: 'main',
+    });
+  });
+
+  it('GitHub Actions takes precedence when multiple platform flags coexist', () => {
+    const meta = collectCIMetadata({
+      CI: 'true',
+      GITHUB_ACTIONS: 'true',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '1',
+      GITHUB_REF_NAME: 'gh-branch',
+      GITHUB_EVENT_NAME: 'push',
+      GITLAB_CI: 'true',
+      CI_JOB_URL: 'https://gitlab.com/org/repo/-/jobs/789',
+      CI_COMMIT_REF_NAME: 'gl-branch',
+      CI_PIPELINE_SOURCE: 'merge_request_event',
+      CIRCLECI: 'true',
+      CIRCLE_BUILD_URL: 'https://circleci.com/gh/org/repo/42',
+      CIRCLE_BRANCH: 'cc-branch',
+    });
+    // Returned object should be exactly the GitHub Actions collector's
+    // output — no fields from GitLab or CircleCI should leak in.
+    assert.deepEqual(meta, {
+      jobUrl: 'https://github.com/org/repo/actions/runs/1',
+      branch: 'gh-branch',
+      pipelineSource: 'push',
+    });
+  });
+
+  it('GitLab CI takes precedence over CircleCI when both flags coexist', () => {
+    const meta = collectCIMetadata({
+      CI: 'true',
+      GITLAB_CI: 'true',
+      CI_JOB_URL: 'https://gitlab.com/org/repo/-/jobs/789',
+      CI_COMMIT_REF_NAME: 'gl-branch',
+      CIRCLECI: 'true',
+      CIRCLE_BUILD_URL: 'https://circleci.com/gh/org/repo/42',
+      CIRCLE_BRANCH: 'cc-branch',
+    });
+    assert.deepEqual(meta, {
+      jobUrl: 'https://gitlab.com/org/repo/-/jobs/789',
+      branch: 'gl-branch',
+    });
+  });
+
+  it('accepts platform flag value "1" as truthy (parity with CI)', () => {
+    // Defensive: cover the case where someone exports e.g. GITHUB_ACTIONS=1
+    // for local debugging or a non-standard runner emits "1" rather than "true".
+    assert.equal(detectCI({ GITHUB_ACTIONS: '1' }), true);
+    assert.equal(detectCI({ GITLAB_CI: '1' }), true);
+    assert.equal(detectCI({ CIRCLECI: '1' }), true);
+    const meta = collectCIMetadata({
+      GITHUB_ACTIONS: '1',
+      GITHUB_REF_NAME: 'main',
+    });
+    assert.equal(meta?.branch, 'main');
+  });
+
+  it('does not mutate the supplied env object', () => {
+    const env = { CI: 'true', GITHUB_ACTIONS: 'true', GITHUB_REF_NAME: 'main' };
+    const snapshot = { ...env };
+    collectCIMetadata(env);
+    assert.deepEqual(env, snapshot);
+  });
+
+  it('returns undefined when GitHub Actions flag is set but no fields are populated', () => {
+    // Only the platform flag is set; no useful metadata fields. Should return
+    // undefined rather than an empty CIMetadata object.
+    const meta = collectCIMetadata({ GITHUB_ACTIONS: 'true' });
+    assert.equal(meta, undefined);
+  });
+});

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -1219,3 +1219,49 @@ describe('CLI: conditional prerequisite validation', () => {
     assert.equal(checks[0].issuesFound, 3);
   });
 });
+
+// ─── CI/CD metadata (spec E.4) ──────────────────────────────────────────────
+
+describe('CLI mock mode: CI/CD metadata', () => {
+  afterEach(cleanupOutput);
+
+  it('omits ciMetadata when no CI env vars are set', async () => {
+    const { exitCode } = await runCLI({ AGHAST_MOCK_AI: 'true' });
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    // Either no metadata at all, or metadata without ciMetadata.
+    const metadata = results.metadata as Record<string, unknown> | undefined;
+    if (metadata) {
+      assert.equal(metadata.ciMetadata, undefined);
+    }
+  });
+
+  it('populates ciMetadata when GitHub Actions env is provided', async () => {
+    const { exitCode } = await runCLI({
+      AGHAST_MOCK_AI: 'true',
+      CI: 'true',
+      GITHUB_ACTIONS: 'true',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: 'BounceSecurity/aghast-internal',
+      GITHUB_RUN_ID: '999',
+      GITHUB_REF_NAME: 'feat/stretch-116-ci-metadata',
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_RUN_STARTED_AT: '2026-05-04T12:00:00Z',
+    });
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const metadata = results.metadata as Record<string, unknown> | undefined;
+    assert.ok(metadata, 'metadata should be present');
+    const ciMetadata = metadata.ciMetadata as Record<string, unknown> | undefined;
+    assert.ok(ciMetadata, 'ciMetadata should be present');
+    assert.equal(
+      ciMetadata.jobUrl,
+      'https://github.com/BounceSecurity/aghast-internal/actions/runs/999',
+    );
+    assert.equal(ciMetadata.branch, 'feat/stretch-116-ci-metadata');
+    assert.equal(ciMetadata.pipelineSource, 'push');
+    assert.equal(ciMetadata.jobStartedAt, '2026-05-04T12:00:00Z');
+  });
+});

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -10,6 +10,7 @@ import { statSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFile, unlink } from 'node:fs/promises';
+import { CI_ENV_VAR_NAMES } from '../src/ci-metadata.js';
 
 export const testDir = dirname(fileURLToPath(import.meta.url));
 
@@ -142,6 +143,12 @@ export async function runCLI(
     AGHAST_LOG_FILE: '',
     AGHAST_LOG_TYPE: '',
     NO_COLOR: '1',
+    // Scrub CI/CD detection vars so the suite is hermetic when the test
+    // runner itself happens to be inside CI (spec E.4 metadata is opt-in
+    // per test). Tests that want to populate ciMetadata override these.
+    // Source of truth for the var names is `CI_ENV_VAR_NAMES` in
+    // `src/ci-metadata.ts` — adding a var there auto-extends this scrub.
+    ...Object.fromEntries(CI_ENV_VAR_NAMES.map((name) => [name, undefined])),
   };
   const merged = { ...dotenvDefaults, ...env };
   const childEnv = { ...process.env, ...merged };

--- a/tests/sarif-formatter.test.ts
+++ b/tests/sarif-formatter.test.ts
@@ -210,6 +210,67 @@ describe('SarifFormatter', () => {
     assert.equal(sarif.runs[0].results[0].kind, undefined);
     assert.equal(sarif.runs[0].results[0].message.text, 'Confirmed SQLi');
   });
+
+  // ─── CI/CD metadata → SARIF invocations (spec E.4) ────────────────────────
+
+  it('omits invocations when no metadata is present', () => {
+    const sarif = JSON.parse(formatter.format(makeResults()));
+    assert.equal(sarif.runs[0].invocations, undefined);
+  });
+
+  it('omits invocations when metadata.ciMetadata is undefined', () => {
+    const sarif = JSON.parse(formatter.format(makeResults({ metadata: {} })));
+    assert.equal(sarif.runs[0].invocations, undefined);
+  });
+
+  it('omits invocations when ciMetadata exists but is entirely empty', () => {
+    // Defensive: even a non-empty ciMetadata object with no populated fields
+    // should not produce a stray invocations[] in the output.
+    const sarif = JSON.parse(formatter.format(makeResults({ metadata: { ciMetadata: {} } })));
+    assert.equal(sarif.runs[0].invocations, undefined);
+  });
+
+  it('maps full ciMetadata to a single invocation with namespaced properties', () => {
+    const sarif = JSON.parse(formatter.format(makeResults({
+      metadata: {
+        ciMetadata: {
+          jobUrl: 'https://github.com/org/repo/actions/runs/12345',
+          branch: 'feature/auth-fix',
+          pipelineSource: 'push',
+          jobStartedAt: '2026-01-18T10:00:00Z',
+        },
+      },
+    })));
+    assert.equal(Array.isArray(sarif.runs[0].invocations), true);
+    assert.equal(sarif.runs[0].invocations.length, 1);
+    const invocation = sarif.runs[0].invocations[0];
+    assert.equal(invocation.executionSuccessful, true);
+    assert.deepEqual(invocation.properties, {
+      'aghast.ciJobUrl': 'https://github.com/org/repo/actions/runs/12345',
+      'aghast.ciBranch': 'feature/auth-fix',
+      'aghast.ciPipelineSource': 'push',
+      'aghast.ciJobStartedAt': '2026-01-18T10:00:00Z',
+    });
+  });
+
+  it('maps partial ciMetadata (CircleCI shape) without spurious property keys', () => {
+    const sarif = JSON.parse(formatter.format(makeResults({
+      metadata: {
+        ciMetadata: {
+          jobUrl: 'https://circleci.com/gh/org/repo/42',
+          branch: 'main',
+        },
+      },
+    })));
+    const invocation = sarif.runs[0].invocations[0];
+    assert.deepEqual(invocation.properties, {
+      'aghast.ciJobUrl': 'https://circleci.com/gh/org/repo/42',
+      'aghast.ciBranch': 'main',
+    });
+    // Confirm no undefined fields leak in.
+    assert.equal('aghast.ciPipelineSource' in invocation.properties, false);
+    assert.equal('aghast.ciJobStartedAt' in invocation.properties, false);
+  });
 });
 
 describe('mapSeverityToLevel', () => {


### PR DESCRIPTION
Records the CI/CD pipeline context that produced a scan, so findings can be correlated back to the run that generated them. Closes #116 (spec E.4).

## What

- Detects **GitHub Actions**, **GitLab CI** and **CircleCI** from their environment variables, collecting job URL, branch, pipeline trigger and job start time
- Surfaces the result as `metadata.ciMetadata` on scan results — omitted entirely when running locally
- Maps the same fields onto SARIF `runs[].invocations[0].properties` with namespaced `aghast.ci*` keys
- Documents the fields, per-platform env vars and consumer caveats in `docs/scanning.md`

Detection is read-only and never mutates the environment. Adding a platform means adding one collector function.

## Consumer caveats (documented)

- **`branch` is not always a branch name** — it is the platform ref verbatim, so a tag name on tag pushes, and the PR merge ref (e.g. `123/merge`) on GitHub Actions `pull_request` events. Check `pipelineSource` to disambiguate.
- **`pipelineSource` vocabularies differ across platforms** and should be treated as an opaque string.

## Verification

`npm run lint`, `npm run build` clean.

Functional smoke tests across all three platforms, since unit tests alone cannot exercise env detection end-to-end:

| Scenario | Result |
|---|---|
| Local, no CI vars | No `ciMetadata` emitted |
| GitHub Actions | All four fields populated |
| GitHub Actions → SARIF | `invocations[0].properties` with `aghast.*` keys |
| GitLab CI | All four fields |
| CircleCI | `jobUrl` + `branch` only, no empty keys |

## Note on a pre-existing test flake

Local Windows full-suite runs intermittently fail with `ENOENT` on `tests/fixtures/git-repo/security_checks_results.json`. **This is pre-existing and unrelated to this change** — the same suite fails intermittently at baseline, the failing test varies between runs, and every failure is the same shared fixture file.

The cause is that several test files spawn CLI scans writing to that one default output path while `afterEach` cleanup deletes it, so concurrent tests race. It does not reproduce on Linux CI. Worth fixing separately by giving each test file its own output path.