### PR TITLE
feat: add glob pattern-based target discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Seven core components orchestrated by the Security Scanner:
 2. **Check Library** — Two-layer config: loads check registry from `checks-config.json` (Layer 1: id, repositories, enabled) and per-check definitions from `checks/<id>/<id>.json` (Layer 2: name, instructions, severity, checkTarget) within a config directory specified via `--config-dir`. Merges layers, filters by repository, loads markdown instructions from each check folder.
 3. **Agent Provider** — Abstraction layer over agent SDKs / harnesses that delegate to LLMs (reference impls: Claude Code, OpenCode)
 4. **Repository Analyzer** — Extracts Git metadata (remote URL, branch, commit) from target repos
-5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, Opengrep, OpenAnt, and SARIF providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
+5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, Opengrep, OpenAnt, SARIF and Glob providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
 6. **Diff Filter** — Optional post-discovery transformation (`src/diff-filter.ts`) that narrows any SARIF-producing discovery's output to findings touching a git diff, using OpenAnt's call graph for flow-adjacency. Activated automatically when a diff source is provided; individual checks can opt out via `checkTarget.diffFilter: false`.
 7. **Report Generator** — Produces `security_checks_results.json` (or `.sarif`) conforming to the `ScanResults` schema
 
@@ -29,7 +29,7 @@ Seven core components orchestrated by the Security Scanner:
 
 **Check types**: Three check types with pluggable discovery:
 - `repository` — AI analyzes the whole repo (no discovery needed)
-- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `opengrep` (Opengrep rules — Semgrep fork, identical rule syntax), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings)
+- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `opengrep` (Opengrep rules — Semgrep fork, identical rule syntax), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings), `glob` (file path pattern, whole-file targets)
 - `static` — A discovery method finds issues mapped directly to results, no AI involvement. Discovery methods: `semgrep`, `opengrep`
 
 Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `opengrep`, `openant`, `sarif`) to select the discovery strategy. Targeted checks can also set `checkTarget.analysisMode` to control what the AI does with each target: `custom` (default, uses `instructionsFile`), `false-positive-validation`, or `general-vuln-discovery` (built-in prompt templates, no `instructionsFile` needed).
@@ -151,7 +151,7 @@ listed instead of its contents.
 
 **Subsystems** — each is a registry plus interchangeable implementations; read the named file for the interface, then the sibling directory for the implementations
 
-- `src/discovery.ts` + `src/discoveries/` — Pluggable target discovery: `DiscoveryProvider` interface, `DiscoveryRegistry`, orchestration. Implementations: semgrep, opengrep, openant, sarif
+- `src/discovery.ts` + `src/discoveries/` — Pluggable target discovery: `DiscoveryProvider` interface, `DiscoveryRegistry`, orchestration. Implementations: semgrep, opengrep, openant, sarif, glob
 - `src/formatters/index.ts` + `src/formatters/` — Output formatter registry and implementations (json, sarif, csv, html); `types.ts` defines the `OutputFormatter` interface
 - `src/provider-registry.ts` + `src/*-provider.ts` — Agent providers (`claude-code-provider.ts`, `opencode-provider.ts`, `mock-agent-provider.ts`); `provider-utils.ts` holds the shared OUTPUT_SCHEMA
 - `src/diff-filter.ts` — Diff filter (`applyDiffFilter`), applied post-discovery whenever a diff source exists and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets using the OpenAnt call graph (depth-1), falling back to file+line overlap (depth-0) when OpenAnt is unavailable. Supported by `diff-parser.ts` and `diff-unit-matcher.ts`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,24 @@ Opengrep can be used as a drop-in replacement for Semgrep: change `discovery: "s
 }
 ```
 
+**Targeted check with glob discovery** (whole-file targets selected by file path pattern):
+
+```json
+{
+  "id": "aghast-route-review",
+  "name": "Route Handler Review",
+  "instructionsFile": "aghast-route-review.md",
+  "severity": "high",
+  "confidence": "medium",
+  "checkTarget": {
+    "type": "targeted",
+    "discovery": "glob",
+    "glob": "src/routes/**/*.ts",
+    "maxTargets": 50
+  }
+}
+```
+
 **Targeted check with OpenAnt discovery** (code units analyzed by AI):
 
 ```json
@@ -182,10 +200,11 @@ Diff filtering works identically for `openant` discovery: the filter narrows the
 | `model`            | `string`                      | No       | AI model override for this check (e.g. `claude-sonnet-4-20250514`). Takes precedence over CLI `--model` and runtime config |
 | `checkTarget`      | `object`                      | No       | Target configuration (omit for repository checks) |
 | `checkTarget.type` | `string`                      | Yes**    | `repository`, `targeted`, or `static` (**required if `checkTarget` present) |
-| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `opengrep`, `sarif`, or `openant` (***required for `targeted` and `static` types) |
+| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, or `glob` (***required for `targeted` and `static` types) |
 | `checkTarget.analysisMode` | `string`              | No       | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery`. Built-in modes use their own prompt template and don't require `instructionsFile`. See [How It Works](how-it-works.md) |
 | `checkTarget.rules`| `string` or `string[]`        | Yes****  | Rule file path(s) relative to check folder (****only for `semgrep` or `opengrep` discovery — both tools share the same rule syntax) |
 | `checkTarget.sarifFile` | `string`                 | Yes***** | Path to SARIF file relative to target repository (*****only for `sarif` discovery) |
