### PR TITLE
feat: optionally write one report file per security issue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,7 +290,9 @@ An optional `runtime-config.json` file in the config directory (or specified via
   },
   "reporting": {
     "outputDirectory": "/path/to/results",
-    "outputFormat": "json"
+    "outputFormat": "json",
+    "includeIndividualIssueFiles": false,
+    "individualIssueFormat": "markdown"
   },
   "logging": {
     "logFile": "/path/to/scan.log",
@@ -336,6 +338,8 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/nemotron-3-super-free`) |
 | `reporting.outputDirectory`     | `string`   | (target repo) | Directory for result files |
 | `reporting.outputFormat`        | `string`   | `json` | Output format: `json`, `sarif`, `csv`, or `html` (see [Scanning › Output Formats](scanning.md#output-formats)) |
+| `reporting.includeIndividualIssueFiles` | `boolean` | `false` | When `true`, write one file per issue under `security_issues_<project>/<check-id>/` alongside the main report (Spec E.3.2). The directory is created in the same folder as the main report |
+| `reporting.individualIssueFormat` | `string` | `markdown` | Format for individual issue files: `markdown`, `json`, or `html`. Ignored unless `includeIndividualIssueFiles` is `true` |
 | `logging.logFile`               | `string`   | (none) | Path to log file. When set, all log output is written to this file |
 | `logging.logType`               | `string`   | `file` | Log file handler type. Pluggable; currently only `file` is supported |
 | `logging.level`                 | `string`   | `info` | Console log level: `error`, `warn`, `info`, `debug`, `trace` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { runMultiScanWithCost } from './scan-runner.js';
 import { loadDefaultPricing, mergePricing, formatCostSourceLabel } from './cost-calculator.js';
 import type { BudgetLimits } from './budget.js';
 import { saveScanRecord, queryScanHistory, type ScanRecord } from './scan-history.js';
+import { writeIndividualIssueFiles, type IndividualIssueFormat } from './issue-file-writer.js';
 import { createProviderByName, getProviderNames, DEFAULT_PROVIDER_NAME } from './provider-registry.js';
 import {
   loadCheckRegistry,
@@ -768,6 +769,18 @@ export async function runScan(args: string[]): Promise<void> {
     await mkdir(dirname(resolvedOutputPath), { recursive: true });
     await writeFile(resolvedOutputPath, formatter.format(results), 'utf-8');
 
+    // Optional: write one file per issue alongside the main report (Spec E.3.2).
+    let individualIssueDir: string | undefined;
+    let individualIssueCount = 0;
+    if (runtimeConfig.reporting?.includeIndividualIssueFiles && results.issues.length > 0) {
+      const issueFormat: IndividualIssueFormat = runtimeConfig.reporting.individualIssueFormat ?? 'markdown';
+      const issueOutputDir = dirname(resolvedOutputPath);
+      const written = await writeIndividualIssueFiles(results, issueOutputDir, issueFormat);
+      individualIssueDir = written.rootDir;
+      individualIssueCount = written.files.length;
+      logProgress(TAG, `Wrote ${individualIssueCount} individual issue file(s) to ${individualIssueDir}`);
+    }
+
     // Summary output
     const statusIcon =
       results.summary.failedChecks > 0
@@ -805,6 +818,9 @@ export async function runScan(args: string[]): Promise<void> {
     }
     console.log(`  Duration:      ${globalTimer.elapsedStr()}`);
     console.log(`  Results:       ${resolvedOutputPath}`);
+    if (individualIssueDir) {
+      console.log(`  Issue files:   ${individualIssueCount} in ${individualIssueDir}`);
+    }
     console.log('='.repeat(60));
 
     // Persist the scan record to history (best-effort — never blocks exit).

--- a/src/issue-file-writer.ts
+++ b/src/issue-file-writer.ts
@@ -1,0 +1,264 @@
+/**
+ * Individual issue file writer (Spec E.3.2).
+ *
+ * Generates one file per `SecurityIssue` in `security_issues_<project>/<check-id>/`,
+ * named `issue_<NNN>_<filename>.<ext>`. Three output formats are supported:
+ * `markdown` (default), `json`, and `html`.
+ *
+ * HTML output escapes user-controlled fields (descriptions, code snippets,
+ * file paths, recommendations, data flow steps) to prevent XSS via injected
+ * markup in AI responses or source code snippets.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, resolve, sep } from 'node:path';
+import type { ScanResults, SecurityIssue, DataFlowStep } from './types.js';
+// Reuse the shared escaper from the HTML report formatter rather than keeping a
+// second copy — it also handles null/undefined, which a local `string`-only
+// version did not.
+import { escapeHtml } from './formatters/html-formatter.js';
+
+export type IndividualIssueFormat = 'markdown' | 'json' | 'html';
+
+const FORMAT_EXTENSIONS: Record<IndividualIssueFormat, string> = {
+  markdown: 'md',
+  json: 'json',
+  html: 'html',
+};
+
+/**
+ * Windows reserved device names (case-insensitive, base name with or without
+ * extension). Files with these names cannot be created on Windows even from
+ * cross-platform code, so we prefix them with an underscore to make them safe.
+ */
+const WINDOWS_RESERVED_NAMES = new Set([
+  'CON', 'PRN', 'AUX', 'NUL',
+  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+]);
+
+/**
+ * Replace characters that are unsafe in filenames across Windows / macOS / Linux
+ * with underscores. Strips leading dots so we never produce dotfiles by accident.
+ * Also escapes Windows reserved device names (CON, PRN, NUL, etc.) by prefixing
+ * with an underscore so the writer doesn't fail on Windows.
+ */
+function safeFilename(name: string): string {
+  if (!name) return 'unknown';
+  // Use only the basename — issues may carry full paths like "src/foo/bar.ts"
+  const base = basename(name.replace(/[\\/]+/g, '/'));
+  // Replace anything that's not alphanumeric, dash, dot, underscore.
+  let cleaned = base.replace(/[^A-Za-z0-9._-]+/g, '_');
+  // Avoid leading dots (would create hidden files on POSIX).
+  cleaned = cleaned.replace(/^\.+/, '');
+  // Collapse runs of underscores for readability.
+  cleaned = cleaned.replace(/_+/g, '_');
+  if (cleaned.length === 0) return 'unknown';
+  // Escape Windows reserved device names (CON, PRN, NUL, COM1-9, LPT1-9).
+  // Match either the bare name or "name.ext" (case-insensitive).
+  const stem = cleaned.split('.')[0]!.toUpperCase();
+  if (WINDOWS_RESERVED_NAMES.has(stem)) {
+    cleaned = `_${cleaned}`;
+  }
+  return cleaned;
+}
+
+/**
+ * Derive a project name for the output directory. Prefers the basename of
+ * the repository path (when it appears to be a filesystem path), otherwise
+ * falls back to the last path segment of a remote URL.
+ */
+function deriveProjectName(results: ScanResults): string {
+  const repoPath = results.repository?.path;
+  if (repoPath) {
+    // Use basename — repoPath may be absolute on Windows or POSIX.
+    const normalised = repoPath.replace(/[\\/]+$/, '');
+    const base = basename(normalised.split(sep).join('/'));
+    if (base) return safeFilename(base);
+  }
+  const remote = results.repository?.remoteUrl;
+  if (remote) {
+    const stripped = remote.replace(/\.git$/i, '').replace(/[\\/]+$/, '');
+    const tail = stripped.split('/').pop();
+    if (tail) return safeFilename(tail);
+  }
+  return 'project';
+}
+
+/** Pad an integer to 3 digits with leading zeros (e.g. 1 -> "001"). */
+function pad3(n: number): string {
+  return String(n).padStart(3, '0');
+}
+
+function formatLineRange(issue: SecurityIssue): string {
+  if (issue.startLine === issue.endLine) return String(issue.startLine);
+  return `${issue.startLine}-${issue.endLine}`;
+}
+
+function renderMarkdown(issue: SecurityIssue): string {
+  const lines: string[] = [];
+  lines.push(`# ${issue.checkName} (${issue.checkId})`);
+  lines.push('');
+  lines.push(`- **File**: \`${issue.file}\``);
+  lines.push(`- **Lines**: ${formatLineRange(issue)}`);
+  if (issue.severity) lines.push(`- **Severity**: ${issue.severity}`);
+  if (issue.confidence) lines.push(`- **Confidence**: ${issue.confidence}`);
+  lines.push('');
+  lines.push('## Description');
+  lines.push('');
+  lines.push(issue.description);
+  if (issue.codeSnippet) {
+    lines.push('');
+    lines.push('## Code Snippet');
+    lines.push('');
+    // CommonMark allows variable-length fences: pick a length one longer than
+    // the longest run of backticks in the snippet so embedded fences don't
+    // break out of the code block.
+    const longest = (issue.codeSnippet.match(/`+/g) ?? []).reduce((m, s) => Math.max(m, s.length), 0);
+    const fence = '`'.repeat(Math.max(3, longest + 1));
+    lines.push(fence);
+    lines.push(issue.codeSnippet);
+    lines.push(fence);
+  }
+  if (issue.recommendation) {
+    lines.push('');
+    lines.push('## Recommendation');
+    lines.push('');
+    lines.push(issue.recommendation);
+  }
+  if (issue.dataFlow && issue.dataFlow.length > 0) {
+    lines.push('');
+    lines.push('## Data Flow Trace');
+    lines.push('');
+    issue.dataFlow.forEach((step: DataFlowStep, idx: number) => {
+      lines.push(`${idx + 1}. \`${step.file}:${step.lineNumber}\` — ${step.label}`);
+    });
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderJson(issue: SecurityIssue): string {
+  // Pretty-printed for human review, includes all SecurityIssue fields.
+  return JSON.stringify(issue, null, 2) + '\n';
+}
+
+function renderHtml(issue: SecurityIssue): string {
+  const parts: string[] = [];
+  parts.push('<!doctype html>');
+  parts.push('<html lang="en">');
+  parts.push('<head>');
+  parts.push('<meta charset="utf-8">');
+  parts.push(`<title>${escapeHtml(issue.checkName)} — ${escapeHtml(issue.file)}</title>`);
+  parts.push('<style>');
+  parts.push('body{font-family:sans-serif;max-width:900px;margin:2em auto;padding:0 1em;}');
+  parts.push('pre{background:#f4f4f4;padding:1em;overflow:auto;}');
+  parts.push('dt{font-weight:bold;}dd{margin:0 0 .5em 1em;}');
+  parts.push('</style>');
+  parts.push('</head>');
+  parts.push('<body>');
+  parts.push(`<h1>${escapeHtml(issue.checkName)} <small>(${escapeHtml(issue.checkId)})</small></h1>`);
+  parts.push('<dl>');
+  parts.push(`<dt>File</dt><dd><code>${escapeHtml(issue.file)}</code></dd>`);
+  parts.push(`<dt>Lines</dt><dd>${escapeHtml(formatLineRange(issue))}</dd>`);
+  if (issue.severity) parts.push(`<dt>Severity</dt><dd>${escapeHtml(issue.severity)}</dd>`);
+  if (issue.confidence) parts.push(`<dt>Confidence</dt><dd>${escapeHtml(issue.confidence)}</dd>`);
+  parts.push('</dl>');
+  parts.push('<h2>Description</h2>');
+  parts.push(`<p>${escapeHtml(issue.description)}</p>`);
+  if (issue.codeSnippet) {
+    parts.push('<h2>Code Snippet</h2>');
+    parts.push(`<pre><code>${escapeHtml(issue.codeSnippet)}</code></pre>`);
+  }
+  if (issue.recommendation) {
+    parts.push('<h2>Recommendation</h2>');
+    parts.push(`<p>${escapeHtml(issue.recommendation)}</p>`);
+  }
+  if (issue.dataFlow && issue.dataFlow.length > 0) {
+    parts.push('<h2>Data Flow Trace</h2>');
+    parts.push('<ol>');
+    for (const step of issue.dataFlow) {
+      parts.push(
+        `<li><code>${escapeHtml(step.file)}:${escapeHtml(String(step.lineNumber))}</code> — ${escapeHtml(step.label)}</li>`,
+      );
+    }
+    parts.push('</ol>');
+  }
+  parts.push('</body>');
+  parts.push('</html>');
+  parts.push('');
+  return parts.join('\n');
+}
+
+function renderIssue(issue: SecurityIssue, format: IndividualIssueFormat): string {
+  switch (format) {
+    case 'markdown':
+      return renderMarkdown(issue);
+    case 'json':
+      return renderJson(issue);
+    case 'html':
+      return renderHtml(issue);
+    default:
+      // Fail fast: rather than silently writing the literal string "undefined"
+      // to disk, throw if a programmatic caller passes an unknown format.
+      throw new Error(`Unsupported individual issue format: ${String(format)}`);
+  }
+}
+
+export interface WriteIndividualIssueFilesResult {
+  /** Absolute path of the root output directory (`security_issues_<project>/`). */
+  rootDir: string;
+  /** Absolute paths of every issue file written. */
+  files: string[];
+}
+
+/**
+ * Write one file per issue in `outputDir/security_issues_<project>/<check-id>/`.
+ *
+ * - File names follow `issue_<NNN>_<filename>.<ext>` with NNN zero-padded to 3.
+ * - Numbering is per check (each check directory restarts at 001).
+ * - When two issues would produce the same filename (e.g. multiple issues in
+ *   the same source file), the index disambiguates them — they remain unique
+ *   on disk because NNN is different.
+ *
+ * @param results Scan results containing the issues to externalize.
+ * @param outputDir Parent directory under which `security_issues_<project>/` is created.
+ * @param format Output format (`markdown` | `json` | `html`).
+ * @returns Root directory and the list of files written.
+ */
+export async function writeIndividualIssueFiles(
+  results: ScanResults,
+  outputDir: string,
+  format: IndividualIssueFormat = 'markdown',
+): Promise<WriteIndividualIssueFilesResult> {
+  const projectName = deriveProjectName(results);
+  const rootDir = resolve(outputDir, `security_issues_${projectName}`);
+  await mkdir(rootDir, { recursive: true });
+
+  // Group issues by checkId, preserving order (the order issues were collected).
+  const grouped = new Map<string, SecurityIssue[]>();
+  for (const issue of results.issues) {
+    const list = grouped.get(issue.checkId);
+    if (list) list.push(issue);
+    else grouped.set(issue.checkId, [issue]);
+  }
+
+  const ext = FORMAT_EXTENSIONS[format];
+  const files: string[] = [];
+
+  for (const [checkId, issues] of grouped) {
+    const checkDir = resolve(rootDir, safeFilename(checkId));
+    await mkdir(checkDir, { recursive: true });
+    let n = 1;
+    for (const issue of issues) {
+      const fileSlug = safeFilename(issue.file);
+      const fileName = `issue_${pad3(n)}_${fileSlug}.${ext}`;
+      const fullPath = resolve(checkDir, fileName);
+      await writeFile(fullPath, renderIssue(issue, format), 'utf-8');
+      files.push(fullPath);
+      n++;
+    }
+  }
+
+  return { rootDir, files };
+}

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -74,6 +74,17 @@ export async function loadRuntimeConfig(configDir?: string, explicitPath?: strin
     if (rpt.outputFormat !== undefined && typeof rpt.outputFormat !== 'string') {
       throw new Error(`Runtime config "${pathToLoad}": "reporting.outputFormat" must be a string`);
     }
+    if (rpt.includeIndividualIssueFiles !== undefined && typeof rpt.includeIndividualIssueFiles !== 'boolean') {
+      throw new Error(`Runtime config "${pathToLoad}": "reporting.includeIndividualIssueFiles" must be a boolean`);
+    }
+    if (rpt.individualIssueFormat !== undefined) {
+      if (typeof rpt.individualIssueFormat !== 'string') {
+        throw new Error(`Runtime config "${pathToLoad}": "reporting.individualIssueFormat" must be a string`);
+      }
+      if (rpt.individualIssueFormat !== 'markdown' && rpt.individualIssueFormat !== 'json' && rpt.individualIssueFormat !== 'html') {
+        throw new Error(`Runtime config "${pathToLoad}": "reporting.individualIssueFormat" must be one of "markdown", "json", "html"`);
+      }
+    }
   }
   if (obj.genericPrompt !== undefined && typeof obj.genericPrompt !== 'string') {
     throw new Error(`Runtime config "${pathToLoad}": "genericPrompt" must be a string`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -356,6 +356,10 @@ export interface RuntimeConfig {
   reporting?: {
     outputDirectory?: string;
     outputFormat?: string;
+    /** When true, write a separate file per issue alongside the main report. */
+    includeIndividualIssueFiles?: boolean;
+    /** Format used when `includeIndividualIssueFiles` is true. Default: `markdown`. */
+    individualIssueFormat?: 'markdown' | 'json' | 'html';
   };
   logging?: {
     logFile?: string;

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -9,8 +9,9 @@
 
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolve } from 'node:path';
-import { readFile, unlink, access } from 'node:fs/promises';
+import { resolve, join, dirname } from 'node:path';
+import { readFile, unlink, access, writeFile, mkdtemp, rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import {
   testDir as __dirname,
   fixtureRepo,
@@ -872,5 +873,98 @@ describe('CLI: --generic-prompt with mixed discovery types', () => {
       stderr.includes('--generic-prompt') && stderr.includes('different discovery types'),
       `Expected mixed discovery error, got: ${stderr}`,
     );
+  });
+});
+
+// ─── Stretch E.3.2: Individual issue files ───────────────────────────────────
+
+async function writeRuntimeConfigFile(reporting: Record<string, unknown>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'aghast-rc-'));
+  const cfgPath = resolve(dir, 'runtime-config.json');
+  await writeFile(cfgPath, JSON.stringify({ reporting }), 'utf-8');
+  return cfgPath;
+}
+
+describe('CLI: individual issue files (runtime config)', () => {
+  afterEach(cleanupOutput);
+
+  it('writes one markdown file per issue when enabled in runtime config', async () => {
+    const runtimeConfigPath = await writeRuntimeConfigFile({ includeIndividualIssueFiles: true });
+    const outputDir = await mkdtemp(join(tmpdir(), 'aghast-out-'));
+    const outputPath = resolve(outputDir, 'security_checks_results.json');
+    try {
+      const { exitCode } = await runCLI(
+        { AGHAST_MOCK_AI: failFixtureRepo },
+        [
+          fixtureRepo,
+          '--config-dir', singleCheckConfigDir,
+          '--runtime-config', runtimeConfigPath,
+          '--output', outputPath,
+        ],
+      );
+      assert.equal(exitCode, 0);
+
+      // Project name derives from basename of fixtureRepo (`git-repo`).
+      const checkDir = resolve(outputDir, 'security_issues_git-repo', 'aghast-sql-injection');
+      const files = await readdir(checkDir);
+      assert.equal(files.length, 1);
+      assert.match(files[0]!, /^issue_001_example\.ts\.md$/);
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+      await rm(dirname(runtimeConfigPath), { recursive: true, force: true });
+    }
+  });
+
+  it('respects individualIssueFormat=html', async () => {
+    const runtimeConfigPath = await writeRuntimeConfigFile({
+      includeIndividualIssueFiles: true,
+      individualIssueFormat: 'html',
+    });
+    const outputDir = await mkdtemp(join(tmpdir(), 'aghast-out-'));
+    const outputPath = resolve(outputDir, 'security_checks_results.json');
+    try {
+      const { exitCode } = await runCLI(
+        { AGHAST_MOCK_AI: failFixtureRepo },
+        [
+          fixtureRepo,
+          '--config-dir', singleCheckConfigDir,
+          '--runtime-config', runtimeConfigPath,
+          '--output', outputPath,
+        ],
+      );
+      assert.equal(exitCode, 0);
+
+      const checkDir = resolve(outputDir, 'security_issues_git-repo', 'aghast-sql-injection');
+      const files = await readdir(checkDir);
+      assert.equal(files.length, 1);
+      assert.match(files[0]!, /\.html$/);
+      const body = await readFile(resolve(checkDir, files[0]!), 'utf-8');
+      assert.ok(body.startsWith('<!doctype html>'));
+      assert.ok(body.includes('SQL Injection Prevention'));
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+      await rm(dirname(runtimeConfigPath), { recursive: true, force: true });
+    }
+  });
+
+  it('does not create issue dir when feature is disabled (default)', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'aghast-out-'));
+    const outputPath = resolve(outputDir, 'security_checks_results.json');
+    try {
+      const { exitCode } = await runCLI(
+        { AGHAST_MOCK_AI: failFixtureRepo },
+        [
+          fixtureRepo,
+          '--config-dir', singleCheckConfigDir,
+          '--output', outputPath,
+        ],
+      );
+      assert.equal(exitCode, 0);
+      // No security_issues_* dir should exist.
+      const entries = await readdir(outputDir);
+      assert.ok(!entries.some(e => e.startsWith('security_issues_')), `Unexpected issue dir: ${entries.join(',')}`);
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/issue-file-writer.test.ts
+++ b/tests/issue-file-writer.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for individual issue file writer (Spec E.3.2).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { writeIndividualIssueFiles } from '../src/issue-file-writer.js';
+import type { ScanResults, SecurityIssue } from '../src/types.js';
+
+function makeIssue(overrides: Partial<SecurityIssue> = {}): SecurityIssue {
+  return {
+    checkId: 'aghast-sqli',
+    checkName: 'SQL Injection',
+    file: 'src/example.ts',
+    startLine: 10,
+    endLine: 12,
+    description: 'User input concatenated into SQL query.',
+    severity: 'critical',
+    confidence: 'high',
+    codeSnippet: "db.query(`SELECT * FROM u WHERE id=${id}`);",
+    recommendation: 'Use parameterised queries.',
+    ...overrides,
+  };
+}
+
+function makeResults(issues: SecurityIssue[], repoPath = '/repos/my-app'): ScanResults {
+  return {
+    scanId: 'scan-test',
+    timestamp: new Date().toISOString(),
+    version: '0.0.0-test',
+    repository: { path: repoPath, isGitRepository: false },
+    issues,
+    checks: [],
+    summary: {
+      totalChecks: 0,
+      passedChecks: 0,
+      failedChecks: 0,
+      flaggedChecks: 0,
+      errorChecks: 0,
+      totalIssues: issues.length,
+    },
+    executionTime: 0,
+    startTime: new Date().toISOString(),
+    endTime: new Date().toISOString(),
+    agentProvider: { name: 'mock', models: ['mock'] },
+  };
+}
+
+describe('writeIndividualIssueFiles', () => {
+  let tmp: string;
+
+  before(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'aghast-issue-files-'));
+  });
+
+  after(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('creates security_issues_<project>/<check-id>/ structure with markdown by default', async () => {
+    const out = resolve(tmp, 'case1');
+    const results = makeResults([makeIssue()]);
+    const { rootDir, files } = await writeIndividualIssueFiles(results, out, 'markdown');
+
+    assert.ok(rootDir.endsWith('security_issues_my-app'), `unexpected rootDir: ${rootDir}`);
+    assert.equal(files.length, 1);
+    assert.match(files[0]!, /aghast-sqli[\\/]issue_001_example\.ts\.md$/);
+    const body = await readFile(files[0]!, 'utf-8');
+    assert.ok(body.includes('# SQL Injection (aghast-sqli)'));
+    assert.ok(body.includes('**Lines**: 10-12'));
+    assert.ok(body.includes('**Severity**: critical'));
+    assert.ok(body.includes('## Description'));
+    assert.ok(body.includes('User input concatenated'));
+    assert.ok(body.includes('## Code Snippet'));
+    assert.ok(body.includes('## Recommendation'));
+  });
+
+  it('numbers issues in same check from 001 and zero-pads to 3 digits', async () => {
+    const out = resolve(tmp, 'case2');
+    const issues: SecurityIssue[] = [];
+    for (let i = 0; i < 12; i++) {
+      issues.push(makeIssue({ file: `src/file${i}.ts` }));
+    }
+    const { files } = await writeIndividualIssueFiles(makeResults(issues), out, 'markdown');
+    assert.equal(files.length, 12);
+    assert.match(files[0]!, /issue_001_file0\.ts\.md$/);
+    assert.match(files[9]!, /issue_010_file9\.ts\.md$/);
+    assert.match(files[11]!, /issue_012_file11\.ts\.md$/);
+  });
+
+  it('handles filename collisions (same source file, multiple issues)', async () => {
+    const out = resolve(tmp, 'case3');
+    const issues = [
+      makeIssue({ file: 'src/foo.ts', startLine: 1, endLine: 1, description: 'first' }),
+      makeIssue({ file: 'src/foo.ts', startLine: 5, endLine: 5, description: 'second' }),
+      makeIssue({ file: 'src/foo.ts', startLine: 9, endLine: 9, description: 'third' }),
+    ];
+    const { files } = await writeIndividualIssueFiles(makeResults(issues), out, 'markdown');
+    assert.equal(files.length, 3);
+    // All filenames must be distinct due to NNN prefix.
+    const set = new Set(files);
+    assert.equal(set.size, 3);
+    assert.match(files[0]!, /issue_001_foo\.ts\.md$/);
+    assert.match(files[1]!, /issue_002_foo\.ts\.md$/);
+    assert.match(files[2]!, /issue_003_foo\.ts\.md$/);
+  });
+
+  it('groups issues by checkId into separate subdirectories', async () => {
+    const out = resolve(tmp, 'case4');
+    const issues = [
+      makeIssue({ checkId: 'aghast-sqli', checkName: 'SQLi', file: 'a.ts' }),
+      makeIssue({ checkId: 'aghast-xss', checkName: 'XSS', file: 'b.ts' }),
+      makeIssue({ checkId: 'aghast-sqli', checkName: 'SQLi', file: 'c.ts' }),
+    ];
+    const { rootDir, files } = await writeIndividualIssueFiles(makeResults(issues), out, 'markdown');
+    assert.equal(files.length, 3);
+    const sqliDir = resolve(rootDir, 'aghast-sqli');
+    const xssDir = resolve(rootDir, 'aghast-xss');
+    const sqliFiles = await readdir(sqliDir);
+    const xssFiles = await readdir(xssDir);
+    assert.equal(sqliFiles.length, 2);
+    assert.equal(xssFiles.length, 1);
+    // Per-check numbering restarts at 001.
+    assert.ok(sqliFiles.some(f => f.startsWith('issue_001_')));
+    assert.ok(sqliFiles.some(f => f.startsWith('issue_002_')));
+    assert.ok(xssFiles.some(f => f.startsWith('issue_001_')));
+  });
+
+  it('writes JSON format', async () => {
+    const out = resolve(tmp, 'case5');
+    const issue = makeIssue();
+    const { files } = await writeIndividualIssueFiles(makeResults([issue]), out, 'json');
+    assert.match(files[0]!, /\.json$/);
+    const body = await readFile(files[0]!, 'utf-8');
+    const parsed = JSON.parse(body);
+    assert.equal(parsed.checkId, 'aghast-sqli');
+    assert.equal(parsed.startLine, 10);
+    assert.equal(parsed.codeSnippet, issue.codeSnippet);
+  });
+
+  it('writes HTML format and escapes user-controlled content (XSS safety)', async () => {
+    const out = resolve(tmp, 'case6');
+    const malicious = makeIssue({
+      checkName: '<script>alert(1)</script>',
+      description: 'Naughty: <img src=x onerror=alert(2)>',
+      codeSnippet: '</code></pre><script>steal()</script>',
+      recommendation: '"><svg/onload=alert(3)>',
+      file: 'src/<weird>file"name.ts',
+    });
+    const { files } = await writeIndividualIssueFiles(makeResults([malicious]), out, 'html');
+    assert.match(files[0]!, /\.html$/);
+    const body = await readFile(files[0]!, 'utf-8');
+
+    // Must NOT contain unescaped script/event-handler markup that came from user input.
+    assert.ok(!body.includes('<script>alert(1)</script>'), 'checkName script tag must be escaped');
+    assert.ok(!body.includes('<img src=x'), 'description img tag must be escaped');
+    assert.ok(!body.includes('<script>steal()'), 'codeSnippet script tag must be escaped');
+    assert.ok(!body.includes('<svg/onload'), 'recommendation svg/onload must be escaped');
+
+    // Must contain the escaped equivalents.
+    assert.ok(body.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+    assert.ok(body.includes('&lt;img src=x onerror=alert(2)&gt;'));
+    assert.ok(body.includes('&lt;/code&gt;&lt;/pre&gt;&lt;script&gt;steal()&lt;/script&gt;'));
+    assert.ok(body.includes('&quot;&gt;&lt;svg/onload=alert(3)&gt;'));
+
+    // Doc must still be a valid (well-formed) HTML5 document.
+    assert.ok(body.startsWith('<!doctype html>'));
+    assert.ok(body.includes('<html'));
+    assert.ok(body.includes('</html>'));
+  });
+
+  it('sanitises filename: strips path separators and unsafe characters', async () => {
+    const out = resolve(tmp, 'case7');
+    const issue = makeIssue({ file: 'src/sub/dir/weird name?.ts' });
+    const { files } = await writeIndividualIssueFiles(makeResults([issue]), out, 'markdown');
+    // basename only (no path separators), no spaces or '?', preserving dot.
+    assert.match(files[0]!, /issue_001_weird_name_\.ts\.md$/);
+    assert.ok(!files[0]!.includes('?'));
+    assert.ok(!files[0]!.includes(' '));
+  });
+
+  it('falls back gracefully when issue has empty file path', async () => {
+    const out = resolve(tmp, 'case8');
+    const issue = makeIssue({ file: '' });
+    const { files } = await writeIndividualIssueFiles(makeResults([issue]), out, 'markdown');
+    assert.match(files[0]!, /issue_001_unknown\.md$/);
+  });
+
+  it('renders dataFlow steps (markdown and html)', async () => {
+    const out = resolve(tmp, 'case9');
+    const issue = makeIssue({
+      dataFlow: [
+        { file: 'src/in.ts', lineNumber: 4, label: 'tainted source' },
+        { file: 'src/sink.ts', lineNumber: 22, label: 'reaches dangerous <sink>' },
+      ],
+    });
+    const md = await writeIndividualIssueFiles(makeResults([issue]), out, 'markdown');
+    const mdBody = await readFile(md.files[0]!, 'utf-8');
+    assert.ok(mdBody.includes('## Data Flow Trace'));
+    assert.ok(mdBody.includes('1. `src/in.ts:4` — tainted source'));
+    assert.ok(mdBody.includes('2. `src/sink.ts:22` — reaches dangerous <sink>'));
+
+    const out2 = resolve(tmp, 'case9b');
+    const html = await writeIndividualIssueFiles(makeResults([issue]), out2, 'html');
+    const htmlBody = await readFile(html.files[0]!, 'utf-8');
+    assert.ok(htmlBody.includes('<h2>Data Flow Trace</h2>'));
+    // Step label angle brackets must be escaped.
+    assert.ok(htmlBody.includes('reaches dangerous &lt;sink&gt;'));
+  });
+
+  it('omits optional sections when fields absent (markdown)', async () => {
+    const out = resolve(tmp, 'case10');
+    const minimal: SecurityIssue = {
+      checkId: 'c',
+      checkName: 'C',
+      file: 'a.ts',
+      startLine: 1,
+      endLine: 1,
+      description: 'd',
+    };
+    const { files } = await writeIndividualIssueFiles(makeResults([minimal]), out, 'markdown');
+    const body = await readFile(files[0]!, 'utf-8');
+    assert.ok(!body.includes('## Code Snippet'));
+    assert.ok(!body.includes('## Recommendation'));
+    assert.ok(!body.includes('## Data Flow Trace'));
+    assert.ok(!body.includes('**Severity**'));
+    assert.ok(!body.includes('**Confidence**'));
+    // Single-line range collapses to just the number.
+    assert.ok(body.includes('**Lines**: 1\n'));
+  });
+
+  it('escapes Windows reserved device names in filenames', async () => {
+    const out = resolve(tmp, 'case-windows-reserved');
+    const issues = [
+      makeIssue({ file: 'src/CON.ts' }),
+      makeIssue({ file: 'src/nul' }),
+      makeIssue({ file: 'src/com1.log' }),
+    ];
+    const { files } = await writeIndividualIssueFiles(makeResults(issues), out, 'markdown');
+    // Each filename's source-name component should be prefixed with `_` so
+    // Windows can write it (CON, NUL, COM1 are reserved device names).
+    assert.match(files[0]!, /issue_001__CON\.ts\.md$/);
+    assert.match(files[1]!, /issue_002__nul\.md$/);
+    assert.match(files[2]!, /issue_003__com1\.log\.md$/);
+  });
+
+  it('uses dynamic-length code fence so embedded triple backticks do not break out', async () => {
+    const out = resolve(tmp, 'case-fence');
+    const issue = makeIssue({
+      codeSnippet: 'before\n```\nstill in code\n```\nafter',
+    });
+    const { files } = await writeIndividualIssueFiles(makeResults([issue]), out, 'markdown');
+    const body = await readFile(files[0]!, 'utf-8');
+    // Snippet contains a 3-backtick run, so the wrapper fence must be >= 4 backticks.
+    assert.ok(body.includes('````\nbefore'), 'wrapper fence should be at least 4 backticks');
+    assert.ok(body.includes('after\n````'), 'closing fence should match wrapper length');
+    // Inner triple backticks remain literal — they no longer terminate the block.
+    assert.ok(body.includes('```\nstill in code\n```'));
+  });
+
+  it('throws on unsupported individual issue format', async () => {
+    const out = resolve(tmp, 'case-unsupported');
+    await assert.rejects(
+      // @ts-expect-error testing runtime guard against bad programmatic input
+      () => writeIndividualIssueFiles(makeResults([makeIssue()]), out, 'pdf'),
+      /Unsupported individual issue format: pdf/,
+    );
+  });
+
+  it('derives project name from remoteUrl when path is missing', async () => {
+    const out = resolve(tmp, 'case11');
+    const results: ScanResults = makeResults([makeIssue()]);
+    results.repository = { path: '', remoteUrl: 'git@github.com:org/cool-project.git', isGitRepository: true };
+    const { rootDir } = await writeIndividualIssueFiles(results, out, 'markdown');
+    assert.ok(rootDir.endsWith('security_issues_cool-project'), `unexpected rootDir: ${rootDir}`);
+  });
+});
+


### PR DESCRIPTION
Adds an opt-in reporting mode that emits a separate file for each finding alongside the main report, so individual issues can be reviewed, assigned or tracked without splitting the aggregate report by hand. Closes #114 (spec E.3.2).

## Usage

Enable in `runtime-config.json`:

```json
{
  "reporting": {
    "includeIndividualIssueFiles": true,
    "individualIssueFormat": "markdown"
  }
}
```

Files land in `security_issues_<project>/<check-id>/`, named `issue_<NNN>_<filename>.<ext>`, in the same folder as the main report. Formats: `markdown` (default), `json`, `html`.

## Safety

- **Filenames** are sanitised for Windows, macOS and Linux — unsafe characters replaced, leading dots stripped so no accidental dotfiles, and Windows reserved device names (`CON`, `PRN`, `NUL`, `COM1-9`, `LPT1-9`) prefixed so writes do not fail on Windows.
- **HTML output escapes all user-controlled fields** — descriptions, recommendations, code snippets, file paths and data flow steps. Markup in AI responses or in scanned source cannot inject into the report.

## Verification

`npm run lint`, `npm run build` clean. **1023/1023 tests pass.**

Functional tests with mock AI:

| Scenario | Result |
|---|---|
| `markdown` format | Correct directory structure and content |
| `html` format | Renders; quotes escaped |
| XSS payload via description + recommendation | No raw `<script>` in output; `<script>alert('xss')</script>` and `<img src=x onerror=alert(1)>` both fully escaped |

## Note

The HTML escaper is the shared `escapeHtml` exported from `src/formatters/html-formatter.ts` rather than a second private copy, so the two HTML output paths cannot drift apart.