### PR TITLE
feat: post scan findings as inline GitHub PR review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ listed instead of its contents.
 - `src/diff-filter.ts` — Diff filter (`applyDiffFilter`), applied post-discovery whenever a diff source exists and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets using the OpenAnt call graph (depth-1), falling back to file+line overlap (depth-0) when OpenAnt is unavailable. Supported by `diff-parser.ts` and `diff-unit-matcher.ts`
 - `src/*-runner.ts` — External tool execution with mock support (semgrep, opengrep, openant). `semgrep-runner.ts` exports the shared `runSarifScanner`/`verifySarifScannerInstalled` helpers that `opengrep-runner.ts` delegates to
 - `src/cost-calculator.ts`, `src/budget.ts`, `src/scan-history.ts` — Cost/budget subsystem: token→USD estimation from `config/pricing.json`, per-scan and per-period limits, and persisted history at `~/.aghast/history.json`
+- `src/result-handlers/` — Post-scan delivery of findings to external systems. Currently `pr-comment-handler.ts` (GitHub PR inline review comments, spec E.7 Phase 1); issue trackers and notifications are the intended future siblings
 
 **Design decisions worth knowing**
 
@@ -173,7 +174,7 @@ listed instead of its contents.
 
 ## Conventions
 
-- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep/Opengrep, E6xxx=OpenAnt, E70xx=budget, E9xxx=internal/fatal.
+- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep/Opengrep, E6xxx=OpenAnt, E70xx=budget, E72xx=result handlers (PR comments etc.), E9xxx=internal/fatal.
 - **Color output**: Use helpers from `src/colors.ts` for colored output, never raw ANSI codes. The `NO_COLOR` env var is respected automatically via `picocolors`.
 
 ## Development Workflow

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -33,8 +33,45 @@ aghast scan <repo-path> --config-dir <path> [options]
 | `--diff-file <path>` | Path to pre-generated unified diff file (alternative to `--diff-ref`) |
 | `--budget-limit-cost <usd>` | Abort the scan when accumulated cost exceeds this USD value (warns at 80%) |
 | `--budget-limit-tokens <n>` | Abort the scan when accumulated tokens exceed this count (warns at 80%) |
+| `--pr <number>` | Pull request number to post findings to as inline review comments (Phase 1, Spec E.7) |
+| `--repo <owner/repo>` | GitHub repository in `owner/repo` form (defaults to `$GITHUB_REPOSITORY`) |
+| `--base-sha <sha>` | Optional base commit SHA (defaults to `$GITHUB_BASE_SHA`) |
+| `--head-sha <sha>` | Optional head commit SHA (defaults to `$GITHUB_HEAD_SHA` then `$GITHUB_SHA`) |
 
 Run `aghast scan --help` for the full list of options.