+| `checkTarget.glob` | `string`                      | Yes****** | Glob pattern (e.g. `src/routes/**/*.ts`) relative to repository root (******only for `glob` discovery) |
 | `checkTarget.maxTargets` | `number`               | No       | Limit number of targets/units to analyze |
 | `checkTarget.concurrency` | `number`              | No       | Max parallel AI analyses for targeted checks (default: 5) |
 | `checkTarget.diffFilter` | `boolean`              | No       | Set to `false` to skip diff filtering for this check even when a diff source is available. Default (omitted or `true`): filter automatically whenever a diff source is provided |
@@ -219,6 +238,7 @@ The `discovery` field on `checkTarget` specifies how targets are found for `targ
 | `opengrep` | Opengrep installed | Runs Opengrep (a Semgrep fork with identical rule syntax and SARIF output) — supports `targeted` and `static` check types | Yes |
 | `sarif` | SARIF file in check definition (`sarifFile`) | Reads findings from an external SARIF file | Yes |
 | `openant` | OpenAnt + Python 3.11+ | Runs `openant parse` on the target repo to extract code units with call graph context | Yes |
+| `glob` | None | Walks the repository and selects whole-file targets matching a glob pattern (e.g. `src/routes/**/*.ts`). Targeted checks only. Always skips: `.git`, `node_modules`, `.venv`, `venv`, `__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`, `dist`, `build`, `.next`, `.nuxt`, `.cache`, `.idea`, `.vscode`. Files larger than 10 MiB and symlinks are also skipped | No |
 
 ### Diff filtering
 

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -205,6 +205,18 @@ export async function loadCheckDefinition(checkFolderPath: string): Promise<Chec
     if (ct.diffRef !== undefined && typeof ct.diffRef !== 'string') {
       throw new Error(`Check definition "${defPath}": "checkTarget.diffRef" must be a string`);
     }
+
+    // Validate glob discovery fields
+    if (ct.glob !== undefined && (typeof ct.glob !== 'string' || ct.glob.trim() === '')) {
+      throw new Error(
+        `Check definition "${defPath}": "checkTarget.glob" must be a non-empty string`,
+      );
+    }
+    if (ct.discovery === 'glob' && (typeof ct.glob !== 'string' || ct.glob.trim() === '')) {
+      throw new Error(
+        `Check definition "${defPath}": "checkTarget.glob" must be a non-empty string when discovery is "glob"`,
+      );
+    }
     // Validate openant filter config
     if (ct.openant !== undefined) {
       if (typeof ct.openant !== 'object' || ct.openant === null) {

--- a/src/discoveries/glob-discovery.ts
+++ b/src/discoveries/glob-discovery.ts
@@ -1,0 +1,251 @@
+/**
+ * Glob-based target discovery.
+ *
+ * Matches files in the repository by glob pattern (e.g. "src/routes/**\/*.ts")
+ * and returns each matched file as a whole-file target. Useful for checks that
+ * apply to entire files (e.g. "review every GraphQL resolver"), without
+ * requiring an external tool such as Semgrep.
+ *
+ * Spec reference: Appendix E.2.1.
+ */
+
+import { readdir, stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import picomatch from 'picomatch';
+import { logDebug } from '../logging.js';
+import { ERROR_CODES, formatError } from '../error-codes.js';
+import { DEFAULT_GENERIC_PROMPT } from '../defaults.js';
+import type { TargetDiscovery, DiscoveredTarget, DiscoveryOptions } from '../discovery.js';
+import type { SecurityCheck } from '../types.js';
+
+const TAG = 'glob-discovery';
+
+/**
+ * Skip files larger than this (in bytes) to avoid OOM when a wide glob
+ * (e.g. "**\/*") accidentally matches a large generated/binary file.
+ * Files above this threshold are excluded from the target set with a debug log.
+ */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+/** Directories that are always skipped when walking the repository tree. */
+const ALWAYS_SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.tox',
+  '.mypy_cache',
+  '.pytest_cache',
+  'dist',
+  'build',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.idea',
+  '.vscode',
+]);
+
+function buildTargetPromptEnrichment(file: string, endLine: number): string {
+  return `\n\nTARGET FILE:
+
+You are analyzing a specific file:
+- File: ${file}
+- Lines: 1-${endLine} (whole file)
+
+You MUST:
+- Analyze ONLY this specific file — do not search for or report issues in other files
+- You may read other files to understand context (e.g., imports, type definitions, data flow), but only report issues in this file
+- Do NOT scan the broader repository for other instances of this vulnerability pattern
+`;
+}
+
+/**
+ * Walk a directory tree recursively and yield every file path (POSIX-normalized,
+ * relative to `root`). Skips well-known noise directories so glob patterns do
+ * not have to opt out of `node_modules`/`.git` etc. on every check.
+ *
+ * Symlinks are NOT followed: `Dirent.isDirectory()` returns true only for real
+ * directories, so symlinked directories (and any cycles they could form) are
+ * skipped. Symlinked files are also skipped (`isFile()` returns false). This
+ * is the safe default — there's no general way to detect a hostile cycle, and
+ * source repos rarely rely on symlink-to-directory for layout.
+ */
+async function* walkFiles(root: string): AsyncGenerator<string> {
+  async function* walk(dir: string): AsyncGenerator<string> {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (ALWAYS_SKIP_DIRS.has(entry.name)) continue;
+        yield* walk(full);
+      } else if (entry.isFile()) {
+        const rel = relative(root, full).split(sep).join('/');
+        yield rel;
+      }
+      // Symlinks (entry.isSymbolicLink()) are intentionally skipped — see
+      // the function-level comment above.
+    }
+  }
+  yield* walk(root);
+}
+
+/**
+ * Count the number of lines in a file by streaming and counting `\n` bytes.
+ * Constant memory; safe for very large files.
+ *
+ * Returns 1 for empty files so that `endLine >= startLine` always holds.
+ * Returns `undefined` if the file cannot be read or exceeds `MAX_FILE_SIZE_BYTES`
+ * — callers should treat that as "skip this target" and log accordingly.
+ */
+async function countLines(filePath: string): Promise<number | undefined> {
+  let size: number;
+  try {
+    const st = await stat(filePath);
+    size = st.size;
+  } catch (err) {
+    logDebug(TAG, `failed to stat ${filePath} for line count: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
+  }
+
+  if (size > MAX_FILE_SIZE_BYTES) {
+    logDebug(TAG, `skipping ${filePath}: size ${size} bytes exceeds limit ${MAX_FILE_SIZE_BYTES}`);
+    return undefined;
+  }
+
+  if (size === 0) return 1;
+
+  return new Promise<number | undefined>((resolvePromise) => {
+    let newlineCount = 0;
+    let endsWithNewline = false;
+    const stream = createReadStream(filePath);
+    stream.on('data', (chunk: string | Buffer) => {
+      // Treat the stream as bytes — counting `\n` bytes is safe for UTF-8 because
+      // 0x0A never appears as a continuation byte of a multi-byte sequence.
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] === 0x0a) newlineCount++;
+      }
+      if (buf.length > 0) endsWithNewline = buf[buf.length - 1] === 0x0a;
+    });
+    stream.on('error', (err) => {
+      logDebug(TAG, `failed to read ${filePath} for line count: ${err.message}`);
+      resolvePromise(undefined);
+    });
+    stream.on('end', () => {
+      // If the file ends with a newline, the count of \n equals the number of lines.
+      // If it does not, the trailing partial line adds one to the count.
+      const lines = endsWithNewline ? newlineCount : newlineCount + 1;
+      resolvePromise(lines || 1);
+    });
+  });
+}
+
+/**
+ * Discover whole-file targets in `repoPath` matching `pattern`.
+ *
+ * Exposed as a named export (rather than only the registry-facing object) so
+ * unit tests can exercise the matching logic directly without going through
+ * the SecurityCheck plumbing.
+ */
+export async function discoverGlobTargets(
+  pattern: string,
+  repoPath: string,
+  maxTargets?: number,
+): Promise<DiscoveredTarget[]> {
+  if (!pattern || pattern.trim() === '') {
+    throw new Error(
+      formatError(ERROR_CODES.E2004, 'Glob discovery requires a non-empty "glob" pattern'),
+    );
+  }
+
+  const matcher = picomatch(pattern, { dot: false });
+  const matches: string[] = [];
+
+  for await (const rel of walkFiles(repoPath)) {
+    if (matcher(rel)) {
+      matches.push(rel);
+    }
+  }
+
+  // Sort BEFORE applying maxTargets so that the truncated subset is deterministic
+  // across platforms (readdir order varies by filesystem). Without this, a glob
+  // with maxTargets=N could analyze a different N files on Linux vs Windows vs
+  // macOS, making findings non-reproducible.
+  matches.sort();
+  const limited = typeof maxTargets === 'number' ? matches.slice(0, maxTargets) : matches;
+
+  // Compute line counts in parallel; drop unreadable / oversized files.
+  const lineCounts = await Promise.all(
+    limited.map((rel) => countLines(join(repoPath, rel))),
+  );
+  const usable: { rel: string; endLine: number }[] = [];
+  for (let i = 0; i < limited.length; i++) {
+    const endLine = lineCounts[i];
+    if (endLine === undefined) continue; // unreadable / oversized — already logged
+    usable.push({ rel: limited[i], endLine });
+  }
+
+  // Surface a single summary log when files were dropped, so users debugging
+  // "why is my big bundle missing from the target set?" don't have to enable
+  // trace-level logging to find the per-file skip messages from countLines.
+  const skippedCount = limited.length - usable.length;
+  if (skippedCount > 0) {
+    logDebug(
+      TAG,
+      `${skippedCount} matched file${skippedCount === 1 ? '' : 's'} skipped (unreadable or > ${MAX_FILE_SIZE_BYTES} bytes)`,
+    );
+  }
+
+  return usable.map(({ rel, endLine }, idx) => ({
+    file: rel,
+    startLine: 1,
+    endLine,
+    label: `[file ${idx + 1}/${usable.length}]`,
+    promptEnrichment: buildTargetPromptEnrichment(rel, endLine),
+  }));
+}
+
+export const globDiscovery: TargetDiscovery = {
+  name: 'glob',
+  defaultGenericPrompt: DEFAULT_GENERIC_PROMPT,
+  needsInstructions: true,
+  // Opted out deliberately. `supportsDiffFilter` became a required field on
+  // TargetDiscovery after this discovery was written (#227), and the diff
+  // filter is built around findings with meaningful line ranges. Glob targets
+  // are whole files, so filtering them has never been designed or tested for
+  // this shape. Opting out preserves the behaviour this discovery was built
+  // and tested with: a glob check scans every matching file. Enabling it later
+  // is a small change plus tests for the whole-file case.
+  supportsDiffFilter: false,
+
+  async discover(
+    check: SecurityCheck,
+    repoPath: string,
+    _options?: DiscoveryOptions,
+  ): Promise<DiscoveredTarget[]> {
+    const checkTarget = check.checkTarget!;
+
+    if (!checkTarget.glob) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E2004,
+          `Check "${check.id}" uses glob discovery but has no "glob" pattern in its check definition`,
+        ),
+      );
+    }
+
+    logDebug(TAG, `Running glob discovery for check "${check.id}": ${checkTarget.glob}`);
+
+    const targets = await discoverGlobTargets(checkTarget.glob, repoPath, checkTarget.maxTargets);
+
+    logDebug(TAG, `Discovered ${targets.length} files matching pattern`);
+    return targets;
+  },
+};

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -59,6 +59,7 @@ interface ParsedFlags {
   discovery?: string;
   semgrepRules?: string;
   sarifFile?: string;
+  glob?: string;
   analysisMode?: string;
   maxTargets?: string;
   language?: string;
@@ -82,6 +83,7 @@ const CLI_FLAG_MAP: Record<string, keyof ParsedFlags> = {
   '--semgrep-rules': 'semgrepRules',
   '--opengrep-rules': 'semgrepRules',
   '--sarif-file': 'sarifFile',
+  '--glob': 'glob',
   '--analysis-mode': 'analysisMode',
   '--max-targets': 'maxTargets',
   '--language': 'language',
@@ -188,6 +190,7 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
     analysisMode: '',
     semgrepRules: '',
     sarifFile: '',
+    glob: '',
     maxTargets: '',
     language: '',
   };
@@ -197,15 +200,22 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
 
   if (result.checkType === 'targeted' || result.checkType === 'static') {
     const discoveryChoices = result.checkType === 'targeted'
-      ? ['semgrep', 'opengrep', 'openant', 'sarif']
+      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob']
       : ['semgrep', 'opengrep'];
     result.discovery = await askChoice('Discovery method', discoveryChoices, 'semgrep', flags.discovery);
     result.maxTargets = await askOptional('Max targets', flags.maxTargets);
 
     if (result.checkType === 'targeted') {
-      const modeChoices = result.discovery === 'openant'
-        ? ['custom', 'general-vuln-discovery']
-        : ['custom', 'false-positive-validation', 'general-vuln-discovery'];
+      let modeChoices: string[];
+      if (result.discovery === 'openant') {
+        modeChoices = ['custom', 'general-vuln-discovery'];
+      } else if (result.discovery === 'glob') {
+        // glob discovery does not support false-positive-validation (no per-target
+        // finding to validate); offer custom and general-vuln-discovery.
+        modeChoices = ['custom', 'general-vuln-discovery'];
+      } else {
+        modeChoices = ['custom', 'false-positive-validation', 'general-vuln-discovery'];
+      }
       result.analysisMode = await askChoice('Analysis mode', modeChoices, 'custom', flags.analysisMode);
     }
 
@@ -223,6 +233,10 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
       result.sarifFile = flags.sarifFile !== undefined
         ? flags.sarifFile
         : await ask('SARIF file path (relative to target repo, e.g. ./sast-results.sarif)', flags.sarifFile);
+    } else if (result.discovery === 'glob') {
+      result.glob = flags.glob !== undefined
+        ? flags.glob
+        : await ask('Glob pattern (e.g. src/routes/**/*.ts)', flags.glob);
     }
   }
 
