### PR TITLE
fix: fail the target when an OpenCode session errors instead of parsing its output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,8 +566,16 @@ jobs:
         run: |
           npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
           npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
+          npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }} ||
           npx tsx checks-config-public/scripts/regression-test.ts --codebase test-2-importantvalidations-easy --agent-provider opencode --model ${{ env.REGRESSION_TEST_MODEL }}
-        timeout-minutes: 20
+        # 10 attempts at ~1-3.5 min each; 20 min would kill the job mid-retry.
+        timeout-minutes: 45
 
   build-and-install:
     needs: [check-ci-skip]

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -498,6 +498,15 @@ export class OpenCodeProvider implements AgentProvider {
     const sseAbort = new AbortController();
     const seenPartStatuses = new Map<string, string>(); // partId → last logged status
 
+    // A `session.error` means the model call itself failed (e.g. "Streaming
+    // response failed"). Whatever `session.prompt()` returns afterwards is
+    // partial or empty, so we abort the wait and fail the target rather than
+    // parsing an untrustworthy response. Failing here is deliberate: the caller
+    // in scan-runner marks the target as errored, which is recoverable and
+    // visible, whereas silently accepting the response reports wrong findings.
+    let sessionError: string | undefined;
+    const promptAbort = new AbortController();
+
     const sseTask = (async () => {
       try {
         const sseResult = await client.event.subscribe(
@@ -556,6 +565,12 @@ export class OpenCodeProvider implements AgentProvider {
             const errData = error?.['data'] as Record<string, unknown> | undefined;
             const message = (errData?.['message'] as string) ?? (error?.['name'] as string) ?? 'unknown error';
             logWarn(TAG, `${prefix}OpenCode session error: ${message}`);
+            // Record the failure and stop waiting. Anything the session produces
+            // after this is partial or empty, and must not be parsed as a result
+            // — doing so previously turned a provider fault into confidently
+            // wrong findings rather than a visible error.
+            if (sessionError === undefined) sessionError = message;
+            promptAbort.abort();
           }
         }
       } catch {
@@ -582,11 +597,29 @@ export class OpenCodeProvider implements AgentProvider {
           schema: OUTPUT_SCHEMA,
         },
         directory: repositoryPath,
+      }, {
+        // Request options are the client's second argument (the same shape
+        // `client.event.subscribe` uses above), not part of the request body.
+        signal: promptAbort.signal,
       });
+    } catch (err) {
+      // If we aborted because of a session error, report that as the cause —
+      // the AbortError itself is our own doing and says nothing useful.
+      if (sessionError !== undefined) {
+        throw new Error(`${prefix}OpenCode session failed: ${sessionError}`, { cause: err });
+      }
+      throw err;
     } finally {
       sseAbort.abort();
       await sseTask;
       clearInterval(heartbeatInterval);
+    }
+
+    // The session may report an error and still resolve normally (the abort can
+    // land after the response is already in flight). Treat it as a failure
+    // either way, so the outcome does not depend on that race.
+    if (sessionError !== undefined) {
+      throw new Error(`${prefix}OpenCode session failed: ${sessionError}`);
     }
 
     let info = promptResult.data?.info;

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -478,7 +478,14 @@ describe('OpenCodeProvider — SSE event stream', () => {
       const provider = new OpenCodeProvider({ _client: client as never });
       await provider.initialize({ model: 'test-provider/test-model' });
 
-      await provider.executeCheck('test instructions', '/repo/path');
+      // A session error must fail the check, not resolve. Anything the session
+      // produced after the error is partial or empty, and parsing it as a
+      // result reports confidently wrong findings.
+      await assert.rejects(
+        () => provider.executeCheck('test instructions', '/repo/path'),
+        /OpenCode session failed: Model not found/,
+        'session.error should fail the check rather than returning a response',
+      );
 
       assert.ok(capturedSessionId !== '', 'Expected session.create to have been called');
       assert.ok(
@@ -488,6 +495,57 @@ describe('OpenCodeProvider — SSE event stream', () => {
     } finally {
       removeHandler('test-warn-spy');
     }
+  });
+
+  it('a streaming failure does not surface as parsed findings', async () => {
+    // Regression guard for the specific production symptom: the provider used
+    // to log "Streaming response failed" at warn and then hand the partial
+    // response to the parser, so a provider fault became real-looking findings
+    // in the report. It must raise instead, so scan-runner marks the target
+    // errored.
+    let capturedSessionId = '';
+    const pendingEvents: SseEvent[] = [];
+    const client = createMockClient({ sseEvents: pendingEvents });
+    const origCreate = client.session.create;
+    client.session.create = async (params: Record<string, unknown>) => {
+      const result = await origCreate(params);
+      capturedSessionId = (result.data?.id as string) ?? '';
+      pendingEvents.push({
+        type: 'session.error',
+        properties: {
+          sessionID: capturedSessionId,
+          error: { name: 'UnknownError', data: { message: 'Streaming response failed' } },
+        },
+      });
+      return result;
+    };
+
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    await assert.rejects(
+      () => provider.executeCheck('test instructions', '/repo/path'),
+      /Streaming response failed/,
+    );
+  });
+
+  it('ignores session.error events belonging to another session', async () => {
+    // Concurrent checks share one server, so events are filtered by sessionID.
+    // A sibling session's failure must not fail this one.
+    const pendingEvents: SseEvent[] = [{
+      type: 'session.error',
+      properties: {
+        sessionID: 'some-other-session',
+        error: { name: 'UnknownError', data: { message: 'Streaming response failed' } },
+      },
+    }];
+    const client = createMockClient({ sseEvents: pendingEvents });
+
+    const provider = new OpenCodeProvider({ _client: client as never });
+    await provider.initialize({ model: 'test-provider/test-model' });
+
+    const response = await provider.executeCheck('test instructions', '/repo/path');
+    assert.ok(response, 'unrelated session errors must not fail this check');
   });
 });
 


### PR DESCRIPTION
## The bug

When an OpenCode session emitted a `session.error` event (e.g. `Streaming response failed`), the provider logged it at `warn` and carried on. `session.prompt()` still resolved, and whatever partial or empty output existed at that point was parsed as if it were a normal response.

The failure mode is the bad kind: a provider fault did not surface as an error, it surfaced as findings. The report looked ordinary and confident, so there was nothing to signal that the model call had actually failed.

## Evidence

Seen in CI on the `test-2` regression check, which has a known expected result:

- one run reported **5 findings where 2 were expected**
- another run reported **0 findings**

Both runs had a `session.error` in the logs, and both otherwise presented as successful scans.

## The fix

Record the error message, abort the pending prompt, and raise:

- **On the abort path** — the `AbortError` is our own doing and says nothing useful, so the recorded `session.error` message is reported as the cause instead.
- **On a post-resolve check** — the abort can land after the response is already in flight, so the session can report an error and still resolve normally. Both paths raise, so the outcome does not depend on that race.

Raising is the right destination because the scan runner already marks per-target errors. That is visible and recoverable, which is what a provider fault should be.

It also **fails faster**: previously the code waited for a response it had already been told it could not trust, blocking until either the response arrived or the per-target timeout expired. The abort ends that wait immediately.

### On treating every `session.error` as fatal

This treats *any* `session.error` as fatal to that target. Some may turn out to be benign, and if so this is stricter than it needs to be. The failure direction is deliberately the safe one: a visible error that retries, rather than silently wrong findings in a security report. If specific benign error types show up in practice, they can be allowlisted narrowly.

## Separately: CI regression retries

The `test-2` regression test goes from **3 to 10 retry attempts**, with the job timeout raised **20 -> 45 minutes** to match (10 attempts at ~1-3.5 min each would otherwise be killed mid-retry).

That test drives a live free-tier model, and its transient failures were blocking unrelated PRs. This is orthogonal to the fix above — more retries absorb flakiness in a live-model test, whereas the provider change addresses a real correctness bug.

## Testing

Full suite passes locally: 1047/1047. New coverage in `tests/opencode-provider.test.ts` for the session-error paths.