+
+## Posting Findings to GitHub Pull Requests
+
+Pass `--pr <number> --repo <owner/repo>` to post inline review comments for each
+finding whose location intersects the PR diff. Findings outside the changed
+lines are skipped (logged at `debug` level), and previously posted comments are
+deduplicated using a hidden marker hash so re-running on the same PR is
+idempotent.
+
+Authentication piggybacks on the [`gh` CLI](https://cli.github.com/) — either
+log in with `gh auth login` or set `GH_TOKEN` / `GITHUB_TOKEN` (e.g. the
+GitHub Actions `secrets.GITHUB_TOKEN`). The token is passed through `gh` via
+the environment and is never written to argv or logs.
+
+```bash
+aghast scan ./repo --config-dir ./checks --pr 42 --repo octo/demo
+```
+
+In a GitHub Actions workflow, `--repo` and `--head-sha` can be omitted and the
+defaults from `$GITHUB_REPOSITORY` / `$GITHUB_HEAD_SHA` / `$GITHUB_SHA` will be
+used automatically.
+
+If `gh` is not installed or not authenticated, posting fails with a `[E7201]`
+error but the scan still completes and the JSON/SARIF report is still written —
+the PR comment phase is non-fatal.
+
+> **Concurrency caveat.** Dedup is per-run: two parallel CI shards posting to
+> the same PR can each pass the marker check and produce duplicate comments.
+> Confine `--pr` to a single matrix job (or run after the matrix completes).
+
+> **Phase 1 only.** Issue tracker creation, AI-assisted remediation, IDE/LSP
+> integration, and Slack/email notifications listed in Spec E.7 are deferred
+> to future iterations.
 
 ## Environment Variables
 

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -8,7 +8,8 @@
  *   E4xxx — Repository/target validation
  *   E5xxx — Semgrep / Opengrep
  *   E6xxx — OpenAnt
- *   E7xxx — Budget / cost controls
+ *   E70xx — Budget / cost controls
+ *   E72xx — Result handlers (PR comments, issue trackers, notifications)
  *   E9xxx — Internal/fatal
  */
 
@@ -55,8 +56,11 @@ export const ERROR_CODES = {
   E6001: ec('E6001', 'OpenAnt not installed'),
   E6002: ec('E6002', 'OpenAnt execution failed'),
 
-  // E7xxx — Budget / cost controls
+  // E70xx — Budget / cost controls
   E7001: ec('E7001', 'Budget limit exceeded'),
+
+  // E72xx — Result handlers
+  E7201: ec('E7201', 'PR comment posting failed'),
 
   // E9xxx — Internal
   E9001: ec('E9001', 'Fatal internal error'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { DEFAULT_OUTPUT_FORMAT, DEFAULT_LOG_LEVEL, DEFAULT_LOG_TYPE } from './de
 import { colorStatus } from './colors.js';
 import { getCheckType } from './check-types.js';
 import { getDiscovery, getRegisteredDiscoveries } from './discovery.js';
+import { postPRComments } from './result-handlers/pr-comment-handler.js';
 import { createRequire } from 'node:module';
 
 const TAG = 'aghast';
@@ -119,6 +120,14 @@ General options:
   --budget-limit-tokens <n>  Abort the scan when accumulated tokens exceed n.
                              Warns at 80%, aborts at 100%
 
+PR comment options (post findings as inline GitHub PR review comments):
+  --pr <number>              Pull request number to post comments on
+  --repo <owner/repo>        GitHub repository in owner/repo form
+                             (default: $GITHUB_REPOSITORY)
+  --base-sha <sha>           Base commit SHA (default: $GITHUB_BASE_SHA)
+  --head-sha <sha>           Head commit SHA
+                             (default: $GITHUB_HEAD_SHA / $GITHUB_SHA)
+
 Environment variables:
   ANTHROPIC_API_KEY           API key for Claude. If unset, AI-based checks fall
                               back to a logged-in local Claude session
@@ -134,6 +143,11 @@ Environment variables:
   AGHAST_OPENANT_DATASET      Use a pre-generated OpenAnt dataset JSON file
   AGHAST_DIFF_REF             Git ref to diff against (CLI --diff-ref takes precedence)
   NO_COLOR                    Set to "1" to disable colored output
+  GITHUB_REPOSITORY           Default for --repo (auto-set in GitHub Actions)
+  GITHUB_BASE_SHA             Default for --base-sha
+  GITHUB_HEAD_SHA             Default for --head-sha
+  GITHUB_SHA                  Fallback for --head-sha (auto-set in GitHub Actions)
+  GH_TOKEN / GITHUB_TOKEN     Auth for the gh CLI when posting PR comments
 
 Examples:
   aghast scan ./my-repo --config-dir ./my-checks
@@ -160,6 +174,10 @@ function parseArgs(args: string[]): {
   diffFile?: string;
   budgetLimitCost?: number;
   budgetLimitTokens?: number;
+  prNumber?: number;
+  prRepo?: string;
+  baseSha?: string;
+  headSha?: string;
 } {
   if (args.length < 1 || args.includes('--help') || args.includes('-h')) {
     console.log(SCAN_HELP);
@@ -187,6 +205,10 @@ function parseArgs(args: string[]): {
   let diffFile: string | undefined;
   let budgetLimitCost: number | undefined;
   let budgetLimitTokens: number | undefined;
+  let prNumber: number | undefined;
+  let prRepo: string | undefined;
+  let baseSha: string | undefined;
+  let headSha: string | undefined;
 
   for (let i = startIdx; i < args.length; i++) {
     switch (args[i]) {
@@ -333,6 +355,48 @@ function parseArgs(args: string[]): {
         i++;
         break;
       }
+      case '--pr': {
+        const raw = args[i + 1];
+        if (!raw) {
+          console.error(formatError(ERROR_CODES.E1001, '--pr requires a pull request number'));
+          process.exit(1);
+        }
+        const parsedNum = Number.parseInt(raw, 10);
+        if (!Number.isInteger(parsedNum) || parsedNum <= 0) {
+          console.error(formatError(ERROR_CODES.E1001, `--pr requires a positive integer (got "${raw}")`));
+          process.exit(1);
+        }
+        prNumber = parsedNum;
+        i++;
+        break;
+      }
+      case '--repo': {
+        prRepo = args[i + 1];
+        if (!prRepo) {
+          console.error(formatError(ERROR_CODES.E1001, '--repo requires an owner/repo argument'));
+          process.exit(1);
+        }
+        i++;
+        break;
+      }
+      case '--base-sha': {
+        baseSha = args[i + 1];
+        if (!baseSha) {
+          console.error(formatError(ERROR_CODES.E1001, '--base-sha requires a SHA argument'));
+          process.exit(1);
+        }
+        i++;
+        break;
+      }
+      case '--head-sha': {
+        headSha = args[i + 1];
+        if (!headSha) {
+          console.error(formatError(ERROR_CODES.E1001, '--head-sha requires a SHA argument'));
+          process.exit(1);
+        }
+        i++;
+        break;
+      }
       case '--fail-on-check-failure':
       case '--debug':
         // Boolean flags are handled above via includes().
@@ -354,7 +418,28 @@ function parseArgs(args: string[]): {
     runtimeConfigPath, model, agentProvider, genericPrompt,
     diffRef, diffFile,
     budgetLimitCost, budgetLimitTokens,
+    prNumber, prRepo, baseSha, headSha,
   };
+}
+
+/**
+ * Parse "owner/repo" into its parts. Returns undefined when the input is
+ * missing or malformed so callers can produce a CLI-friendly error.
+ *
+ * Validates each half against `^[A-Za-z0-9_.-]+$` — the character set GitHub
+ * actually permits in owner/repo names. This rejects whitespace and shell
+ * metacharacters defensively, even though the parsed value is only ever
+ * interpolated into a `gh api` URL path (no shell).
+ */
+const REPO_SLUG_PART = /^[A-Za-z0-9_.-]+$/;
+export function parseRepoSlug(slug: string | undefined): { owner: string; repo: string } | undefined {
+  if (!slug) return undefined;
+  const parts = slug.split('/');
+  if (parts.length !== 2) return undefined;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return undefined;
+  if (!REPO_SLUG_PART.test(owner) || !REPO_SLUG_PART.test(repo)) return undefined;
+  return { owner, repo };
 }
 
 async function createProvider(
@@ -865,6 +950,38 @@ export async function runScan(args: string[]): Promise<void> {
       const reason = outcome.budgetAbortReason ?? 'Budget limit exceeded';
       console.error(formatError(ERROR_CODES.E7001, reason));
       logProgress(TAG, `Scan aborted by budget: ${reason}`);
+    }
+
+    // ─── Optional: post findings as PR comments ──────────────────────────────
+    if (parsed.prNumber !== undefined) {
+      const repoSlug = parsed.prRepo ?? process.env.GITHUB_REPOSITORY;
+      const repoParts = parseRepoSlug(repoSlug);
+      if (!repoParts) {
+        console.error(formatError(
+          ERROR_CODES.E1001,
+          '--pr was supplied but --repo (or $GITHUB_REPOSITORY) is missing or not in owner/repo form',
+        ));
+        await closeAllHandlers();
+        process.exit(1);
+      }
+      try {
+        const headSha = parsed.headSha ?? process.env.GITHUB_HEAD_SHA ?? process.env.GITHUB_SHA;
+        const baseSha = parsed.baseSha ?? process.env.GITHUB_BASE_SHA;
+        const summary = await postPRComments(results, {
+          owner: repoParts.owner,
+          repo: repoParts.repo,
+          prNumber: parsed.prNumber,
+          baseSha,
+          headSha,
+        });
+        console.log(`  PR comments:   posted ${summary.posted}, skipped ${summary.skipped}`);
+      } catch (err) {
+        console.error(formatError(
+          ERROR_CODES.E7201,
+          `Failed to post PR comments: ${err instanceof Error ? err.message : String(err)}`,
+        ));
+        // Non-fatal: don't override scan exit code, but log a warning.
+      }
     }
 
     // Exit code based on --fail-on-check-failure flag or runtime config (spec Section 9.3),

--- a/src/result-handlers/pr-comment-handler.ts
+++ b/src/result-handlers/pr-comment-handler.ts
@@ -1,0 +1,505 @@
+/**
+ * GitHub PR comment result handler (Phase 1 of Spec E.7).
+ *
+ * Posts aghast scan findings as inline review comments on a GitHub pull request.
+ * Issues that fall outside the PR diff are skipped (with a debug log). Existing
+ * comments authored by aghast are deduplicated using a hidden HTML marker
+ * embedded in the comment body.
+ *
+ * Phase-1 limitations (intentional):
+ *   - Multi-line findings (`endLine > startLine`) are anchored at `startLine`
+ *     only; we do not yet emit GitHub's multi-line `start_line`/`line` form.
+ *   - Dedup is best-effort and per-run: two parallel runs (e.g. CI matrix
+ *     shards) on the same PR can each pass the dedup check and post duplicate
+ *     comments. Confine `--pr` to a single matrix shard, or run after the
+ *     matrix completes. A future phase could PATCH instead of POST.
+ *
+ * Future phases (issue tracker integration, AI remediation, IDE/LSP, Slack/email
+ * notifications) are intentionally out of scope here — see GitHub issue #119.
+ */
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendFileSync } from 'node:fs';
+import { logDebug, logProgress, logWarn } from '../logging.js';
+import type { ScanResults, SecurityIssue } from '../types.js';
+
+const TAG = 'pr-comment-handler';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal subset of the GitHub PR "files" API response we care about.
+ * Each entry describes one file in the PR diff; `patch` contains the unified-diff
+ * hunks for that file (omitted by GitHub for binary or very large files).
+ */
+export interface PullRequestFile {
+  filename: string;
+  status: string;
+  patch?: string;
+}
+
+/**
+ * Minimal subset of the GitHub review-comments API response used for dedup.
+ */
+export interface ExistingReviewComment {
+  id: number;
+  path: string;
+  line: number | null;
+  body: string;
+}
+
+/**
+ * Single inline comment in the payload sent to the GitHub Reviews API.
+ * Matches the schema documented at:
+ *   https://docs.github.com/rest/pulls/reviews#create-a-review-for-a-pull-request
+ */
+export interface ReviewComment {
+  path: string;
+  line: number;
+  side: 'LEFT' | 'RIGHT';
+  body: string;
+}
+
+export interface PRCommentContext {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  /** Optional commit SHAs — currently informational; the GitHub API uses
+   *  the PR's head commit by default when posting a review. */
+  baseSha?: string;
+  headSha?: string;
+  /** Optional explicit token. If omitted, the `gh` CLI's stored auth is used. */
+  githubToken?: string;
+}
+
+export interface PRCommentResult {
+  posted: number;
+  skipped: number;
+}
+
+/**
+ * Pluggable command executor — lets tests inject a fake `gh` so we don't hit
+ * GitHub. Receives positional args (no shell interpolation). Returns stdout
+ * and the exit code.
+ */
+export interface CommandExecutor {
+  (
+    command: string,
+    args: string[],
+    options?: { input?: string; env?: NodeJS.ProcessEnv },
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+// ─── Default executor (real `gh` shell-out) ──────────────────────────────────
+
+/**
+ * Test-only fake executor selector.
+ *
+ * When `AGHAST_PR_COMMENT_FAKE_FILES` is set, `gh api .../pulls/<n>/files` calls
+ * resolve to the JSON contents of that file. When `AGHAST_PR_COMMENT_FAKE_LOG`
+ * is set, every captured call (including POST bodies) is appended as JSON-lines
+ * to that path. The real `gh` is never spawned. This is used by CLI integration
+ * tests so we can exercise the full --pr code path without hitting GitHub.
+ */
+function maybeFakeExecutor(): CommandExecutor | undefined {
+  const filesPath = process.env.AGHAST_PR_COMMENT_FAKE_FILES;
+  const logPath = process.env.AGHAST_PR_COMMENT_FAKE_LOG;
+  const commentsPath = process.env.AGHAST_PR_COMMENT_FAKE_COMMENTS;
+  if (!filesPath && !logPath && !commentsPath) return undefined;
+
+  return async (command, args) => {
+    if (logPath) {
+      try {
+        appendFileSync(
+          logPath,
+          JSON.stringify({ command, args }) + '\n',
+          'utf-8',
+        );
+      } catch {
+        // Best-effort logging only.
+      }
+    }
+    const apiPath = args[args.length - 1] ?? '';
+    if (/\/files(\?|$)/.test(apiPath) && filesPath) {
+      const { readFileSync } = await import('node:fs');
+      return { stdout: readFileSync(filesPath, 'utf-8'), stderr: '', exitCode: 0 };
+    }
+    if (/\/comments(\?|$)/.test(apiPath)) {
+      if (commentsPath) {
+        const { readFileSync } = await import('node:fs');
+        return { stdout: readFileSync(commentsPath, 'utf-8'), stderr: '', exitCode: 0 };
+      }
+      return { stdout: '[]', stderr: '', exitCode: 0 };
+    }
+    if (/\/reviews(\?|$)/.test(apiPath)) {
+      return { stdout: '{"id":1}', stderr: '', exitCode: 0 };
+    }
+    return { stdout: '[]', stderr: '', exitCode: 0 };
+  };
+}
+
+export const defaultExecutor: CommandExecutor = (command, args, options = {}) => {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      env: { ...process.env, ...(options.env ?? {}) },
+      shell: false,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf-8');
+    });
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      // Translate the most common failure (gh CLI not installed) into an
+      // actionable message. Without this the user sees `Error: spawn gh ENOENT`
+      // and has to guess what to install.
+      if (err.code === 'ENOENT') {
+        reject(new Error(
+          `gh CLI not found on PATH. Install it from https://cli.github.com or set GH_TOKEN and ensure 'gh' is reachable. (original: ${err.message})`,
+        ));
+        return;
+      }
+      reject(err);
+    });
+    child.on('close', (code) => {
+      resolvePromise({ stdout, stderr, exitCode: code ?? 1 });
+    });
+    if (options.input !== undefined) {
+      child.stdin.end(options.input);
+    } else {
+      child.stdin.end();
+    }
+  });
+};
+
+// ─── Patch parsing ───────────────────────────────────────────────────────────
+
+/**
+ * Parse a unified-diff `patch` (as returned by GitHub's PR files API) into the
+ * set of new-file line numbers that were added or modified by the PR.
+ *
+ * GitHub PR review comments can target either the LEFT (base) or RIGHT (head)
+ * side. We only post comments on lines that exist on the head side — i.e. lines
+ * actually changed (added) by this PR — to avoid leaving stale comments on
+ * unchanged code.
+ */
+export function parsePatchAddedLines(patch: string): Set<number> {
+  const addedLines = new Set<number>();
+  if (!patch) return addedLines;
+
+  const lines = patch.split('\n');
+  let newLine = 0;
+  let inHunk = false;
+  // Hunk header format: @@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@
+  const hunkRegex = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+  for (const line of lines) {
+    const hunkMatch = hunkRegex.exec(line);
+    if (hunkMatch) {
+      newLine = Number(hunkMatch[1]);
+      inHunk = true;
+      continue;
+    }
+    // Defensive: ignore patch content (including stray `+` lines from a
+    // malformed patch) until we see the first hunk header. This prevents us
+    // from ever recording line 0 — which would later masquerade as a real
+    // diff line and either skip or anchor a comment at a nonexistent line.
+    if (!inHunk) continue;
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      addedLines.add(newLine);
+      newLine++;
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      // Removed line — does not advance newLine
+    } else if (line.startsWith('\\')) {
+      // "\ No newline at end of file" — ignore, doesn't advance
+    } else {
+      // Context line: present in both old and new.
+      newLine++;
+    }
+  }
+  return addedLines;
+}
+
+/**
+ * Build a map of file path → set of new-side line numbers changed by the PR.
+ */
+export function buildDiffLineMap(files: PullRequestFile[]): Map<string, Set<number>> {
+  const map = new Map<string, Set<number>>();
+  for (const file of files) {
+    if (!file.patch) continue;
+    map.set(file.filename, parsePatchAddedLines(file.patch));
+  }
+  return map;
+}
+
+// ─── Comment building ────────────────────────────────────────────────────────
+
+/**
+ * Stable hash identifying a single (check + file + line + description) tuple.
+ * Embedded as an HTML comment in the body so future runs can recognise — and
+ * skip — comments they previously posted.
+ */
+export function issueHash(issue: SecurityIssue): string {
+  // Description is deliberately NOT in the hash. AI-generated descriptions are
+  // non-deterministic (the LLM may rephrase the same finding across runs), so
+  // including the description would defeat dedup on re-runs. The trade-off: if
+  // an issue at the same (checkId, file, startLine) genuinely changes meaning,
+  // the original comment will not be refreshed — Phase 1 accepts that staleness
+  // in exchange for idempotent re-runs. A future phase can PATCH the existing
+  // comment to refresh stale descriptions.
+  const payload = [
+    issue.checkId,
+    issue.file,
+    issue.startLine,
+  ].join(' ');
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+const MARKER_PREFIX = '<!-- aghast-issue-id: ';
+const MARKER_SUFFIX = ' -->';
+
+export function buildCommentBody(issue: SecurityIssue): string {
+  const hash = issueHash(issue);
+  const severity = issue.severity ? ` (${issue.severity})` : '';
+  const lines: string[] = [];
+  lines.push(`**aghast: ${issue.checkName}**${severity}`);
+  lines.push('');
+  lines.push(issue.description);
+  if (issue.recommendation) {
+    lines.push('');
+    lines.push(`**Recommendation:** ${issue.recommendation}`);
+  }
+  lines.push('');
+  lines.push(`${MARKER_PREFIX}${hash}${MARKER_SUFFIX}`);
+  return lines.join('\n');
+}
+
+export function extractMarkerHash(body: string): string | undefined {
+  const idx = body.indexOf(MARKER_PREFIX);
+  if (idx === -1) return undefined;
+  const start = idx + MARKER_PREFIX.length;
+  const end = body.indexOf(MARKER_SUFFIX, start);
+  if (end === -1) return undefined;
+  return body.slice(start, end).trim();
+}
+
+/**
+ * Map a SecurityIssue onto a ReviewComment, or return undefined if the issue's
+ * line is not part of the PR diff.
+ */
+export function issueToReviewComment(
+  issue: SecurityIssue,
+  diffLines: Map<string, Set<number>>,
+): ReviewComment | undefined {
+  const fileLines = diffLines.get(issue.file);
+  if (!fileLines || !fileLines.has(issue.startLine)) {
+    return undefined;
+  }
+  return {
+    path: issue.file,
+    line: issue.startLine,
+    side: 'RIGHT',
+    body: buildCommentBody(issue),
+  };
+}
+
+// ─── gh API helpers ──────────────────────────────────────────────────────────
+
+interface GhApiOptions {
+  method?: 'GET' | 'POST';
+  paginate?: boolean;
+  body?: unknown;
+  token?: string;
+}
+
+async function ghApi<T>(
+  executor: CommandExecutor,
+  path: string,
+  options: GhApiOptions = {},
+): Promise<T> {
+  const args: string[] = ['api'];
+  if (options.method && options.method !== 'GET') {
+    args.push('--method', options.method);
+  }
+  if (options.paginate) args.push('--paginate');
+  args.push('-H', 'Accept: application/vnd.github+json');
+  args.push(path);
+
+  let input: string | undefined;
+  if (options.body !== undefined) {
+    args.push('--input', '-');
+    input = JSON.stringify(options.body);
+  }
+
+  // Pass a token via env if provided; we never log or echo it.
+  const env: NodeJS.ProcessEnv = {};
+  if (options.token) env.GH_TOKEN = options.token;
+
+  const result = await executor('gh', args, { input, env });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh api ${path} failed (exit ${result.exitCode}): ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+  if (result.stdout.trim() === '') {
+    return undefined as unknown as T;
+  }
+  return JSON.parse(result.stdout) as T;
+}
+
+async function listPullRequestFiles(
+  executor: CommandExecutor,
+  ctx: PRCommentContext,
+): Promise<PullRequestFile[]> {
+  const path = `repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.prNumber}/files?per_page=100`;
+  return ghApi<PullRequestFile[]>(executor, path, {
+    paginate: true,
+    token: ctx.githubToken,
+  });
+}
+
+async function listExistingReviewComments(
+  executor: CommandExecutor,
+  ctx: PRCommentContext,
+): Promise<ExistingReviewComment[]> {
+  const path = `repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.prNumber}/comments?per_page=100`;
+  return ghApi<ExistingReviewComment[]>(executor, path, {
+    paginate: true,
+    token: ctx.githubToken,
+  });
+}
+
+async function postReview(
+  executor: CommandExecutor,
+  ctx: PRCommentContext,
+  comments: ReviewComment[],
+): Promise<void> {
+  const path = `repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.prNumber}/reviews`;
+  const body: Record<string, unknown> = {
+    event: 'COMMENT',
+    body: `aghast posted ${comments.length} finding${comments.length === 1 ? '' : 's'}.`,
+    comments,
+  };
+  if (ctx.headSha) body.commit_id = ctx.headSha;
+
+  await ghApi<unknown>(executor, path, {
+    method: 'POST',
+    body,
+    token: ctx.githubToken,
+  });
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface PostPRCommentsOptions {
+  /** Inject a custom executor for testing. Defaults to spawning `gh`. */
+  executor?: CommandExecutor;
+}
+
+/**
+ * Post aghast scan issues as inline GitHub PR review comments.
+ *
+ * Workflow:
+ *   1. Fetch the PR's changed-file list and parse each file's diff hunks.
+ *   2. For each issue, compute the corresponding (path, line, RIGHT) target
+ *      and skip issues whose line is outside the diff.
+ *   3. Fetch existing review comments and skip any whose hidden marker hash
+ *      already matches an in-flight comment.
+ *   4. Post the remainder as a single review with `event=COMMENT`.
+ */
+export async function postPRComments(
+  results: ScanResults,
+  ctx: PRCommentContext,
+  options: PostPRCommentsOptions = {},
+): Promise<PRCommentResult> {
+  const executor = options.executor ?? maybeFakeExecutor() ?? defaultExecutor;
+
+  const issues = results.issues ?? [];
+  if (issues.length === 0) {
+    logProgress(TAG, 'No issues to post — skipping PR comment phase');
+    return { posted: 0, skipped: 0 };
+  }
+
+  logProgress(
+    TAG,
+    `Posting up to ${issues.length} finding(s) to ${ctx.owner}/${ctx.repo}#${ctx.prNumber}`,
+  );
+
+  const files = await listPullRequestFiles(executor, ctx);
+  const diffLines = buildDiffLineMap(files);
+  logDebug(TAG, `PR diff covers ${diffLines.size} file(s) with patch hunks`);
+
+  // Map issues onto review comments + bucket the skipped ones.
+  const candidates: ReviewComment[] = [];
+  let skippedOutsideDiff = 0;
+  for (const issue of issues) {
+    const comment = issueToReviewComment(issue, diffLines);
+    if (!comment) {
+      skippedOutsideDiff++;
+      logDebug(
+        TAG,
+        `Skipping issue outside PR diff: ${issue.checkId} ${issue.file}:${issue.startLine}`,
+      );
+      continue;
+    }
+    candidates.push(comment);
+  }
+
+  if (candidates.length === 0) {
+    logProgress(
+      TAG,
+      `No issues fell within the PR diff (${skippedOutsideDiff} skipped)`,
+    );
+    return { posted: 0, skipped: skippedOutsideDiff };
+  }
+
+  // Deduplicate against existing review comments.
+  let existing: ExistingReviewComment[] = [];
+  try {
+    existing = await listExistingReviewComments(executor, ctx);
+  } catch (err) {
+    logWarn(
+      TAG,
+      `Failed to list existing PR comments — skipping dedup: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const existingHashes = new Set<string>();
+  for (const c of existing) {
+    const h = extractMarkerHash(c.body);
+    if (h) existingHashes.add(h);
+  }
+
+  const toPost: ReviewComment[] = [];
+  let skippedDuplicate = 0;
+  for (const comment of candidates) {
+    const h = extractMarkerHash(comment.body);
+    if (h && existingHashes.has(h)) {
+      skippedDuplicate++;
+      logDebug(TAG, `Skipping duplicate comment ${h} on ${comment.path}:${comment.line}`);
+      continue;
+    }
+    toPost.push(comment);
+  }
+
+  const totalSkipped = skippedOutsideDiff + skippedDuplicate;
+  if (toPost.length === 0) {
+    logProgress(
+      TAG,
+      `Nothing new to post (${skippedOutsideDiff} outside diff, ${skippedDuplicate} duplicate)`,
+    );
+    return { posted: 0, skipped: totalSkipped };
+  }
+
+  await postReview(executor, ctx, toPost);
+  logProgress(
+    TAG,
+    `Posted ${toPost.length} comment(s); skipped ${totalSkipped} (${skippedOutsideDiff} outside diff, ${skippedDuplicate} duplicate)`,
+  );
+
+  return { posted: toPost.length, skipped: totalSkipped };
+}

--- a/tests/cli-pr-comments.test.ts
+++ b/tests/cli-pr-comments.test.ts
@@ -1,0 +1,171 @@
+/**
+ * CLI integration tests for the --pr / --repo flags (Phase 1 of Spec E.7).
+ *
+ * Spawns the actual CLI process with AGHAST_MOCK_AI=true and a fake `gh`
+ * executor (driven via AGHAST_PR_COMMENT_FAKE_*) so we exercise the full
+ * argument parsing, scan pipeline, and PR comment handler — without ever
+ * hitting GitHub.
+ */
+
+import { describe, it, afterEach, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  testDir as __dirname,
+  fixtureRepo,
+  singleCheckConfigDir,
+  failFixtureRepo,
+  runCLI,
+} from './cli-test-helpers.js';
+import { parseRepoSlug } from '../src/index.js';
+
+const tmpDir = resolve(__dirname, 'fixtures', 'pr-comments-tmp');
+const filesFixture = resolve(tmpDir, 'pr-files.json');
+const ghLog = resolve(tmpDir, 'gh-calls.jsonl');
+const outputFile = resolve(fixtureRepo, 'security_checks_results_pr.json');
+
+interface CapturedCall {
+  command: string;
+  args: string[];
+}
+
+async function readCalls(): Promise<CapturedCall[]> {
+  let raw: string;
+  try {
+    raw = await readFile(ghLog, 'utf-8');
+  } catch {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => JSON.parse(l) as CapturedCall);
+}
+
+async function cleanup(): Promise<void> {
+  for (const p of [filesFixture, ghLog, outputFile]) {
+    await rm(p, { force: true });
+  }
+}
+
+describe('CLI: --pr posts findings via fake gh executor', () => {
+  before(async () => {
+    await mkdir(tmpDir, { recursive: true });
+  });
+  afterEach(cleanup);
+
+  it('skips issues outside the PR diff and posts those inside', async () => {
+    // PR diff contains src/example.ts with a hunk that adds line 3 — the same
+    // line referenced by failFixtureRepo's mocked AI response.
+    const filesPayload = [
+      {
+        filename: 'src/example.ts',
+        status: 'modified',
+        // @@ -1,2 +1,4 @@ → new lines 3 & 4 added
+        patch: '@@ -1,2 +1,4 @@\n line1\n line2\n+line3 added\n+line4 added',
+      },
+    ];
+    await writeFile(filesFixture, JSON.stringify(filesPayload), 'utf-8');
+
+    const { exitCode, stdout, stderr } = await runCLI(
+      {
+        AGHAST_MOCK_AI: failFixtureRepo,
+        AGHAST_PR_COMMENT_FAKE_FILES: filesFixture,
+        AGHAST_PR_COMMENT_FAKE_LOG: ghLog,
+      },
+      [
+        fixtureRepo,
+        '--config-dir', singleCheckConfigDir,
+        '--output', outputFile,
+        '--pr', '42',
+        '--repo', 'octo/demo',
+      ],
+    );
+    const out = stdout + stderr;
+    assert.equal(exitCode, 0, out);
+    assert.match(out, /PR comments:\s+posted 1, skipped 0/);
+
+    const calls = await readCalls();
+    // Expect at least: list files, list comments, post review.
+    const filesCall = calls.find((c) => c.args.some((a) => /pulls\/42\/files/.test(a)));
+    const commentsCall = calls.find((c) => c.args.some((a) => /pulls\/42\/comments/.test(a)));
+    const reviewCall = calls.find((c) => c.args.some((a) => /pulls\/42\/reviews/.test(a)));
+    assert.ok(filesCall, 'should fetch PR files');
+    assert.ok(commentsCall, 'should fetch existing review comments');
+    assert.ok(reviewCall, 'should POST a review');
+    assert.ok(reviewCall.args.includes('--method'), 'review call uses --method');
+
+    // The POST body is passed via --input - and recorded in the gh log args
+    // chain; we verify the --method POST appears for the reviews endpoint.
+    const idx = reviewCall.args.indexOf('--method');
+    assert.equal(reviewCall.args[idx + 1], 'POST');
+  });
+
+  it('errors when --pr is supplied without a parseable repo slug', async () => {
+    const { exitCode, stderr, stdout } = await runCLI(
+      {
+        AGHAST_MOCK_AI: 'true',
+        // Force GITHUB_REPOSITORY unset
+        GITHUB_REPOSITORY: undefined,
+      },
+      [
+        fixtureRepo,
+        '--config-dir', singleCheckConfigDir,
+        '--output', outputFile,
+        '--pr', '7',
+      ],
+    );
+    const out = stdout + stderr;
+    // The CLI should reject the missing repo slug with E1001.
+    assert.notEqual(exitCode, 0, out);
+    assert.match(out, /E1001/);
+  });
+
+  it('rejects non-numeric --pr values', async () => {
+    const { exitCode, stderr, stdout } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [
+        fixtureRepo,
+        '--config-dir', singleCheckConfigDir,
+        '--output', outputFile,
+        '--pr', 'abc',
+      ],
+    );
+    const out = stdout + stderr;
+    assert.notEqual(exitCode, 0, out);
+    assert.match(out, /E1001/);
+  });
+});
+
+describe('parseRepoSlug', () => {
+  it('accepts a well-formed owner/repo slug', () => {
+    assert.deepEqual(parseRepoSlug('octocat/hello-world'), { owner: 'octocat', repo: 'hello-world' });
+  });
+
+  it('accepts dots, dashes, underscores, and digits in either half', () => {
+    assert.deepEqual(parseRepoSlug('a.b_c-1/x.y_z-2'), { owner: 'a.b_c-1', repo: 'x.y_z-2' });
+  });
+
+  it('rejects undefined / empty input', () => {
+    assert.equal(parseRepoSlug(undefined), undefined);
+    assert.equal(parseRepoSlug(''), undefined);
+  });
+
+  it('rejects missing slash or wrong number of parts', () => {
+    assert.equal(parseRepoSlug('owner_only'), undefined);
+    assert.equal(parseRepoSlug('a/b/c'), undefined);
+  });
+
+  it('rejects empty halves', () => {
+    assert.equal(parseRepoSlug('/repo'), undefined);
+    assert.equal(parseRepoSlug('owner/'), undefined);
+  });
+
+  it('rejects whitespace and shell-special characters in either half', () => {
+    assert.equal(parseRepoSlug('own er/repo'), undefined);
+    assert.equal(parseRepoSlug('owner/re;po'), undefined);
+    assert.equal(parseRepoSlug('owner/$repo'), undefined);
+    assert.equal(parseRepoSlug('owner/repo with space'), undefined);
+  });
+});

--- a/tests/pr-comment-handler.test.ts
+++ b/tests/pr-comment-handler.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for the GitHub PR comment result handler.
+ *
+ * All tests inject a fake CommandExecutor — we never spawn `gh` or hit GitHub.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parsePatchAddedLines,
+  buildDiffLineMap,
+  buildCommentBody,
+  extractMarkerHash,
+  issueHash,
+  issueToReviewComment,
+  postPRComments,
+  type CommandExecutor,
+  type PullRequestFile,
+  type ExistingReviewComment,
+} from '../src/result-handlers/pr-comment-handler.js';
+import type { ScanResults, SecurityIssue } from '../src/types.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface RecordedCall {
+  command: string;
+  args: string[];
+  input?: string;
+  envHasToken: boolean;
+}
+
+interface FakeExecutorOptions {
+  /**
+   * Map from a substring of the API path to the response payload.
+   * The first matching key wins.
+   */
+  responses?: Array<{ match: RegExp; body: unknown; exitCode?: number; stderr?: string }>;
+}
+
+function makeFakeExecutor(opts: FakeExecutorOptions = {}): {
+  executor: CommandExecutor;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const executor: CommandExecutor = async (command, args, options = {}) => {
+    calls.push({
+      command,
+      args: [...args],
+      input: options.input,
+      envHasToken: !!(options.env?.GH_TOKEN ?? options.env?.GITHUB_TOKEN),
+    });
+
+    const apiPath = args[args.length - 1] ?? '';
+    for (const r of opts.responses ?? []) {
+      if (r.match.test(apiPath)) {
+        return {
+          stdout: r.body === undefined ? '' : JSON.stringify(r.body),
+          stderr: r.stderr ?? '',
+          exitCode: r.exitCode ?? 0,
+        };
+      }
+    }
+    // Default: empty array for list endpoints.
+    return { stdout: '[]', stderr: '', exitCode: 0 };
+  };
+  return { executor, calls };
+}
+
+function makeIssue(overrides: Partial<SecurityIssue> = {}): SecurityIssue {
+  return {
+    checkId: 'sql-injection',
+    checkName: 'SQL Injection',
+    file: 'src/db.ts',
+    startLine: 10,
+    endLine: 10,
+    description: 'Unparameterised query',
+    severity: 'high',
+    ...overrides,
+  };
+}
+
+function makeResults(issues: SecurityIssue[]): ScanResults {
+  return {
+    scanId: 'test',
+    timestamp: new Date().toISOString(),
+    version: '0.0.0',
+    repository: { path: '/tmp/repo', isGitRepository: true },
+    issues,
+    checks: [],
+    summary: {
+      totalChecks: 0,
+      passedChecks: 0,
+      failedChecks: 0,
+      flaggedChecks: 0,
+      errorChecks: 0,
+      totalIssues: issues.length,
+    },
+    executionTime: 0,
+    startTime: new Date().toISOString(),
+    endTime: new Date().toISOString(),
+    agentProvider: { name: 'mock', models: ['mock'] },
+  };
+}
+
+// ─── parsePatchAddedLines ────────────────────────────────────────────────────
+
+describe('parsePatchAddedLines', () => {
+  it('returns the new-side line numbers of added lines', () => {
+    const patch = [
+      '@@ -1,3 +1,4 @@',
+      ' line1',
+      ' line2',
+      '+inserted at new line 3',
+      ' line3',
+    ].join('\n');
+    const added = parsePatchAddedLines(patch);
+    assert.deepEqual([...added].sort(), [3]);
+  });
+
+  it('handles multiple hunks and removed lines', () => {
+    const patch = [
+      '@@ -10,3 +10,4 @@',
+      ' a',
+      '+added line at 11',
+      ' b',
+      ' c',
+      '@@ -50,2 +51,2 @@',
+      '-old',
+      '+new at 51',
+      ' tail',
+    ].join('\n');
+    const added = parsePatchAddedLines(patch);
+    assert.deepEqual([...added].sort((x, y) => x - y), [11, 51]);
+  });
+
+  it('returns an empty set for an empty patch', () => {
+    assert.equal(parsePatchAddedLines('').size, 0);
+  });
+
+  it('ignores + lines that appear before any hunk header (malformed patch)', () => {
+    // Defensive: without the inHunk guard this would record line 0.
+    const patch = ['+ stray plus before hunk', '@@ -1,1 +1,2 @@', ' a', '+real at 2'].join('\n');
+    const added = parsePatchAddedLines(patch);
+    assert.deepEqual([...added].sort(), [2]);
+    assert.equal(added.has(0), false);
+  });
+});
+
+// ─── buildDiffLineMap ────────────────────────────────────────────────────────
+
+describe('buildDiffLineMap', () => {
+  it('skips files with no patch (e.g. binary)', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'a.bin', status: 'added' },
+      {
+        filename: 'src/x.ts',
+        status: 'modified',
+        patch: '@@ -0,0 +1,1 @@\n+hello',
+      },
+    ];
+    const map = buildDiffLineMap(files);
+    assert.equal(map.has('a.bin'), false);
+    assert.deepEqual([...(map.get('src/x.ts') ?? [])], [1]);
+  });
+});
+
+// ─── Marker / hashing ────────────────────────────────────────────────────────
+
+describe('issueHash + marker', () => {
+  it('produces a stable hash for the same logical issue', () => {
+    const a = issueHash(makeIssue());
+    const b = issueHash(makeIssue());
+    assert.equal(a, b);
+  });
+
+  it('is stable when only the description changes (LLM rephrasing)', () => {
+    // Description is intentionally NOT in the hash so AI rephrasing across
+    // runs does not produce a duplicate comment.
+    const a = issueHash(makeIssue({ description: 'one' }));
+    const b = issueHash(makeIssue({ description: 'two' }));
+    assert.equal(a, b);
+  });
+
+  it('changes when the file or line changes', () => {
+    const base = makeIssue();
+    assert.notEqual(issueHash(base), issueHash({ ...base, file: 'src/other.ts' }));
+    assert.notEqual(issueHash(base), issueHash({ ...base, startLine: base.startLine + 1 }));
+  });
+
+  it('changes when the checkId changes', () => {
+    const a = issueHash(makeIssue({ checkId: 'sql-injection' }));
+    const b = issueHash(makeIssue({ checkId: 'xss' }));
+    assert.notEqual(a, b);
+  });
+
+  it('round-trips through buildCommentBody / extractMarkerHash', () => {
+    const issue = makeIssue();
+    const body = buildCommentBody(issue);
+    assert.equal(extractMarkerHash(body), issueHash(issue));
+  });
+
+  it('extractMarkerHash returns undefined when no marker is present', () => {
+    assert.equal(extractMarkerHash('just a normal comment'), undefined);
+  });
+});
+
+// ─── issueToReviewComment ────────────────────────────────────────────────────
+
+describe('issueToReviewComment', () => {
+  it('returns undefined when the file is not in the diff', () => {
+    const diff = new Map<string, Set<number>>([['other.ts', new Set([1, 2])]]);
+    const issue = makeIssue({ file: 'src/db.ts', startLine: 1 });
+    assert.equal(issueToReviewComment(issue, diff), undefined);
+  });
+
+  it('returns undefined when the line is not in the diff for that file', () => {
+    const diff = new Map<string, Set<number>>([['src/db.ts', new Set([1, 2])]]);
+    const issue = makeIssue({ file: 'src/db.ts', startLine: 99 });
+    assert.equal(issueToReviewComment(issue, diff), undefined);
+  });
+
+  it('produces a RIGHT-side comment when the line is in the diff', () => {
+    const diff = new Map<string, Set<number>>([['src/db.ts', new Set([10])]]);
+    const issue = makeIssue();
+    const comment = issueToReviewComment(issue, diff);
+    assert.ok(comment);
+    assert.equal(comment.path, 'src/db.ts');
+    assert.equal(comment.line, 10);
+    assert.equal(comment.side, 'RIGHT');
+    assert.match(comment.body, /aghast-issue-id:/);
+  });
+});
+
+// ─── postPRComments (integration with fake executor) ─────────────────────────
+
+describe('postPRComments', () => {
+  const ctx = {
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 42,
+  };
+
+  const filesPayload: PullRequestFile[] = [
+    {
+      filename: 'src/db.ts',
+      status: 'modified',
+      patch: '@@ -1,1 +1,2 @@\n a\n+line at 2',
+    },
+    {
+      filename: 'src/other.ts',
+      status: 'modified',
+      patch: '@@ -10,1 +10,2 @@\n a\n+line at 11',
+    },
+  ];
+
+  it('skips issues outside the PR diff and posts none when nothing matches', async () => {
+    const { executor, calls } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: filesPayload },
+      ],
+    });
+    const issues = [
+      makeIssue({ file: 'src/db.ts', startLine: 999 }),
+      makeIssue({ file: 'unknown.ts', startLine: 1 }),
+    ];
+    const result = await postPRComments(makeResults(issues), ctx, { executor });
+    assert.deepEqual(result, { posted: 0, skipped: 2 });
+    // Only the files endpoint should be called — no review POST, no comments
+    // listing, since we short-circuit when there's nothing to post.
+    const postCalls = calls.filter((c) => c.args.includes('--method'));
+    assert.equal(postCalls.length, 0);
+  });
+
+  it('posts a single review with one comment per in-diff issue', async () => {
+    const { executor, calls } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: filesPayload },
+        { match: /pulls\/42\/comments/, body: [] as ExistingReviewComment[] },
+        { match: /pulls\/42\/reviews/, body: { id: 1 } },
+      ],
+    });
+    const issues = [
+      makeIssue({ file: 'src/db.ts', startLine: 2 }),
+      makeIssue({ file: 'src/other.ts', startLine: 11, description: 'XSS' }),
+      makeIssue({ file: 'src/db.ts', startLine: 5 }), // outside diff
+    ];
+    const result = await postPRComments(makeResults(issues), ctx, { executor });
+    assert.deepEqual(result, { posted: 2, skipped: 1 });
+
+    const postCall = calls.find((c) => c.args.includes('--method'));
+    assert.ok(postCall, 'expected a POST review call');
+    assert.ok(postCall.input, 'review POST should have a JSON body');
+    const body = JSON.parse(postCall.input) as {
+      event: string;
+      comments: Array<{ path: string; line: number; side: string }>;
+    };
+    assert.equal(body.event, 'COMMENT');
+    assert.equal(body.comments.length, 2);
+    assert.equal(body.comments[0].side, 'RIGHT');
+    assert.deepEqual(
+      body.comments.map((c) => `${c.path}:${c.line}`).sort(),
+      ['src/db.ts:2', 'src/other.ts:11'],
+    );
+  });
+
+  it('skips comments whose marker hash already exists on the PR', async () => {
+    const issue = makeIssue({ file: 'src/db.ts', startLine: 2 });
+    const existingBody = buildCommentBody(issue);
+    const { executor, calls } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: filesPayload },
+        {
+          match: /pulls\/42\/comments/,
+          body: [{ id: 99, path: issue.file, line: 2, body: existingBody }],
+        },
+      ],
+    });
+    const result = await postPRComments(makeResults([issue]), ctx, { executor });
+    assert.deepEqual(result, { posted: 0, skipped: 1 });
+    const postCall = calls.find((c) => c.args.includes('--method'));
+    assert.equal(postCall, undefined, 'no review should be posted when all dupes');
+  });
+
+  it('returns early when the scan produced no issues', async () => {
+    const { executor, calls } = makeFakeExecutor();
+    const result = await postPRComments(makeResults([]), ctx, { executor });
+    assert.deepEqual(result, { posted: 0, skipped: 0 });
+    assert.equal(calls.length, 0, 'no API calls should be made for empty scans');
+  });
+
+  it('passes a token via env when supplied (and never via argv or stdin)', async () => {
+    const { executor, calls } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: filesPayload },
+        { match: /pulls\/42\/comments/, body: [] },
+        { match: /pulls\/42\/reviews/, body: { id: 1 } },
+      ],
+    });
+    const issues = [makeIssue({ file: 'src/db.ts', startLine: 2 })];
+    await postPRComments(makeResults(issues), { ...ctx, githubToken: 'sekret' }, { executor });
+    for (const c of calls) {
+      assert.ok(c.envHasToken, 'token should be exposed via env');
+      for (const a of c.args) {
+        assert.ok(!a.includes('sekret'), 'token must never appear in argv');
+      }
+      // The stdin payload (POST body) must never echo the token either —
+      // covers the case where a future bug interpolates it into JSON.
+      assert.ok(
+        c.input === undefined || !c.input.includes('sekret'),
+        'token must never appear in stdin/input payload',
+      );
+      // Spot-check the full command-line blob (command + args).
+      const blob = c.command + ' ' + c.args.join(' ');
+      assert.ok(!blob.includes('sekret'), 'token must never appear in command line');
+    }
+  });
+
+  it('surfaces gh API errors when the files endpoint fails', async () => {
+    const { executor } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: undefined, exitCode: 1, stderr: 'boom' },
+      ],
+    });
+    await assert.rejects(
+      () => postPRComments(makeResults([makeIssue()]), ctx, { executor }),
+      /boom/,
+    );
+  });
+
+  it('continues posting when listing existing comments fails (warns instead)', async () => {
+    const { executor, calls } = makeFakeExecutor({
+      responses: [
+        { match: /pulls\/42\/files/, body: filesPayload },
+        { match: /pulls\/42\/comments/, body: undefined, exitCode: 1, stderr: 'rate limited' },
+        { match: /pulls\/42\/reviews/, body: { id: 1 } },
+      ],
+    });
+    const issues = [makeIssue({ file: 'src/db.ts', startLine: 2 })];
+    const result = await postPRComments(makeResults(issues), ctx, { executor });
+    assert.equal(result.posted, 1);
+    assert.equal(result.skipped, 0);
+    const postCall = calls.find((c) => c.args.includes('--method'));
+    assert.ok(postCall, 'should still post the review when dedup listing fails');
+  });
+});


### PR DESCRIPTION
Posts each finding as an inline review comment on a pull request, so results surface where the code is actually reviewed rather than only in a report file. Closes #119 (spec E.7, Phase 1).

## Usage

```bash
aghast scan ./repo --config-dir ./checks --pr 42 --repo octo/demo
```

In GitHub Actions, `--repo` and `--head-sha` can be omitted — they default from `$GITHUB_REPOSITORY`, `$GITHUB_HEAD_SHA` and `$GITHUB_SHA`.

## Behaviour

- Only findings whose location **intersects the PR diff** are posted; the rest are skipped and logged at `debug` level
- **Idempotent** — re-running on the same PR deduplicates against previously posted comments using a hidden marker
- **Non-fatal** — if `gh` is missing, unauthenticated, or the API call fails, the scan reports `E7201`, still writes its report, and leaves the exit code unchanged

Authentication piggybacks on the [`gh` CLI](https://cli.github.com/): either `gh auth login` or `GH_TOKEN` / `GITHUB_TOKEN` (e.g. Actions `secrets.GITHUB_TOKEN`). The token is passed through the environment and never written to argv or logs.

## Verification

`npm run lint`, `npm run build` clean. **1044/1045 tests pass** — the single failure is a pre-existing Windows-local race on a shared test fixture that also reproduces on `main` at baseline and does not occur on Linux CI.

| Check | Result |
|---|---|
| `--help` lists the PR options | ✅ |
| Unknown option still rejected | `E1002` ✅ |
| `--pr` without `--repo` or `$GITHUB_REPOSITORY` | `E1001` ✅ |
| `--pr abc` / `--pr 0` | `E1001` positive-integer required ✅ |
| `gh` failure against a nonexistent repo | `E7201`, **exit 0**, report still written ✅ |

## Error code namespace

`E7xxx` is subdivided so result handlers do not collide with the existing budget controls:

```
E70xx — Budget / cost controls      → E7001 'Budget limit exceeded'
E72xx — Result handlers             → E7201 'PR comment posting failed'
```

## Phase 1 scope

Issue tracker creation, AI-assisted remediation, IDE/LSP integration and Slack/email notifications from spec E.7 are deferred. `src/result-handlers/` is structured so those become siblings of the PR comment handler.

> **Concurrency caveat (documented):** dedup is per-run, so two parallel CI shards posting to the same PR can each pass the marker check and produce duplicates. Confine `--pr` to a single matrix job, or run it after the matrix completes.