@@ -268,7 +282,7 @@ async function loadExistingRegistry(registryPath: string): Promise<RegistryFile>
 }
 
 function validateInputs(
-  inputs: { id: string; severity: string; confidence: string; checkType: string; discovery: string; analysisMode: string; maxTargets: string; language: string; sarifFile: string },
+  inputs: { id: string; severity: string; confidence: string; checkType: string; discovery: string; analysisMode: string; maxTargets: string; language: string; sarifFile: string; glob: string },
 ): string[] {
   const errors: string[] = [];
 
@@ -300,7 +314,7 @@ function validateInputs(
 
   if ((inputs.checkType === 'targeted' || inputs.checkType === 'static') && inputs.checkType) {
     const validDiscoveries = inputs.checkType === 'targeted'
-      ? ['semgrep', 'opengrep', 'openant', 'sarif']
+      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob']
       : ['semgrep', 'opengrep'];
     if (!inputs.discovery || !validDiscoveries.includes(inputs.discovery)) {
       errors.push(`Invalid discovery "${inputs.discovery}" for check type "${inputs.checkType}". Must be one of: ${validDiscoveries.join(', ')}`);
@@ -308,11 +322,17 @@ function validateInputs(
     if (inputs.discovery === 'sarif' && !inputs.sarifFile) {
       errors.push('sarifFile is required for sarif discovery');
     }
+    if (inputs.discovery === 'glob' && !inputs.glob) {
+      errors.push('glob pattern is required for glob discovery');
+    }
 
     if (inputs.analysisMode) {
-      const validModes = inputs.discovery === 'openant'
-        ? ['custom', 'general-vuln-discovery']
-        : ['custom', 'false-positive-validation', 'general-vuln-discovery'];
+      let validModes: string[];
+      if (inputs.discovery === 'openant' || inputs.discovery === 'glob') {
+        validModes = ['custom', 'general-vuln-discovery'];
+      } else {
+        validModes = ['custom', 'false-positive-validation', 'general-vuln-discovery'];
+      }
       if (!validModes.includes(inputs.analysisMode)) {
         errors.push(`Invalid analysis mode "${inputs.analysisMode}" for ${inputs.discovery} discovery. Must be one of: ${validModes.join(', ')}`);
       }
@@ -409,6 +429,7 @@ function generateCheckDefinition(inputs: {
   analysisMode: string;
   semgrepRules: string;
   sarifFile: string;
+  glob: string;
   maxTargets: string;
 }): Record<string, unknown> {
   const def: Record<string, unknown> = {
@@ -448,6 +469,8 @@ function generateCheckDefinition(inputs: {
       }
     } else if (inputs.discovery === 'sarif') {
       checkTarget.sarifFile = inputs.sarifFile;
+    } else if (inputs.discovery === 'glob') {
+      checkTarget.glob = inputs.glob;
     }
     if (inputs.analysisMode && inputs.analysisMode !== 'custom') {
       checkTarget.analysisMode = inputs.analysisMode;
@@ -502,6 +525,7 @@ Options:
   --semgrep-rules <paths>    Comma-separated rule file paths (for semgrep/opengrep discovery)
   --opengrep-rules <paths>   Alias for --semgrep-rules; do not pass both (error)
   --sarif-file <path>        SARIF file path in check definition, relative to repo (for sarif discovery)
+  --glob <pattern>           Glob pattern (for glob discovery, e.g. "src/routes/**/*.ts")
   --analysis-mode <mode>     Analysis mode for targeted checks (default: custom). See below
   --max-targets <n>          Maximum number of targets to analyze
   --language <lang>          Language for Semgrep/Opengrep template: python, javascript, typescript
@@ -520,6 +544,7 @@ Discovery mechanisms:
   opengrep    Opengrep (Semgrep fork) rules find targets (targeted or static)
   openant     OpenAnt code analysis finds units (targeted only)
   sarif       External SARIF file provides findings (targeted only)
+  glob        File path glob pattern selects whole-file targets (targeted only)
 
 Analysis modes (targeted checks only):
   custom                      Use a custom instructions markdown file (default)

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -22,6 +22,7 @@ import { openantDiscovery } from './discoveries/openant-discovery.js';
 import { sarifDiscovery } from './discoveries/sarif-discovery.js';
 import { applyDiffFilter } from './diff-filter.js';
 import { runOpenAnt } from './openant-runner.js';
+import { globDiscovery } from './discoveries/glob-discovery.js';
 import type { DiscoveredTarget } from './discovery.js';
 import {
   DEFAULT_MODEL,
@@ -56,6 +57,7 @@ registerDiscovery(semgrepDiscovery);
 registerDiscovery(opengrepDiscovery);
 registerDiscovery(openantDiscovery);
 registerDiscovery(sarifDiscovery);
+registerDiscovery(globDiscovery);
 
 /**
  * Decide whether to apply the diff filter to a check's discovered targets.

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,10 +85,12 @@ export interface OpenAntFilterConfig {
 
 export interface CheckTargetDefinition {
   type: 'targeted' | 'static' | 'repository';
-  discovery?: 'semgrep' | 'opengrep' | 'openant' | 'sarif';
+  discovery?: 'semgrep' | 'opengrep' | 'openant' | 'sarif' | 'glob';
   rules?: string | string[];
   config?: string;
   sarifFile?: string;
+  /** Glob pattern used by the "glob" discovery (e.g. "src/routes/**\/*.ts"). */
+  glob?: string;
   maxTargets?: number;
   concurrency?: number;
   /** Cap on issues returned per target; omit for unlimited. See docs/configuration.md. */

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -27,6 +27,7 @@ import {
   multiTargetCappedConfigDir,
   mixedChecksConfigDir,
   semgrepOnlyConfigDir,
+  globCheckConfigDir,
   cli3TargetsSarif,
   emptyResultsSarif,
   noEndlineSarif,
@@ -1275,6 +1276,55 @@ describe('CLI mock mode: concurrency progress output', () => {
       assert.ok(issue.file, 'Each issue should have a file');
       assert.ok(issue.description, 'Each issue should have a description');
     }
+  });
+});
+
+// ─── Glob discovery (Spec E.2.1) ─────────────────────────────────────────────
+
+describe('CLI mock mode: glob discovery', () => {
+  afterEach(cleanupOutput);
+
+  it('PASS: glob check matches files and AI returns no issues → PASS', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [repoDir, '--config-dir', globCheckConfigDir],
+    );
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    const summary = results.summary as Record<string, number>;
+
+    assert.equal(checks.length, 1);
+    assert.equal(checks[0].checkId, 'aghast-glob-test');
+    assert.equal(checks[0].status, 'PASS');
+    // git-repo fixture has src/example.ts → exactly 1 file matches src/**/*.ts
+    assert.equal(checks[0].targetsAnalyzed, 1, 'Should discover 1 .ts file in src/');
+    assert.equal(summary.passedChecks, 1);
+    assert.equal(summary.totalIssues, 0);
+  });
+
+  it('FAIL: glob check + failing mock response → FAIL with enriched issue', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: failFixtureRepo },
+      [repoDir, '--config-dir', globCheckConfigDir],
+    );
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    const issues = results.issues as Array<Record<string, unknown>>;
+
+    assert.equal(checks[0].status, 'FAIL');
+    assert.equal(checks[0].targetsAnalyzed, 1);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].checkId, 'aghast-glob-test');
+    assert.equal(issues[0].checkName, 'Glob Discovery Test');
+    // The glob "src/**/*.ts" should match exactly src/example.ts in the
+    // git-repo fixture — assert the file path so this test fails loudly if
+    // someone adds another .ts file to the fixture (which would silently
+    // change the target set without this assertion).
+    assert.equal(issues[0].file, 'src/example.ts');
   });
 });
 

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -75,6 +75,7 @@ export const semgrepDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-conf
 export const sarifDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'sarif-diff-filter');
 export const openantDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'openant-diff-filter');
 export const fpValidationConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'fp-validation');
+export const globCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'glob-check');
 
 // SARIF fixtures
 export const cli3TargetsSarif = resolve(testDir, 'fixtures', 'sarif', 'cli-3-targets.sarif');

--- a/tests/fixtures/cli-configs/glob-check/checks-config.json
+++ b/tests/fixtures/cli-configs/glob-check/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-glob-test",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/glob-check/checks/aghast-glob-test/aghast-glob-test.json
+++ b/tests/fixtures/cli-configs/glob-check/checks/aghast-glob-test/aghast-glob-test.json
@@ -1,0 +1,10 @@
+{
+  "id": "aghast-glob-test",
+  "name": "Glob Discovery Test",
+  "instructionsFile": "aghast-glob-test.md",
+  "checkTarget": {
+    "type": "targeted",
+    "discovery": "glob",
+    "glob": "src/**/*.ts"
+  }
+}

--- a/tests/fixtures/cli-configs/glob-check/checks/aghast-glob-test/aghast-glob-test.md
+++ b/tests/fixtures/cli-configs/glob-check/checks/aghast-glob-test/aghast-glob-test.md
@@ -1,0 +1,12 @@
+### Glob Discovery Test
+
+#### Overview
+Validates that glob-based discovery walks the repository and produces whole-file targets.
+
+#### What to Check
+1. Each matching TypeScript source file is presented to the AI as a whole-file target
+2. The discovery does not pick up files outside the glob pattern
+
+#### Result
+- **PASS**: No issues are reported by the AI
+- **FAIL**: The AI reports any issue

--- a/tests/glob-discovery.test.ts
+++ b/tests/glob-discovery.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for the glob-based target discovery (Spec E.2.1).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+import { discoverGlobTargets, globDiscovery } from '../src/discoveries/glob-discovery.js';
+import type { SecurityCheck } from '../src/types.js';
+
+/**
+ * Build a small fixture tree on disk so the discovery has real files to walk.
+ * Returns the absolute root path; caller is responsible for cleanup.
+ */
+async function buildFixtureRepo(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'aghast-glob-'));
+
+  const layout: Record<string, string> = {
+    'src/routes/users.ts': 'export const a = 1;\nexport const b = 2;\n',
+    'src/routes/posts.ts': 'export const a = 1;\n',
+    'src/routes/admin/secrets.ts': 'export const a = 1;\nexport const b = 2;\nexport const c = 3;\n',
+    'src/lib/util.ts': 'export const x = 1;\n',
+    'src/lib/util.js': 'module.exports = 1;\n',
+    'tests/users.test.ts': 'test();\n',
+    'README.md': '# readme\n',
+    'node_modules/skip-me/index.ts': 'export const skip = 1;\n',
+    '.git/HEAD': 'ref: refs/heads/main\n',
+    'empty.ts': '',
+    'no-trailing-newline.ts': 'line1\nline2\nline3',
+  };
+
+  for (const [rel, content] of Object.entries(layout)) {
+    const full = join(root, rel);
+    // Create the parent directory tree (if any) before writing the file.
+    const parts = rel.split(/[\\/]/);
+    parts.pop();
+    if (parts.length > 0) {
+      await mkdir(join(root, parts.join('/')), { recursive: true });
+    }
+    await writeFile(full, content, 'utf-8');
+  }
+
+  return root;
+}
+
+describe('glob discovery: discoverGlobTargets', () => {
+  let repoRoot: string;
+
+  before(async () => {
+    repoRoot = await buildFixtureRepo();
+  });
+
+  after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('matches files under a nested glob', async () => {
+    const targets = await discoverGlobTargets('src/routes/**/*.ts', repoRoot);
+    const files = targets.map((t) => t.file).sort();
+    assert.deepEqual(files, [
+      'src/routes/admin/secrets.ts',
+      'src/routes/posts.ts',
+      'src/routes/users.ts',
+    ]);
+  });
+
+  it('matches by file extension across the tree', async () => {
+    const targets = await discoverGlobTargets('**/*.md', repoRoot);
+    const files = targets.map((t) => t.file);
+    assert.deepEqual(files, ['README.md']);
+  });
+
+  it('skips node_modules and .git automatically', async () => {
+    const targets = await discoverGlobTargets('**/*.ts', repoRoot);
+    const files = targets.map((t) => t.file);
+    assert.ok(!files.some((f) => f.startsWith('node_modules/')), 'should not include node_modules');
+    assert.ok(!files.some((f) => f.startsWith('.git/')), 'should not include .git');
+  });
+
+  it('returns an empty array when no files match', async () => {
+    const targets = await discoverGlobTargets('**/*.does-not-exist', repoRoot);
+    assert.deepEqual(targets, []);
+  });
+
+  it('respects maxTargets by truncating the result set', async () => {
+    const targets = await discoverGlobTargets('src/routes/**/*.ts', repoRoot, 2);
+    assert.equal(targets.length, 2);
+  });
+
+  it('produces whole-file targets with startLine 1 and endLine = line count', async () => {
+    const targets = await discoverGlobTargets('src/routes/admin/secrets.ts', repoRoot);
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].startLine, 1);
+    // secrets.ts has 3 non-empty lines + trailing newline → 3 lines
+    assert.equal(targets[0].endLine, 3);
+  });
+
+  it('handles empty files (endLine >= startLine)', async () => {
+    const targets = await discoverGlobTargets('empty.ts', repoRoot);
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].startLine, 1);
+    assert.ok(targets[0].endLine >= targets[0].startLine);
+  });
+
+  it('handles files without a trailing newline', async () => {
+    const targets = await discoverGlobTargets('no-trailing-newline.ts', repoRoot);
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].endLine, 3);
+  });
+
+  it('attaches a label and prompt enrichment to each target', async () => {
+    const targets = await discoverGlobTargets('src/routes/users.ts', repoRoot);
+    assert.equal(targets.length, 1);
+    assert.match(targets[0].label, /file 1\/1/);
+    assert.ok(targets[0].promptEnrichment, 'should have prompt enrichment');
+    assert.match(targets[0].promptEnrichment!, /TARGET FILE/);
+    assert.match(targets[0].promptEnrichment!, /src\/routes\/users\.ts/);
+  });
+
+  it('returns POSIX-style relative paths even on Windows', async () => {
+    const targets = await discoverGlobTargets('src/lib/*.ts', repoRoot);
+    for (const t of targets) {
+      assert.ok(!t.file.includes('\\'), `file path should not contain backslashes: ${t.file}`);
+    }
+  });
+
+  it('throws on empty pattern', async () => {
+    await assert.rejects(
+      () => discoverGlobTargets('', repoRoot),
+      /non-empty "glob" pattern/,
+    );
+  });
+});
+
+describe('glob discovery: TargetDiscovery interface', () => {
+  let repoRoot: string;
+
+  before(async () => {
+    repoRoot = await buildFixtureRepo();
+  });
+
+  after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('declares the expected discovery name', () => {
+    assert.equal(globDiscovery.name, 'glob');
+    assert.equal(globDiscovery.needsInstructions, true);
+  });
+
+  it('reads the glob pattern from check.checkTarget.glob', async () => {
+    const check: SecurityCheck = {
+      id: 'aghast-test',
+      name: 'Test',
+      repositories: [],
+      checkTarget: {
+        type: 'targeted',
+        discovery: 'glob',
+        glob: '**/*.md',
+      },
+    };
+    const targets = await globDiscovery.discover(check, repoRoot);
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].file, 'README.md');
+  });
+
+  it('throws when checkTarget.glob is missing', async () => {
+    const check: SecurityCheck = {
+      id: 'aghast-test',
+      name: 'Test',
+      repositories: [],
+      checkTarget: {
+        type: 'targeted',
+        discovery: 'glob',
+      },
+    };
+    await assert.rejects(
+      () => globDiscovery.discover(check, repoRoot),
+      /no "glob" pattern/,
+    );
+  });
+
+  it('honours maxTargets via the SecurityCheck path', async () => {
+    const check: SecurityCheck = {
+      id: 'aghast-test',
+      name: 'Test',
+      repositories: [],
+      checkTarget: {
+        type: 'targeted',
+        discovery: 'glob',
+        glob: 'src/routes/**/*.ts',
+        maxTargets: 1,
+      },
+    };
+    const targets = await globDiscovery.discover(check, repoRoot);
+    assert.equal(targets.length, 1);
+  });
+
+  it('rejects empty glob via the SecurityCheck path', async () => {
+    const check: SecurityCheck = {
+      id: 'aghast-test',
+      name: 'Test',
+      repositories: [],
+      checkTarget: {
+        type: 'targeted',
+        discovery: 'glob',
+        glob: '',
+      },
+    };
+    // SecurityCheck.checkTarget.glob === '' is falsy, so the discovery's own
+    // missing-glob guard fires first and produces the same error path as a
+    // truly absent pattern.
+    await assert.rejects(
+      () => globDiscovery.discover(check, repoRoot),
+      /no "glob" pattern/,
+    );
+  });
+});
+
+// ─── maxTargets determinism ─────────────────────────────────────────────────
+
+describe('glob discovery: maxTargets is deterministic across runs', () => {
+  let repoRoot: string;
+
+  before(async () => {
+    repoRoot = await buildFixtureRepo();
+  });
+
+  after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('truncates the SORTED match set, not the readdir order', async () => {
+    // The fixture has three matches under src/routes/**/*.ts; sorted they are:
+    //   src/routes/admin/secrets.ts
+    //   src/routes/posts.ts
+    //   src/routes/users.ts
+    // With maxTargets=2 the deterministic answer is the first two of that sorted list,
+    // regardless of the platform's readdir order.
+    const targets = await discoverGlobTargets('src/routes/**/*.ts', repoRoot, 2);
+    const files = targets.map((t) => t.file);
+    assert.deepEqual(files, [
+      'src/routes/admin/secrets.ts',
+      'src/routes/posts.ts',
+    ]);
+  });
+
+  it('returns identical results across multiple invocations', async () => {
+    const a = await discoverGlobTargets('src/routes/**/*.ts', repoRoot, 2);
+    const b = await discoverGlobTargets('src/routes/**/*.ts', repoRoot, 2);
+    assert.deepEqual(a.map((t) => t.file), b.map((t) => t.file));
+  });
+});
+
+// ─── Symlink handling ──────────────────────────────────────────────────────
+
+describe('glob discovery: symlink handling', () => {
+  let repoRoot: string;
+  let symlinksCreated = false;
+
+  before(async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), 'aghast-glob-symlink-'));
+    await mkdir(join(repoRoot, 'real'), { recursive: true });
+    await writeFile(join(repoRoot, 'real', 'real-file.ts'), 'export const x = 1;\n', 'utf-8');
+    // Symlink creation needs admin on Windows; skip those tests there.
+    if (platform() !== 'win32') {
+      try {
+        await symlink(join(repoRoot, 'real'), join(repoRoot, 'linked-dir'), 'dir');
+        await symlink(
+          join(repoRoot, 'real', 'real-file.ts'),
+          join(repoRoot, 'linked-file.ts'),
+          'file',
+        );
+        symlinksCreated = true;
+      } catch {
+        // Insufficient permissions or unsupported FS — leave symlinksCreated false.
+      }
+    }
+  });
+
+  after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('does not traverse symlinked directories', { skip: platform() === 'win32' }, async () => {
+    if (!symlinksCreated) return;
+    const targets = await discoverGlobTargets('**/*.ts', repoRoot);
+    const files = targets.map((t) => t.file);
+    assert.ok(
+      !files.some((f) => f.startsWith('linked-dir/')),
+      `should not include files under symlinked dir, got: ${files.join(', ')}`,
+    );
+    assert.ok(
+      files.includes('real/real-file.ts'),
+      'should still pick up the real file',
+    );
+  });
+
+  it('does not include symlinked files', { skip: platform() === 'win32' }, async () => {
+    if (!symlinksCreated) return;
+    const targets = await discoverGlobTargets('**/*.ts', repoRoot);
+    const files = targets.map((t) => t.file);
+    assert.ok(
+      !files.includes('linked-file.ts'),
+      `should not include symlinked file, got: ${files.join(', ')}`,
+    );
+  });
+});
+
+// ─── Oversized file handling ───────────────────────────────────────────────
+
+describe('glob discovery: oversized file handling', () => {
+  let repoRoot: string;
+
+  before(async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), 'aghast-glob-oversize-'));
+    // 10 MiB + 1 byte → just over the limit. Use an in-memory buffer to avoid
+    // writing 11 MiB of newlines.
+    const oversize = Buffer.alloc(10 * 1024 * 1024 + 1, 'a'.charCodeAt(0));
+    await writeFile(join(repoRoot, 'huge.ts'), oversize);
+    await writeFile(join(repoRoot, 'small.ts'), 'export const x = 1;\n', 'utf-8');
+  });
+
+  after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('skips files larger than the size limit and keeps small ones', async () => {
+    const targets = await discoverGlobTargets('*.ts', repoRoot);
+    const files = targets.map((t) => t.file);
+    assert.ok(files.includes('small.ts'), 'small file should be kept');
+    assert.ok(!files.includes('huge.ts'), 'oversized file should be skipped');
+  });
+});

--- a/tests/new-check.test.ts
+++ b/tests/new-check.test.ts
@@ -895,4 +895,89 @@ describe('new-check utility', () => {
     assert.equal(checkDef.checkTarget.discovery, 'openant');
     assert.equal(checkDef.checkTarget.maxTargets, 25);
   });
+
+  // ─── Targeted glob checks (Spec E.2.1) ─
+
+  it('targeted glob creates correct checkTarget with instructionsFile', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'glob',
+      '--glob': 'src/routes/**/*.ts',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.type, 'targeted');
+    assert.equal(checkDef.checkTarget.discovery, 'glob');
+    assert.equal(checkDef.checkTarget.glob, 'src/routes/**/*.ts');
+    assert.equal(checkDef.instructionsFile, 'aghast-test.md', 'glob discovery requires instructionsFile by default');
+    assert.equal(checkDef.checkTarget.rules, undefined, 'glob should not have rules');
+    assert.equal(checkDef.checkTarget.sarifFile, undefined, 'glob should not have sarifFile');
+  });
+
+  it('targeted glob generates .md file', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'glob',
+      '--glob': 'src/**/*.ts',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(resolve(checksDir, 'aghast-test'));
+    assert.ok(files.includes('aghast-test.md'), 'glob should generate .md file');
+    assert.ok(files.includes('aghast-test.json'), 'Should still have .json');
+    assert.ok(!files.includes('aghast-test.yaml'), 'glob should not generate Semgrep yaml');
+  });
+
+  it('targeted glob with general-vuln-discovery skips instructionsFile and .md', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'glob',
+      '--glob': 'src/**/*.ts',
+      '--analysis-mode': 'general-vuln-discovery',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.analysisMode, 'general-vuln-discovery');
+    assert.equal(checkDef.instructionsFile, undefined, 'built-in mode does not need instructionsFile');
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(resolve(checksDir, 'aghast-test'));
+    assert.ok(!files.includes('aghast-test.md'), 'built-in mode should not generate .md file');
+  });
+
+  it('targeted glob rejects false-positive-validation analysis mode', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'glob',
+      '--glob': 'src/**/*.ts',
+      '--analysis-mode': 'false-positive-validation',
+    }));
+
+    assert.notEqual(result.exitCode, 0, 'Should reject false-positive-validation for glob discovery');
+    assert.ok(
+      result.stderr.includes('Invalid analysis mode'),
+      `Expected analysis mode error, got: ${result.stderr}`,
+    );
+  });
+
+  it('targeted glob includes maxTargets in checkTarget when provided', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'glob',
+      '--glob': 'src/**/*.ts',
+      '--max-targets': '40',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.discovery, 'glob');
+    assert.equal(checkDef.checkTarget.maxTargets, 40);
+  });
 });


### PR DESCRIPTION
Adds a `glob` discovery provider, so a targeted check can select whole files by path pattern. Checks that apply to an entire file no longer need an external tool such as Semgrep to find their targets.

## Configuring it

Set `checkTarget.discovery` to `"glob"` and supply a `checkTarget.glob` pattern, relative to the repository root:

```json
{
  "checkTarget": {
    "type": "targeted",
    "discovery": "glob",
    "glob": "src/routes/**/*.ts",
    "maxTargets": 50
  }
}
```

Each matching file becomes one target, and the AI analyses the file as a whole — there is no line range to narrow it further.

## Safety and determinism

The repository walk always skips `.git`, `node_modules`, virtualenv directories (`.venv`, `venv`), cache directories (`__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`, `.cache`), build output (`dist`, `build`, `.next`, `.nuxt`) and editor directories (`.idea`, `.vscode`). Files larger than 10 MiB are skipped, as are symlinks, so the walk cannot be led outside the repository or into a link cycle.

Matches are sorted before `maxTargets` is applied. A truncated run therefore analyses the same set of files on every platform, rather than whichever files the filesystem happened to return first.

## Diff filtering

This provider declares `supportsDiffFilter: false`. The diff filter is built around findings that carry a meaningful line range — it narrows targets by checking which ones touch changed lines, optionally following the OpenAnt call graph. Glob targets are whole files with no line range, so that comparison has nothing to work with. Enabling it later is a small change plus tests, once we decide what "touched" should mean for a whole-file target.
