### PR TITLE
feat: add script-based target discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Seven core components orchestrated by the Security Scanner:
 2. **Check Library** — Two-layer config: loads check registry from `checks-config.json` (Layer 1: id, repositories, enabled) and per-check definitions from `checks/<id>/<id>.json` (Layer 2: name, instructions, severity, checkTarget) within a config directory specified via `--config-dir`. Merges layers, filters by repository, loads markdown instructions from each check folder.
 3. **Agent Provider** — Abstraction layer over agent SDKs / harnesses that delegate to LLMs (reference impls: Claude Code, OpenCode)
 4. **Repository Analyzer** — Extracts Git metadata (remote URL, branch, commit) from target repos
-5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, Opengrep, OpenAnt, SARIF and Glob providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
+5. **Discovery Providers** — Pluggable target discovery system (`src/discovery.ts`): Semgrep, Opengrep, OpenAnt, SARIF, Glob and Script providers find code locations for targeted/static checks. Providers declare whether they support the cross-cutting diff filter step via `supportsDiffFilter`.
 6. **Diff Filter** — Optional post-discovery transformation (`src/diff-filter.ts`) that narrows any SARIF-producing discovery's output to findings touching a git diff, using OpenAnt's call graph for flow-adjacency. Activated automatically when a diff source is provided; individual checks can opt out via `checkTarget.diffFilter: false`.
 7. **Report Generator** — Produces `security_checks_results.json` (or `.sarif`) conforming to the `ScanResults` schema
 
@@ -29,7 +29,7 @@ Seven core components orchestrated by the Security Scanner:
 
 **Check types**: Three check types with pluggable discovery:
 - `repository` — AI analyzes the whole repo (no discovery needed)
-- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `opengrep` (Opengrep rules — Semgrep fork, identical rule syntax), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings), `glob` (file path pattern, whole-file targets)
+- `targeted` — A discovery method finds specific code locations, AI analyzes each independently. Discovery methods: `semgrep` (Semgrep rules), `opengrep` (Opengrep rules — Semgrep fork, identical rule syntax), `openant` (OpenAnt code units with call graph context), `sarif` (external SARIF file findings), `glob` (file path pattern, whole-file targets), `script` (user-provided Node.js or bash script)
 - `static` — A discovery method finds issues mapped directly to results, no AI involvement. Discovery methods: `semgrep`, `opengrep`
 
 Each targeted/static check specifies `checkTarget.discovery` (e.g., `semgrep`, `opengrep`, `openant`, `sarif`) to select the discovery strategy. Targeted checks can also set `checkTarget.analysisMode` to control what the AI does with each target: `custom` (default, uses `instructionsFile`), `false-positive-validation`, or `general-vuln-discovery` (built-in prompt templates, no `instructionsFile` needed).
@@ -151,7 +151,7 @@ listed instead of its contents.
 
 **Subsystems** — each is a registry plus interchangeable implementations; read the named file for the interface, then the sibling directory for the implementations
 
-- `src/discovery.ts` + `src/discoveries/` — Pluggable target discovery: `DiscoveryProvider` interface, `DiscoveryRegistry`, orchestration. Implementations: semgrep, opengrep, openant, sarif, glob
+- `src/discovery.ts` + `src/discoveries/` — Pluggable target discovery: `DiscoveryProvider` interface, `DiscoveryRegistry`, orchestration. Implementations: semgrep, opengrep, openant, sarif, glob, script
 - `src/formatters/index.ts` + `src/formatters/` — Output formatter registry and implementations (json, sarif, csv, html); `types.ts` defines the `OutputFormatter` interface
 - `src/provider-registry.ts` + `src/*-provider.ts` — Agent providers (`claude-code-provider.ts`, `opencode-provider.ts`, `mock-agent-provider.ts`); `provider-utils.ts` holds the shared OUTPUT_SCHEMA
 - `src/diff-filter.ts` — Diff filter (`applyDiffFilter`), applied post-discovery whenever a diff source exists and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets using the OpenAnt call graph (depth-1), falling back to file+line overlap (depth-0) when OpenAnt is unavailable. Supported by `diff-parser.ts` and `diff-unit-matcher.ts`
@@ -174,7 +174,7 @@ listed instead of its contents.
 
 ## Conventions
 
-- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep/Opengrep, E6xxx=OpenAnt, E70xx=budget, E72xx=result handlers (PR comments etc.), E9xxx=internal/fatal.
+- **Error codes**: All CLI error paths must use codes from `src/error-codes.ts` via `formatError()`. Numbering scheme: E1xxx=CLI parsing, E2xxx=configuration, E3xxx=agent provider, E4xxx=repository/target validation, E5xxx=Semgrep/Opengrep, E6xxx=OpenAnt, E70xx=budget, E71xx=script discovery, E72xx=result handlers (PR comments etc.), E9xxx=internal/fatal.
 - **Color output**: Use helpers from `src/colors.ts` for colored output, never raw ANSI codes. The `NO_COLOR` env var is respected automatically via `picocolors`.
 
 ## Development Workflow

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,7 @@ The `discovery` field on `checkTarget` specifies how targets are found for `targ
 | `sarif` | SARIF file in check definition (`sarifFile`) | Reads findings from an external SARIF file | Yes |
 | `openant` | OpenAnt + Python 3.11+ | Runs `openant parse` on the target repo to extract code units with call graph context | Yes |
 | `glob` | None | Walks the repository and selects whole-file targets matching a glob pattern (e.g. `src/routes/**/*.ts`). Targeted checks only. Always skips: `.git`, `node_modules`, `.venv`, `venv`, `__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`, `dist`, `build`, `.next`, `.nuxt`, `.cache`, `.idea`, `.vscode`. Files larger than 10 MiB and symlinks are also skipped | No |
+| `script` | None (script must be node or bash) | Runs a user-provided discovery script in the repo and parses its stdout into targets. Runs with `shell: false`, a curated environment with secrets stripped, a hard timeout and a bounded stdout. Script and output paths must resolve inside the repo, symlinks included | No |
 
 ### Diff filtering
 

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -217,6 +217,58 @@ export async function loadCheckDefinition(checkFolderPath: string): Promise<Chec
         `Check definition "${defPath}": "checkTarget.glob" must be a non-empty string when discovery is "glob"`,
       );
     }
+
+    // Validate script-discovery fields
+    if (ct.script !== undefined && typeof ct.script !== 'string') {
+      throw new Error(`Check definition "${defPath}": "checkTarget.script" must be a string`);
+    }
+    if (ct.scriptType !== undefined) {
+      if (typeof ct.scriptType !== 'string' || (ct.scriptType !== 'node' && ct.scriptType !== 'bash')) {
+        throw new Error(
+          `Check definition "${defPath}": "checkTarget.scriptType" must be "node" or "bash"`,
+        );
+      }
+    }
+    if (ct.outputFormat !== undefined) {
+      if (
+        typeof ct.outputFormat !== 'string' ||
+        (ct.outputFormat !== 'lines' &&
+          ct.outputFormat !== 'json-array' &&
+          ct.outputFormat !== 'json-object')
+      ) {
+        throw new Error(
+          `Check definition "${defPath}": "checkTarget.outputFormat" must be one of "lines", "json-array", "json-object"`,
+        );
+      }
+    }
+    if (ct.cwd !== undefined && typeof ct.cwd !== 'string') {
+      throw new Error(`Check definition "${defPath}": "checkTarget.cwd" must be a string`);
+    }
+    if (
+      ct.timeoutMs !== undefined &&
+      (typeof ct.timeoutMs !== 'number' || ct.timeoutMs <= 0 || !Number.isFinite(ct.timeoutMs))
+    ) {
+      throw new Error(
+        `Check definition "${defPath}": "checkTarget.timeoutMs" must be a positive number`,
+      );
+    }
+    if (ct.discovery === 'script') {
+      if (typeof ct.script !== 'string' || ct.script.trim() === '') {
+        throw new Error(
+          `Check definition "${defPath}": "checkTarget.script" is required when discovery is "script"`,
+        );
+      }
+      if (typeof ct.scriptType !== 'string') {
+        throw new Error(
+          `Check definition "${defPath}": "checkTarget.scriptType" is required when discovery is "script"`,
+        );
+      }
+      if (typeof ct.outputFormat !== 'string') {
+        throw new Error(
+          `Check definition "${defPath}": "checkTarget.outputFormat" is required when discovery is "script"`,
+        );
+      }
+    }
     // Validate openant filter config
     if (ct.openant !== undefined) {
       if (typeof ct.openant !== 'object' || ct.openant === null) {

--- a/src/discoveries/script-discovery.ts
+++ b/src/discoveries/script-discovery.ts
@@ -153,6 +153,31 @@ interface ScriptTargetInput {
 }
 
 /**
+ * True when `candidateAbs` lives inside `rootAbs`. Both must be absolute.
+ *
+ * Two ways to be outside, and both matter:
+ *   - a `..` prefix, the ordinary case;
+ *   - an absolute result, which is what `relative()` returns on Windows when
+ *     the two paths are on different drives (`C:\repo` vs `D:\checks`).
+ *
+ * Exported so the rule can be unit-tested against Windows-style paths on any
+ * platform. It exists as a single function because it previously did not: two
+ * call sites implemented the rule separately, one omitted the absolute-path
+ * case, and cross-drive layouts were rejected as a result.
+ *
+ * Pass a `pathApi` of `path.win32` or `path.posix` to test either flavour.
+ */
+export function isInsideRoot(
+  rootAbs: string,
+  candidateAbs: string,
+  pathApi: { relative: (a: string, b: string) => string; isAbsolute: (p: string) => boolean } =
+    { relative, isAbsolute },
+): boolean {
+  const rel = pathApi.relative(rootAbs, candidateAbs);
+  return !rel.startsWith('..') && !pathApi.isAbsolute(rel);
+}
+
+/**
  * Verify that `candidateAbs` (an already-resolved absolute path) lives inside
  * `rootAbs` (also absolute). Throws via `formatError(E2004, ...)` if the
  * candidate escapes the root. Returns void.
@@ -161,8 +186,7 @@ interface ScriptTargetInput {
  * symlink-aware re-check.
  */
 function assertInsideRoot(rootAbs: string, candidateAbs: string, label: string): void {
-  const rel = relative(rootAbs, candidateAbs);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
+  if (!isInsideRoot(rootAbs, candidateAbs)) {
     throw new Error(
       formatError(
         ERROR_CODES.E2004,
@@ -612,7 +636,7 @@ export const scriptDiscovery: TargetDiscovery = {
     // the target repo) — in that case resolveInside(checkBase, ...) above
     // already constrained the script to the check folder.
     const checkBaseAbs = resolve(checkBase);
-    const checkBaseInsideRepo = !relative(repoRoot, checkBaseAbs).startsWith('..');
+    const checkBaseInsideRepo = isInsideRoot(repoRoot, checkBaseAbs);
     if (checkBaseInsideRepo) {
       // re-raise propagates the original E2004-formatted message
       assertInsideRoot(repoRoot, scriptAbs, `[${check.id}] checkTarget.script`);

--- a/src/discoveries/script-discovery.ts
+++ b/src/discoveries/script-discovery.ts
@@ -1,0 +1,751 @@
+/**
+ * Script-based target discovery.
+ *
+ * Runs a user-provided script (`node` or `bash`) in the target repository
+ * and parses its stdout to produce discovery targets. Useful when target
+ * discovery is too custom for Semgrep / SARIF / OpenAnt — e.g. parsing an
+ * OpenAPI spec, querying a build manifest, walking a database schema, etc.
+ *
+ * ─── Trust model ─────────────────────────────────────────────────────────────
+ *
+ * Scripts run with the full privileges of the aghast process. They are not
+ * sandboxed. Treat any script referenced by a check definition as trusted
+ * code — only enable script-discovery checks whose script you (or your team)
+ * have read and audited.
+ *
+ * Defensive measures applied here:
+ * - Script path must resolve INSIDE the configured check folder or repo
+ *   (no `..` escape, no absolute paths to /etc/shadow, etc.).
+ * - Symlink-aware: both the script path and `cwd` are realpath'd and
+ *   re-checked against the repo root, so a symlink inside the check folder
+ *   pointing outside the repo cannot be used to execute external code.
+ * - Spawned with `shell: false` and array args — no shell interpolation, no
+ *   command injection from check-definition fields.
+ * - Spawned with a curated environment: only a small allow-list of neutral
+ *   env vars (PATH, HOME, locale, temp dirs, Windows essentials) is forwarded.
+ *   As defence-in-depth, any var matching a known-secret pattern (`*_KEY`,
+ *   `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, or `ANTHROPIC_*` / `OPENAI_*` /
+ *   `GITHUB_*` / `AGHAST_*` / `AWS_*` / `GCP_*` / `AZURE_*` prefixes) is
+ *   also explicitly dropped. Allow-list matching is case-insensitive so
+ *   the Windows-style `Path` / `SystemRoot` casing works the same as POSIX
+ *   `PATH`.
+ * - cwd, when supplied, must resolve (and realpath) inside the repo root.
+ * - Hard timeout (default 30s, configurable per check).
+ * - Stdout is bounded (8 MiB) to prevent memory exhaustion from runaway scripts.
+ * - Both the line-format and JSON-format output paths cap the number of
+ *   parsed targets (MAX_LINE_TARGETS / MAX_JSON_TARGETS) to bound memory
+ *   even if a script floods within the stdout cap.
+ * - Output is parsed as data (lines / JSON) — never `eval`-ed.
+ * - File paths returned by the script are validated to be relative & inside
+ *   the repo (no `..` escape, no absolute paths) before they are forwarded
+ *   to the AI prompt or snippet extractor.
+ * - On `bash` scripts, Windows is unsupported (no system bash) and a clear
+ *   error is raised rather than silently falling back.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFile, realpath } from 'node:fs/promises';
+import { resolve, relative, isAbsolute, normalize } from 'node:path';
+import { logDebug, logProgress, logWarn } from '../logging.js';
+import { ERROR_CODES, formatError } from '../error-codes.js';
+import { DEFAULT_GENERIC_PROMPT } from '../defaults.js';
+import type { TargetDiscovery, DiscoveredTarget, DiscoveryOptions } from '../discovery.js';
+import type { SecurityCheck } from '../types.js';
+
+const TAG = 'script-discovery';
+
+/** Default timeout: 30s. Overridable per check via `checkTarget.timeoutMs`. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Cap on total stdout we will buffer (8 MiB). */
+const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
+
+/** Cap on total stderr we will buffer (1 MiB) — only used for diagnostics. */
+const MAX_STDERR_BYTES = 1 * 1024 * 1024;
+
+/** Maximum number of lines we will keep when parsing `lines` format. */
+const MAX_LINE_TARGETS = 100_000;
+
+/** Maximum number of items we will keep when parsing `json-array` / `json-object` format. */
+const MAX_JSON_TARGETS = 100_000;
+
+/**
+ * Build a curated environment for the spawned discovery script.
+ *
+ * Discovery scripts need to walk the repo, possibly run small helper tools,
+ * but they never need API credentials. We start from a minimal allow-list of
+ * "neutral" env vars (PATH/locale/temp dirs) and then ALSO drop any var whose
+ * name matches a known-secret pattern even if it slipped through. Both layers
+ * are defence-in-depth.
+ *
+ * Exported for testing.
+ */
+export function buildScriptEnv(parent: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  // Allow-list: variables a normal CLI tool needs to function.
+  // Case-insensitive: on Windows `process.env` enumerates keys with their
+  // original casing (e.g. `Path`, `SystemRoot`, `ProgramFiles`), so a strict
+  // case-sensitive `Set.has` would drop those vars and break script
+  // discovery on Windows. We normalize to upper-case for membership checks.
+  const ALLOW_LIST_UPPER: ReadonlySet<string> = new Set(
+    [
+      'PATH',
+      'HOME',
+      'USER',
+      'USERNAME',
+      'LANG',
+      'LC_ALL',
+      'LC_CTYPE',
+      'LC_MESSAGES',
+      'LC_NUMERIC',
+      'LC_TIME',
+      'TZ',
+      'TMPDIR',
+      'TMP',
+      'TEMP',
+      // Windows essentials (uppercased — case-insensitive match below)
+      'SYSTEMROOT',
+      'SYSTEMDRIVE',
+      'COMSPEC',
+      'PATHEXT',
+      'WINDIR',
+      'APPDATA',
+      'LOCALAPPDATA',
+      'PROGRAMDATA',
+      'PROGRAMFILES',
+      'PROGRAMFILES(X86)',
+      'PUBLIC',
+      'USERPROFILE',
+    ].map((s) => s.toUpperCase()),
+  );
+  // Block-list patterns: never forward, even if they accidentally appear in
+  // the allow-list. The `i` flag makes them case-insensitive too.
+  const BLOCK_PATTERNS: ReadonlyArray<RegExp> = [
+    /(?:^|_)KEY$/i,
+    /(?:^|_)TOKEN$/i,
+    /(?:^|_)SECRET$/i,
+    /(?:^|_)PASSWORD$/i,
+    /(?:^|_)PASSWD$/i,
+    /^ANTHROPIC_/i,
+    /^OPENAI_/i,
+    /^GITHUB_/i,
+    /^AGHAST_/i, // aghast-internal config should not leak to discovery scripts
+    /^AWS_/i,
+    /^GCP_/i,
+    /^AZURE_/i,
+    /^NPM_TOKEN/i,
+  ];
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(parent)) {
+    if (v === undefined) continue;
+    if (!ALLOW_LIST_UPPER.has(k.toUpperCase())) continue;
+    if (BLOCK_PATTERNS.some((re) => re.test(k))) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+interface ScriptTargetInput {
+  file: string;
+  startLine?: number;
+  endLine?: number;
+  message?: string;
+  snippet?: string;
+}
+
+/**
+ * Verify that `candidateAbs` (an already-resolved absolute path) lives inside
+ * `rootAbs` (also absolute). Throws via `formatError(E2004, ...)` if the
+ * candidate escapes the root. Returns void.
+ *
+ * Used both for the textual `resolve` check and for the post-`realpath`
+ * symlink-aware re-check.
+ */
+function assertInsideRoot(rootAbs: string, candidateAbs: string, label: string): void {
+  const rel = relative(rootAbs, candidateAbs);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(
+      formatError(
+        ERROR_CODES.E2004,
+        `${label} "${candidateAbs}" resolves outside of "${rootAbs}" — refusing to run`,
+      ),
+    );
+  }
+}
+
+/**
+ * Symlink-aware path validation. Resolves the realpath of `target` and verifies
+ * the realpath is still inside `rootAbs`. If the target does not yet exist
+ * (e.g. cwd that the script will create), falls back to the textual path.
+ */
+async function assertRealpathInsideRoot(
+  rootAbs: string,
+  target: string,
+  label: string,
+): Promise<void> {
+  let realTarget: string;
+  try {
+    realTarget = await realpath(target);
+  } catch {
+    // Path may not exist yet — textual check (already performed elsewhere) suffices.
+    return;
+  }
+  // realpath of root may itself differ if the repo is reached via a symlink;
+  // resolve both ends to be consistent.
+  let realRoot: string;
+  try {
+    realRoot = await realpath(rootAbs);
+  } catch {
+    realRoot = rootAbs;
+  }
+  assertInsideRoot(realRoot, realTarget, `${label} (after symlink resolution)`);
+}
+
+/**
+ * Resolve a path that should live inside `root`. Throws if the resolved
+ * absolute path escapes the root directory (path traversal protection).
+ *
+ * Both `..` segments and absolute-path inputs are handled by re-resolving
+ * against `root` and then verifying that `relative(root, resolved)` does
+ * not start with `..`.
+ *
+ * NOTE: This is a textual check only — it does NOT follow symlinks. Callers
+ * that care about symlink escape (e.g. when about to spawn the file as code)
+ * should additionally call `assertRealpathInsideRoot`.
+ */
+function resolveInside(root: string, candidate: string, label: string): string {
+  if (typeof candidate !== 'string' || candidate.length === 0) {
+    throw new Error(formatError(ERROR_CODES.E2004, `${label} must be a non-empty string`));
+  }
+  // Reject absolute paths up-front: scripts in check definitions should be
+  // expressed relative to the check folder / repo, never absolute.
+  if (isAbsolute(candidate)) {
+    throw new Error(
+      formatError(ERROR_CODES.E2004, `${label} must be a relative path, got absolute: "${candidate}"`),
+    );
+  }
+  const rootAbs = resolve(root);
+  const resolved = resolve(rootAbs, candidate);
+  assertInsideRoot(rootAbs, resolved, label);
+  return resolved;
+}
+
+/**
+ * Validate a file path emitted by a script: must be relative, must not
+ * traverse outside the repo via `..`. Returns the normalized path.
+ */
+function validateScriptFilePath(file: string, idx: number): string {
+  if (typeof file !== 'string' || file.length === 0) {
+    throw new Error(formatError(ERROR_CODES.E7105, `Script target[${idx}].file must be a non-empty string`));
+  }
+  if (isAbsolute(file)) {
+    throw new Error(
+      formatError(
+        ERROR_CODES.E7105,
+        `Script target[${idx}].file must be relative (got absolute: "${file}")`,
+      ),
+    );
+  }
+  // normalize collapses redundant segments; if the result starts with `..`
+  // the path escapes the repo root.
+  const norm = normalize(file).replace(/\\/g, '/');
+  if (norm === '..' || norm.startsWith('../') || norm.startsWith('..\\')) {
+    throw new Error(
+      formatError(
+        ERROR_CODES.E7105,
+        `Script target[${idx}].file "${file}" escapes the repository root via ".."`,
+      ),
+    );
+  }
+  return norm;
+}
+
+/**
+ * Parse stdout into a list of discovery target inputs.
+ * - `lines`: one file path per non-empty, non-comment line.
+ * - `json-array`: a JSON array of strings (file paths) or objects.
+ * - `json-object`: an object with a `targets` array of strings or objects.
+ *
+ * Both `lines` and JSON formats cap parsed targets at MAX_LINE_TARGETS /
+ * MAX_JSON_TARGETS (100k each); the rest are dropped with a warning log.
+ *
+ * Output is treated as DATA: never eval'd, never interpolated into commands.
+ */
+export function parseScriptOutput(
+  raw: string,
+  format: 'lines' | 'json-array' | 'json-object',
+): ScriptTargetInput[] {
+  if (format === 'lines') {
+    // NOTE: the `lines` format treats blank lines and lines starting with `#`
+    // as comments and skips them. Documented intentionally — file paths
+    // beginning with `#` are unusual and unsupported.
+    const out: ScriptTargetInput[] = [];
+    let truncated = false;
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      if (trimmed.startsWith('#')) continue;
+      out.push({ file: trimmed });
+      if (out.length >= MAX_LINE_TARGETS) {
+        truncated = true;
+        break;
+      }
+    }
+    if (truncated) {
+      logWarn(
+        TAG,
+        `Script output truncated at MAX_LINE_TARGETS=${MAX_LINE_TARGETS}; remaining lines ignored`,
+      );
+    }
+    return out;
+  }
+
+  // JSON formats
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      formatError(
+        ERROR_CODES.E7105,
+        `Script output is not valid JSON for outputFormat=${format}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ),
+      { cause: err },
+    );
+  }
+
+  let arr: unknown;
+  if (format === 'json-array') {
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        formatError(ERROR_CODES.E7105, `Script outputFormat=json-array expects a JSON array at the root`),
+      );
+    }
+    arr = parsed;
+  } else {
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7105,
+          `Script outputFormat=json-object expects a JSON object with a "targets" array`,
+        ),
+      );
+    }
+    const targets = (parsed as Record<string, unknown>).targets;
+    if (!Array.isArray(targets)) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7105,
+          `Script outputFormat=json-object expects a "targets" array; got ${typeof targets}`,
+        ),
+      );
+    }
+    arr = targets;
+  }
+
+  const out: ScriptTargetInput[] = [];
+  const items = arr as unknown[];
+  // Cap JSON-parsed item count to bound memory even if the script flooded
+  // structured output within the stdout cap.
+  const limit = Math.min(items.length, MAX_JSON_TARGETS);
+  if (items.length > MAX_JSON_TARGETS) {
+    logWarn(
+      TAG,
+      `Script JSON output truncated at MAX_JSON_TARGETS=${MAX_JSON_TARGETS} (script returned ${items.length} items)`,
+    );
+  }
+  for (let i = 0; i < limit; i++) {
+    const item = items[i];
+    if (typeof item === 'string') {
+      out.push({ file: item });
+      continue;
+    }
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7105,
+          `Script target[${i}] must be a string or object, got ${Array.isArray(item) ? 'array' : typeof item}`,
+        ),
+      );
+    }
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.file !== 'string' || obj.file.length === 0) {
+      throw new Error(
+        formatError(ERROR_CODES.E7105, `Script target[${i}].file must be a non-empty string`),
+      );
+    }
+    const t: ScriptTargetInput = { file: obj.file };
+    if (obj.startLine !== undefined) {
+      if (typeof obj.startLine !== 'number' || !Number.isFinite(obj.startLine) || obj.startLine < 0) {
+        throw new Error(
+          formatError(ERROR_CODES.E7105, `Script target[${i}].startLine must be a non-negative number`),
+        );
+      }
+      t.startLine = Math.floor(obj.startLine);
+    }
+    if (obj.endLine !== undefined) {
+      if (typeof obj.endLine !== 'number' || !Number.isFinite(obj.endLine) || obj.endLine < 0) {
+        throw new Error(
+          formatError(ERROR_CODES.E7105, `Script target[${i}].endLine must be a non-negative number`),
+        );
+      }
+      t.endLine = Math.floor(obj.endLine);
+    }
+    if (obj.message !== undefined) {
+      if (typeof obj.message !== 'string') {
+        throw new Error(formatError(ERROR_CODES.E7105, `Script target[${i}].message must be a string`));
+      }
+      t.message = obj.message;
+    }
+    if (obj.snippet !== undefined) {
+      if (typeof obj.snippet !== 'string') {
+        throw new Error(formatError(ERROR_CODES.E7105, `Script target[${i}].snippet must be a string`));
+      }
+      t.snippet = obj.snippet;
+    }
+    out.push(t);
+  }
+  return out;
+}
+
+interface RunScriptResult {
+  stdout: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}
+
+/**
+ * Execute the script as a child process and capture stdout.
+ * - Uses `spawn` with `shell: false`: never invoke a shell, never interpolate.
+ * - Passes a curated env (no API keys / tokens) — see `buildScriptEnv`.
+ * - Bounds stdout/stderr buffers and kills the process on timeout.
+ */
+export function runScript(opts: {
+  command: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+  env?: NodeJS.ProcessEnv;
+}): Promise<RunScriptResult> {
+  return new Promise((resolvePromise, reject) => {
+    let stdoutLen = 0;
+    let stderrLen = 0;
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timedOut = false;
+    let stdoutTruncated = false;
+
+    const child = spawn(opts.command, opts.args, {
+      cwd: opts.cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      env: opts.env ?? buildScriptEnv(),
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // Kill the whole process; on POSIX SIGKILL is unmaskable. On Windows
+      // Node's kill() invokes TerminateProcess regardless of the signal.
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // already exited
+      }
+    }, opts.timeoutMs);
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (stdoutTruncated) return;
+      if (stdoutLen + chunk.length > MAX_STDOUT_BYTES) {
+        stdoutTruncated = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // ignore
+        }
+        return;
+      }
+      stdoutChunks.push(chunk);
+      stdoutLen += chunk.length;
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      if (stderrLen + chunk.length > MAX_STDERR_BYTES) return;
+      stderrChunks.push(chunk);
+      stderrLen += chunk.length;
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(
+          new Error(
+            formatError(
+              ERROR_CODES.E7101,
+              `Script discovery timed out after ${opts.timeoutMs}ms`,
+            ),
+          ),
+        );
+        return;
+      }
+      if (stdoutTruncated) {
+        reject(
+          new Error(
+            formatError(
+              ERROR_CODES.E7103,
+              `Script discovery stdout exceeded ${MAX_STDOUT_BYTES} bytes — aborted`,
+            ),
+          ),
+        );
+        return;
+      }
+      resolvePromise({
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        exitCode: code,
+        signal,
+      });
+    });
+  });
+}
+
+/**
+ * Resolve the runtime command + leading args for a given scriptType.
+ * Returns `[command, ...leadingArgs]`. The script path is appended later.
+ */
+function commandForScriptType(scriptType: 'node' | 'bash'): [string, string[]] {
+  if (scriptType === 'node') {
+    // Use the same Node binary that's running aghast — avoids surprises from
+    // PATH lookups picking up an unexpected node.
+    return [process.execPath, []];
+  }
+  if (scriptType === 'bash') {
+    if (process.platform === 'win32') {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7106,
+          `scriptType="bash" is not supported on Windows; use scriptType="node" instead`,
+        ),
+      );
+    }
+    // Use bare `bash` so PATH lookup works on systems where bash lives at
+    // /usr/bin/bash, /usr/local/bin/bash, NixOS store paths, etc. spawn() with
+    // shell:false still resolves bare command names through PATH.
+    return ['bash', []];
+  }
+  // Should be unreachable due to upstream validation.
+  throw new Error(
+    formatError(ERROR_CODES.E7106, `Unknown scriptType: "${scriptType as string}"`),
+  );
+}
+
+export const scriptDiscovery: TargetDiscovery = {
+  name: 'script',
+  defaultGenericPrompt: DEFAULT_GENERIC_PROMPT,
+  needsInstructions: true,
+  // Opted out deliberately, same reasoning as the glob discovery.
+  // `supportsDiffFilter` became a required field on TargetDiscovery after this
+  // discovery was written (#227). A discovery script can emit either whole-file
+  // targets or explicit line ranges, so filter behaviour would vary per script
+  // with nothing to validate it against. Opting out preserves the behaviour
+  // this discovery was built and tested with: the script decides the target
+  // set, and aghast analyses all of it.
+  supportsDiffFilter: false,
+
+  async discover(
+    check: SecurityCheck,
+    repoPath: string,
+    _options?: DiscoveryOptions,
+  ): Promise<DiscoveredTarget[]> {
+    const checkTarget = check.checkTarget!;
+
+    if (!checkTarget.script) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E2004,
+          `Check "${check.id}" uses script discovery but has no "script" in its check definition`,
+        ),
+      );
+    }
+    if (!checkTarget.scriptType) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E2004,
+          `Check "${check.id}" uses script discovery but has no "scriptType" in its check definition`,
+        ),
+      );
+    }
+    if (!checkTarget.outputFormat) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E2004,
+          `Check "${check.id}" uses script discovery but has no "outputFormat" in its check definition`,
+        ),
+      );
+    }
+
+    // Script path: resolve relative to check folder if available, else repo root.
+    // Then re-validate that the absolute resolution is inside the repo (so
+    // a check folder symlinked outside the repo can't be used to escape).
+    const checkBase = check.checkDir ?? repoPath;
+    const repoRoot = resolve(repoPath);
+    let scriptAbs: string;
+    try {
+      scriptAbs = resolveInside(checkBase, checkTarget.script, 'checkTarget.script');
+    } catch (err) {
+      // Re-throw with check id for context
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`[${check.id}] ${msg}`, { cause: err });
+    }
+
+    // Defence-in-depth: also enforce script lives inside the repo root, so that
+    // even if checkDir points outside the repo we don't run arbitrary scripts.
+    // Skip this check when the check folder itself lives outside the repo
+    // (the common case during local dev where checks-config/ is a sibling of
+    // the target repo) — in that case resolveInside(checkBase, ...) above
+    // already constrained the script to the check folder.
+    const checkBaseAbs = resolve(checkBase);
+    const checkBaseInsideRepo = !relative(repoRoot, checkBaseAbs).startsWith('..');
+    if (checkBaseInsideRepo) {
+      // re-raise propagates the original E2004-formatted message
+      assertInsideRoot(repoRoot, scriptAbs, `[${check.id}] checkTarget.script`);
+    }
+
+    // Validate script file exists & is readable.
+    try {
+      await readFile(scriptAbs, { flag: 'r' });
+    } catch (err) {
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7104,
+          `[${check.id}] script "${checkTarget.script}" not found or unreadable at "${scriptAbs}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+        { cause: err },
+      );
+    }
+
+    // Symlink-aware re-check: if the script (or any parent component) is a
+    // symlink whose realpath escapes the constraining root, refuse to run.
+    // We use the check folder as the constraining root when checkBase is
+    // outside the repo (local-dev case); otherwise we use the repo root.
+    const symlinkConstrainingRoot = checkBaseInsideRepo ? repoRoot : checkBaseAbs;
+    await assertRealpathInsideRoot(
+      symlinkConstrainingRoot,
+      scriptAbs,
+      `[${check.id}] checkTarget.script`,
+    );
+
+    // Resolve cwd: must be inside repo. Defaults to repo root.
+    let scriptCwd = repoRoot;
+    if (checkTarget.cwd !== undefined) {
+      try {
+        scriptCwd = resolveInside(repoRoot, checkTarget.cwd, 'checkTarget.cwd');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`[${check.id}] ${msg}`, { cause: err });
+      }
+      // Symlink-aware cwd check.
+      await assertRealpathInsideRoot(repoRoot, scriptCwd, `[${check.id}] checkTarget.cwd`);
+    }
+
+    const timeoutMs =
+      typeof checkTarget.timeoutMs === 'number' && checkTarget.timeoutMs > 0
+        ? Math.floor(checkTarget.timeoutMs)
+        : DEFAULT_TIMEOUT_MS;
+
+    const [command, leadingArgs] = commandForScriptType(checkTarget.scriptType);
+    // No shell interpolation: array args, shell:false in spawn.
+    const args = [...leadingArgs, scriptAbs];
+
+    logProgress(TAG, `Running script discovery for check ${check.id}: ${checkTarget.scriptType} ${checkTarget.script}`);
+    logDebug(TAG, `cmd=${command} args=${JSON.stringify(args)} cwd=${scriptCwd} timeout=${timeoutMs}ms`);
+
+    let result: RunScriptResult;
+    try {
+      result = await runScript({ command, args, cwd: scriptCwd, timeoutMs });
+    } catch (err) {
+      // Already-formatted E7xxx errors from runScript pass through cause.
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7104,
+          `[${check.id}] script discovery failed: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+        { cause: err },
+      );
+    }
+
+    if (result.exitCode !== 0) {
+      const stderrPreview = result.stderr.length > 500 ? result.stderr.slice(0, 500) + '…' : result.stderr;
+      throw new Error(
+        formatError(
+          ERROR_CODES.E7102,
+          `[${check.id}] script exited with code=${result.exitCode} signal=${result.signal ?? 'none'}; stderr: ${stderrPreview}`,
+        ),
+      );
+    }
+
+    // Surface non-empty stderr even on success (warnings, deprecations).
+    if (result.stderr.trim().length > 0) {
+      const preview = result.stderr.length > 500 ? result.stderr.slice(0, 500) + '…' : result.stderr;
+      logDebug(TAG, `[${check.id}] script stderr (exit 0): ${preview}`);
+    }
+
+    if (result.stdout.trim().length === 0) {
+      logDebug(TAG, `[${check.id}] script produced empty output — 0 targets`);
+      return [];
+    }
+
+    const parsedTargets = parseScriptOutput(result.stdout, checkTarget.outputFormat);
+
+    // Apply maxTargets in two places: here (early — bounds memory) and again in
+    // scan-runner (canonical limit applied uniformly across discoveries).
+    let limited = parsedTargets;
+    if (
+      typeof checkTarget.maxTargets === 'number' &&
+      checkTarget.maxTargets > 0 &&
+      limited.length > checkTarget.maxTargets
+    ) {
+      limited = limited.slice(0, checkTarget.maxTargets);
+    }
+
+    logDebug(TAG, `[${check.id}] script produced ${parsedTargets.length} targets (using ${limited.length})`);
+
+    // Convert parsed inputs to DiscoveredTarget objects.
+    return limited.map((t, idx) => {
+      // Reject absolute / `..`-traversing file paths before they reach the
+      // AI prompt or the snippet extractor.
+      const safeFile = validateScriptFilePath(t.file, idx);
+      // Normalize line numbers: DiscoveredTarget is documented as 1-based,
+      // so coerce undefined or 0 → 1.
+      const rawStart = typeof t.startLine === 'number' ? t.startLine : 1;
+      const startLine = rawStart < 1 ? 1 : rawStart;
+      const rawEnd = typeof t.endLine === 'number' ? t.endLine : startLine;
+      const endLine = rawEnd < 1 ? startLine : rawEnd;
+      const enrichment = `\n\nTARGET LOCATION (from script discovery):
+
+- File: ${safeFile}
+- Lines: ${startLine}-${endLine}${t.message ? `\n- Message: ${t.message}` : ''}
+`;
+      const out: DiscoveredTarget = {
+        file: safeFile,
+        startLine,
+        endLine,
+        label: `[script-target ${idx + 1}/${limited.length}]`,
+        promptEnrichment: enrichment,
+      };
+      if (t.message !== undefined) out.message = t.message;
+      if (t.snippet !== undefined) out.snippet = t.snippet;
+      return out;
+    });
+  },
+};
+

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -9,6 +9,7 @@
  *   E5xxx — Semgrep / Opengrep
  *   E6xxx — OpenAnt
  *   E70xx — Budget / cost controls
+ *   E71xx — Script discovery
  *   E72xx — Result handlers (PR comments, issue trackers, notifications)
  *   E9xxx — Internal/fatal
  */
@@ -58,6 +59,14 @@ export const ERROR_CODES = {
 
   // E70xx — Budget / cost controls
   E7001: ec('E7001', 'Budget limit exceeded'),
+
+  // E71xx — Script discovery
+  E7101: ec('E7101', 'Script discovery timeout'),
+  E7102: ec('E7102', 'Script discovery non-zero exit'),
+  E7103: ec('E7103', 'Script discovery stdout overflow'),
+  E7104: ec('E7104', 'Script discovery spawn/IO failure'),
+  E7105: ec('E7105', 'Script discovery output parse failure'),
+  E7106: ec('E7106', 'Script discovery unsupported scriptType for platform'),
 
   // E72xx — Result handlers
   E7201: ec('E7201', 'PR comment posting failed'),

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -23,6 +23,7 @@ import { sarifDiscovery } from './discoveries/sarif-discovery.js';
 import { applyDiffFilter } from './diff-filter.js';
 import { runOpenAnt } from './openant-runner.js';
 import { globDiscovery } from './discoveries/glob-discovery.js';
+import { scriptDiscovery } from './discoveries/script-discovery.js';
 import type { DiscoveredTarget } from './discovery.js';
 import {
   DEFAULT_MODEL,
@@ -58,6 +59,7 @@ registerDiscovery(opengrepDiscovery);
 registerDiscovery(openantDiscovery);
 registerDiscovery(sarifDiscovery);
 registerDiscovery(globDiscovery);
+registerDiscovery(scriptDiscovery);
 
 /**
  * Decide whether to apply the diff filter to a check's discovered targets.

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface OpenAntFilterConfig {
 
 export interface CheckTargetDefinition {
   type: 'targeted' | 'static' | 'repository';
-  discovery?: 'semgrep' | 'opengrep' | 'openant' | 'sarif' | 'glob';
+  discovery?: 'semgrep' | 'opengrep' | 'openant' | 'sarif' | 'glob' | 'script';
   rules?: string | string[];
   config?: string;
   sarifFile?: string;
@@ -118,6 +118,16 @@ export interface CheckTargetDefinition {
    *   5. This field (check-level fallback).
    */
   diffRef?: string;
+  /** Script discovery: path to the script (relative to check folder, must resolve inside repo). */
+  script?: string;
+  /** Script discovery: which runtime to invoke. */
+  scriptType?: 'node' | 'bash';
+  /** Script discovery: how the script's stdout is parsed. */
+  outputFormat?: 'lines' | 'json-array' | 'json-object';
+  /** Script discovery: working directory for the script (relative to repo root; defaults to repo root). */
+  cwd?: string;
+  /** Script discovery: timeout in milliseconds (default 30000). */
+  timeoutMs?: number;
 }
 
 // --- A.2b Check Target (discovered location) ---

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -28,6 +28,7 @@ import {
   mixedChecksConfigDir,
   semgrepOnlyConfigDir,
   globCheckConfigDir,
+  scriptDiscoveryConfigDir,
   cli3TargetsSarif,
   emptyResultsSarif,
   noEndlineSarif,
@@ -1414,5 +1415,27 @@ describe('CLI mock mode: CI/CD metadata', () => {
     assert.equal(ciMetadata.branch, 'feat/stretch-116-ci-metadata');
     assert.equal(ciMetadata.pipelineSource, 'push');
     assert.equal(ciMetadata.jobStartedAt, '2026-05-04T12:00:00Z');
+  });
+});
+
+// ─── Script-based target discovery ────────────────────────────────────────────
+
+describe('CLI mock mode: script discovery', () => {
+  afterEach(cleanupOutput);
+
+  it('PASS: script emits 3 lines, mock AI returns no issues per target', async () => {
+    const { exitCode, stderr } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [repoDir, '--config-dir', scriptDiscoveryConfigDir],
+    );
+    assert.equal(exitCode, 0, `Expected exit 0 but got ${exitCode}. stderr: ${stderr}`);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks.length, 1);
+    assert.equal(checks[0].checkId, 'aghast-script-demo');
+    assert.equal(checks[0].status, 'PASS');
+    assert.equal(checks[0].targetsAnalyzed, 3, 'Should analyze 3 targets from script output');
+    assert.equal(checks[0].issuesFound, 0);
   });
 });

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -76,6 +76,7 @@ export const sarifDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-config
 export const openantDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'openant-diff-filter');
 export const fpValidationConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'fp-validation');
 export const globCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'glob-check');
+export const scriptDiscoveryConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'script-discovery');
 
 // SARIF fixtures
 export const cli3TargetsSarif = resolve(testDir, 'fixtures', 'sarif', 'cli-3-targets.sarif');

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -101,7 +101,7 @@ describe('Built-in discoveries (loaded via scan-runner)', () => {
   // Import scan-runner to trigger the side-effect registration of built-in discoveries.
   // This must be a dynamic import so the registry is populated after clearDiscoveryRegistry()
   // in the beforeEach above doesn't interfere.
-  it('semgrep, opengrep, openant, and sarif are registered after scan-runner loads', async () => {
+  it('all built-in discoveries are registered after scan-runner loads', async () => {
     // Dynamic import triggers the registerDiscovery() calls in scan-runner.ts
     await import('../src/scan-runner.js');
     const names = getRegisteredDiscoveries();
@@ -109,6 +109,8 @@ describe('Built-in discoveries (loaded via scan-runner)', () => {
     assert.ok(names.includes('opengrep'), 'opengrep should be registered');
     assert.ok(names.includes('openant'), 'openant should be registered');
     assert.ok(names.includes('sarif'), 'sarif should be registered');
+    assert.ok(names.includes('glob'), 'glob should be registered');
+    assert.ok(names.includes('script'), 'script should be registered');
     assert.ok(!names.includes('diff-semgrep'), 'diff-semgrep is no longer a discovery');
   });
 
@@ -117,5 +119,9 @@ describe('Built-in discoveries (loaded via scan-runner)', () => {
     assert.equal(getDiscovery('semgrep').supportsDiffFilter, true);
     assert.equal(getDiscovery('sarif').supportsDiffFilter, true);
     assert.equal(getDiscovery('openant').supportsDiffFilter, true);
+    // Whole-file discoveries opt out — the filter is built around findings with
+    // meaningful line ranges. See the comments on each provider.
+    assert.equal(getDiscovery('glob').supportsDiffFilter, false);
+    assert.equal(getDiscovery('script').supportsDiffFilter, false);
   });
 });

--- a/tests/fixtures/cli-configs/script-discovery/checks-config.json
+++ b/tests/fixtures/cli-configs/script-discovery/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-script-demo",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/aghast-script-demo.json
+++ b/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/aghast-script-demo.json
@@ -1,0 +1,13 @@
+{
+  "id": "aghast-script-demo",
+  "name": "Script Discovery Demo",
+  "instructionsFile": "aghast-script-demo.md",
+  "checkTarget": {
+    "type": "targeted",
+    "discovery": "script",
+    "scriptType": "node",
+    "script": "discover.cjs",
+    "outputFormat": "lines",
+    "timeoutMs": 15000
+  }
+}

--- a/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/aghast-script-demo.md
+++ b/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/aghast-script-demo.md
@@ -1,0 +1,12 @@
+### Script Discovery Demo
+
+#### Overview
+A demo check that uses script discovery to enumerate target locations.
+
+#### What to Check
+1. Each script-discovered target represents a place worth analyzing.
+2. The AI is given the file + line range and decides whether the code is vulnerable.
+
+#### Result
+- **PASS**: AI returns no issues for any target.
+- **FAIL**: AI returns at least one issue.

--- a/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/discover.cjs
+++ b/tests/fixtures/cli-configs/script-discovery/checks/aghast-script-demo/discover.cjs
@@ -1,0 +1,10 @@
+// Script-discovery fixture: emits 3 file paths from the test git-repo fixture.
+// One path per line — outputFormat: "lines" in the check definition.
+//
+// NOTE: We intentionally emit duplicates here. Unlike SARIF discovery (which
+// dedupes), script discovery treats every emitted target as a deliberate
+// instruction from the script author — if you want dedup, dedupe in the
+// script. The 3 duplicates exist so the test verifies targetsAnalyzed === 3.
+process.stdout.write('src/example.ts\n');
+process.stdout.write('src/example.ts\n');
+process.stdout.write('src/example.ts\n');

--- a/tests/script-discovery.test.ts
+++ b/tests/script-discovery.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Unit tests for the script-discovery module.
+ *
+ * Covers output parsing across all formats, child-process execution, timeout
+ * handling, path traversal rejection, and empty-output behavior.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm, mkdir, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  scriptDiscovery,
+  parseScriptOutput,
+  runScript,
+  buildScriptEnv,
+} from '../src/discoveries/script-discovery.js';
+import type { SecurityCheck } from '../src/types.js';
+
+let tmpRoot: string;
+let repoDir: string;
+let checkDir: string;
+
+before(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'aghast-script-discovery-'));
+  repoDir = join(tmpRoot, 'repo');
+  checkDir = join(repoDir, 'checks', 'demo');
+  await mkdir(checkDir, { recursive: true });
+});
+
+after(async () => {
+  if (tmpRoot) {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+function check(opts: Partial<SecurityCheck['checkTarget']> & { id?: string }): SecurityCheck {
+  return {
+    id: opts.id ?? 'demo-script-check',
+    name: 'Demo Script Check',
+    repositories: [],
+    checkDir,
+    instructionsFile: 'demo.md',
+    checkTarget: {
+      type: 'targeted',
+      discovery: 'script',
+      ...opts,
+    } as SecurityCheck['checkTarget'],
+  };
+}
+
+describe('parseScriptOutput: lines', () => {
+  it('parses one path per non-empty line', () => {
+    const out = parseScriptOutput('foo.js\nbar/baz.ts\n', 'lines');
+    assert.equal(out.length, 2);
+    assert.equal(out[0].file, 'foo.js');
+    assert.equal(out[1].file, 'bar/baz.ts');
+  });
+
+  it('skips blank and comment lines', () => {
+    const out = parseScriptOutput('# comment\n\nfile.ts\n  \n# another\nother.ts\n', 'lines');
+    assert.equal(out.length, 2);
+    assert.equal(out[0].file, 'file.ts');
+    assert.equal(out[1].file, 'other.ts');
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(parseScriptOutput('', 'lines'), []);
+  });
+});
+
+describe('parseScriptOutput: json-array', () => {
+  it('accepts an array of strings', () => {
+    const out = parseScriptOutput(JSON.stringify(['a.js', 'b.js']), 'json-array');
+    assert.equal(out.length, 2);
+    assert.equal(out[0].file, 'a.js');
+    assert.equal(out[1].file, 'b.js');
+  });
+
+  it('accepts an array of objects with file + lines + message', () => {
+    const out = parseScriptOutput(
+      JSON.stringify([
+        { file: 'x.ts', startLine: 5, endLine: 7, message: 'hi', snippet: 'snippet text' },
+      ]),
+      'json-array',
+    );
+    assert.equal(out[0].file, 'x.ts');
+    assert.equal(out[0].startLine, 5);
+    assert.equal(out[0].endLine, 7);
+    assert.equal(out[0].message, 'hi');
+    assert.equal(out[0].snippet, 'snippet text');
+  });
+
+  it('rejects a non-array root', () => {
+    assert.throws(
+      () => parseScriptOutput('{"a":1}', 'json-array'),
+      /expects a JSON array/,
+    );
+  });
+
+  it('rejects malformed JSON', () => {
+    assert.throws(
+      () => parseScriptOutput('{not json', 'json-array'),
+      /not valid JSON/,
+    );
+  });
+
+  it('rejects entries without a "file" string', () => {
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify([{ startLine: 1 }]), 'json-array'),
+      /must be a non-empty string/,
+    );
+  });
+
+  it('rejects entries that are arrays/null', () => {
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify([null]), 'json-array'),
+      /must be a string or object/,
+    );
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify([[1, 2]]), 'json-array'),
+      /must be a string or object/,
+    );
+  });
+
+  it('rejects negative line numbers', () => {
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify([{ file: 'a.js', startLine: -1 }]), 'json-array'),
+      /non-negative number/,
+    );
+  });
+});
+
+describe('parseScriptOutput: json-object', () => {
+  it('accepts {targets: [...]}', () => {
+    const out = parseScriptOutput(
+      JSON.stringify({ targets: ['a.js', { file: 'b.js' }] }),
+      'json-object',
+    );
+    assert.equal(out.length, 2);
+    assert.equal(out[0].file, 'a.js');
+    assert.equal(out[1].file, 'b.js');
+  });
+
+  it('rejects missing targets array', () => {
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify({ other: [] }), 'json-object'),
+      /"targets" array/,
+    );
+  });
+
+  it('rejects an array root', () => {
+    assert.throws(
+      () => parseScriptOutput(JSON.stringify([1, 2, 3]), 'json-object'),
+      /expects a JSON object/,
+    );
+  });
+});
+
+describe('runScript: child process control', () => {
+  it('captures stdout and exit code 0', async () => {
+    const result = await runScript({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write("hello\\n")'],
+      cwd: repoDir,
+      timeoutMs: 5000,
+    });
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'hello\n');
+  });
+
+  it('captures non-zero exit code', async () => {
+    const result = await runScript({
+      command: process.execPath,
+      args: ['-e', 'process.exit(7)'],
+      cwd: repoDir,
+      timeoutMs: 5000,
+    });
+    assert.equal(result.exitCode, 7);
+  });
+
+  it('rejects after timeout when the script hangs', async () => {
+    await assert.rejects(
+      runScript({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)'],
+        cwd: repoDir,
+        timeoutMs: 200,
+      }),
+      /timed out/,
+    );
+  });
+});
+
+describe('scriptDiscovery.discover', () => {
+  it('parses lines output and returns DiscoveredTarget[]', async () => {
+    const scriptPath = join(checkDir, 'list.cjs');
+    await writeFile(
+      scriptPath,
+      `console.log("src/a.ts");\nconsole.log("src/b.ts");\n`,
+    );
+
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'list.cjs',
+        scriptType: 'node',
+        outputFormat: 'lines',
+      }),
+      repoDir,
+    );
+
+    assert.equal(targets.length, 2);
+    assert.equal(targets[0].file, 'src/a.ts');
+    assert.equal(targets[0].startLine, 1);
+    assert.equal(targets[0].endLine, 1);
+    assert.match(targets[0].label, /script-target 1\/2/);
+    assert.ok(targets[0].promptEnrichment?.includes('TARGET LOCATION'));
+  });
+
+  it('parses json-array output with line numbers', async () => {
+    const scriptPath = join(checkDir, 'targets.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stdout.write(JSON.stringify([{ file: "src/x.ts", startLine: 10, endLine: 20, message: "found" }]));`,
+    );
+
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'targets.cjs',
+        scriptType: 'node',
+        outputFormat: 'json-array',
+      }),
+      repoDir,
+    );
+
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].file, 'src/x.ts');
+    assert.equal(targets[0].startLine, 10);
+    assert.equal(targets[0].endLine, 20);
+    assert.equal(targets[0].message, 'found');
+  });
+
+  it('parses json-object output', async () => {
+    const scriptPath = join(checkDir, 'object.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stdout.write(JSON.stringify({ targets: [{ file: "lib/c.ts" }] }));`,
+    );
+
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'object.cjs',
+        scriptType: 'node',
+        outputFormat: 'json-object',
+      }),
+      repoDir,
+    );
+
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].file, 'lib/c.ts');
+  });
+
+  it('returns empty array on empty stdout', async () => {
+    const scriptPath = join(checkDir, 'empty.cjs');
+    await writeFile(scriptPath, `// nothing\n`);
+
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'empty.cjs',
+        scriptType: 'node',
+        outputFormat: 'lines',
+      }),
+      repoDir,
+    );
+    assert.deepEqual(targets, []);
+  });
+
+  it('applies maxTargets limit', async () => {
+    const scriptPath = join(checkDir, 'many.cjs');
+    await writeFile(
+      scriptPath,
+      `for (let i = 0; i < 50; i++) console.log("file-" + i + ".ts");`,
+    );
+
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'many.cjs',
+        scriptType: 'node',
+        outputFormat: 'lines',
+        maxTargets: 5,
+      }),
+      repoDir,
+    );
+    assert.equal(targets.length, 5);
+    assert.equal(targets[0].file, 'file-0.ts');
+    assert.equal(targets[4].file, 'file-4.ts');
+  });
+
+  it('rejects path traversal in script field (../escape)', async () => {
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: '../../etc/passwd',
+          scriptType: 'node',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /resolves outside/,
+    );
+  });
+
+  it('rejects absolute script path', async () => {
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: resolve(tmpRoot, 'evil.cjs'),
+          scriptType: 'node',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /must be a relative path/,
+    );
+  });
+
+  it('rejects path traversal in cwd', async () => {
+    const scriptPath = join(checkDir, 'list-cwd.cjs');
+    await writeFile(scriptPath, `console.log("a.ts");`);
+
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'list-cwd.cjs',
+          scriptType: 'node',
+          outputFormat: 'lines',
+          cwd: '../escape',
+        }),
+        repoDir,
+      ),
+      /resolves outside/,
+    );
+  });
+
+  it('rejects when script does not exist', async () => {
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'missing-script.cjs',
+          scriptType: 'node',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /not found or unreadable/,
+    );
+  });
+
+  it('rejects when scriptType is missing', async () => {
+    const scriptPath = join(checkDir, 'noop.cjs');
+    await writeFile(scriptPath, `console.log("a.ts");`);
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'noop.cjs',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /scriptType/,
+    );
+  });
+
+  it('rejects when outputFormat is missing', async () => {
+    const scriptPath = join(checkDir, 'noop2.cjs');
+    await writeFile(scriptPath, `console.log("a.ts");`);
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'noop2.cjs',
+          scriptType: 'node',
+        }),
+        repoDir,
+      ),
+      /outputFormat/,
+    );
+  });
+
+  it('rejects when script exits non-zero', async () => {
+    const scriptPath = join(checkDir, 'fail.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stderr.write("boom\\n"); process.exit(3);`,
+    );
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'fail.cjs',
+          scriptType: 'node',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /exited with code=3/,
+    );
+  });
+
+  it('enforces per-check timeout', async () => {
+    const scriptPath = join(checkDir, 'hang.cjs');
+    await writeFile(
+      scriptPath,
+      `setInterval(() => {}, 1000);`,
+    );
+
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'hang.cjs',
+          scriptType: 'node',
+          outputFormat: 'lines',
+          timeoutMs: 200,
+        }),
+        repoDir,
+      ),
+      /timed out/,
+    );
+  });
+
+  it('rejects bash on Windows', async () => {
+    if (process.platform !== 'win32') {
+      // Skip silently — only meaningful on Windows
+      return;
+    }
+    const scriptPath = join(checkDir, 'bash.sh');
+    await writeFile(scriptPath, `echo "hi"`);
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'bash.sh',
+          scriptType: 'bash',
+          outputFormat: 'lines',
+        }),
+        repoDir,
+      ),
+      /not supported on Windows/,
+    );
+  });
+
+});
+
+// ─── New tests for security hardening ────────────────────────────────────────
+
+describe('buildScriptEnv (env sanitization)', () => {
+  it('strips ANTHROPIC_API_KEY and GITHUB_TOKEN', () => {
+    const env = buildScriptEnv({
+      ANTHROPIC_API_KEY: 'sk-leak',
+      GITHUB_TOKEN: 'ghs_leak',
+      OPENAI_API_KEY: 'sk-leak2',
+      AGHAST_DEBUG: 'true',
+      PATH: '/usr/bin',
+      HOME: '/home/u',
+    });
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.GITHUB_TOKEN, undefined);
+    assert.equal(env.OPENAI_API_KEY, undefined);
+    assert.equal(env.AGHAST_DEBUG, undefined);
+    assert.equal(env.PATH, '/usr/bin');
+    assert.equal(env.HOME, '/home/u');
+  });
+
+  it('strips arbitrary *_KEY / *_TOKEN / *_SECRET / *_PASSWORD vars', () => {
+    const env = buildScriptEnv({
+      MY_API_KEY: 'leak',
+      SOME_TOKEN: 'leak',
+      DB_PASSWORD: 'leak',
+      WEBHOOK_SECRET: 'leak',
+      DB_PASSWD: 'leak',
+      PATH: '/usr/bin',
+    });
+    assert.equal(env.MY_API_KEY, undefined);
+    assert.equal(env.SOME_TOKEN, undefined);
+    assert.equal(env.DB_PASSWORD, undefined);
+    assert.equal(env.WEBHOOK_SECRET, undefined);
+    assert.equal(env.DB_PASSWD, undefined);
+    assert.equal(env.PATH, '/usr/bin');
+  });
+
+  it('keeps only allow-listed env vars', () => {
+    const env = buildScriptEnv({
+      PATH: '/usr/bin',
+      RANDOM_VAR: 'should-be-dropped',
+      LANG: 'en_US.UTF-8',
+    });
+    assert.equal(env.PATH, '/usr/bin');
+    assert.equal(env.LANG, 'en_US.UTF-8');
+    assert.equal(env.RANDOM_VAR, undefined);
+  });
+
+  it('matches allow-list case-insensitively (Windows-style Path/SystemRoot survive)', () => {
+    // On Windows, `process.env` enumerates with original casing such as
+    // `Path`, `SystemRoot`, `ProgramFiles`. A strict `Set.has` would drop
+    // those; the allow-list must match case-insensitively.
+    const env = buildScriptEnv({
+      Path: 'C:\\Windows\\System32',
+      SystemRoot: 'C:\\Windows',
+      ProgramFiles: 'C:\\Program Files',
+      // sanity: still rejects unknown vars regardless of case
+      RandomVar: 'drop-me',
+    });
+    assert.equal(env.Path, 'C:\\Windows\\System32');
+    assert.equal(env.SystemRoot, 'C:\\Windows');
+    assert.equal(env.ProgramFiles, 'C:\\Program Files');
+    assert.equal(env.RandomVar, undefined);
+  });
+});
+
+describe('runScript: stdout overflow', () => {
+  it('rejects when stdout exceeds the 8 MiB cap', async () => {
+    // 9 MiB of "x" — comfortably exceeds MAX_STDOUT_BYTES = 8 MiB.
+    await assert.rejects(
+      runScript({
+        command: process.execPath,
+        args: ['-e', "process.stdout.write('x'.repeat(9 * 1024 * 1024))"],
+        cwd: repoDir,
+        timeoutMs: 30_000,
+      }),
+      /stdout exceeded/,
+    );
+  });
+});
+
+describe('scriptDiscovery: emitted file path validation', () => {
+  it('rejects script-emitted absolute file paths', async () => {
+    const scriptPath = join(checkDir, 'abs.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stdout.write(JSON.stringify([{ file: "/etc/passwd" }]));`,
+    );
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'abs.cjs',
+          scriptType: 'node',
+          outputFormat: 'json-array',
+        }),
+        repoDir,
+      ),
+      /must be relative/,
+    );
+  });
+
+  it('rejects script-emitted file paths that traverse via ".."', async () => {
+    const scriptPath = join(checkDir, 'traverse.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stdout.write(JSON.stringify([{ file: "../../etc/passwd" }]));`,
+    );
+    await assert.rejects(
+      scriptDiscovery.discover(
+        check({
+          script: 'traverse.cjs',
+          scriptType: 'node',
+          outputFormat: 'json-array',
+        }),
+        repoDir,
+      ),
+      /escapes the repository root/,
+    );
+  });
+
+  it('normalizes startLine=0 to 1 (1-based line numbering)', async () => {
+    const scriptPath = join(checkDir, 'zero.cjs');
+    await writeFile(
+      scriptPath,
+      `process.stdout.write(JSON.stringify([{ file: "src/x.ts", startLine: 0, endLine: 0 }]));`,
+    );
+    const targets = await scriptDiscovery.discover(
+      check({
+        script: 'zero.cjs',
+        scriptType: 'node',
+        outputFormat: 'json-array',
+      }),
+      repoDir,
+    );
+    assert.equal(targets[0].startLine, 1);
+    assert.equal(targets[0].endLine, 1);
+  });
+});
+
+describe('scriptDiscovery: symlink escape', () => {
+  it('rejects when the script is a symlink whose realpath escapes the check folder', async (t) => {
+    if (process.platform === 'win32') {
+      // Symlink creation on Windows requires elevated privileges; skip.
+      t.skip('symlink test skipped on Windows');
+      return;
+    }
+    // Create a target file outside the repo entirely.
+    const outsideDir = await mkdtemp(join(tmpdir(), 'aghast-outside-'));
+    try {
+      const outsideScript = join(outsideDir, 'evil.cjs');
+      await writeFile(outsideScript, `console.log("pwned.ts");`);
+      // Symlink inside checkDir → outside file
+      const linkPath = join(checkDir, 'evil-link.cjs');
+      await symlink(outsideScript, linkPath);
+
+      await assert.rejects(
+        scriptDiscovery.discover(
+          check({
+            script: 'evil-link.cjs',
+            scriptType: 'node',
+            outputFormat: 'lines',
+          }),
+          repoDir,
+        ),
+        /resolves outside/,
+      );
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseScriptOutput: JSON cap (defence in depth)', () => {
+  it('caps json-array at MAX_JSON_TARGETS', () => {
+    const big = JSON.stringify(Array.from({ length: 100_001 }, (_, i) => `f${i}.ts`));
+    const out = parseScriptOutput(big, 'json-array');
+    assert.equal(out.length, 100_000);
+  });
+});

--- a/tests/script-discovery.test.ts
+++ b/tests/script-discovery.test.ts
@@ -9,12 +9,13 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, writeFile, rm, mkdir, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, win32, posix } from 'node:path';
 import {
   scriptDiscovery,
   parseScriptOutput,
   runScript,
   buildScriptEnv,
+  isInsideRoot,
 } from '../src/discoveries/script-discovery.js';
 import type { SecurityCheck } from '../src/types.js';
 
@@ -626,5 +627,80 @@ describe('parseScriptOutput: JSON cap (defence in depth)', () => {
     const big = JSON.stringify(Array.from({ length: 100_001 }, (_, i) => `f${i}.ts`));
     const out = parseScriptOutput(big, 'json-array');
     assert.equal(out.length, 100_000);
+  });
+});
+
+describe('isInsideRoot', () => {
+  const win = { relative: win32.relative, isAbsolute: win32.isAbsolute };
+
+  it('accepts a path inside the root', () => {
+    assert.equal(isInsideRoot('/repo', '/repo/checks/demo', posix), true);
+  });
+
+  it('rejects a path escaping via ..', () => {
+    assert.equal(isInsideRoot('/repo', '/elsewhere/checks', posix), false);
+  });
+
+  it('rejects a Windows path on a different drive', () => {
+    // The bug this guards. Across drives `relative()` returns an ABSOLUTE path
+    // rather than a '..' chain, so a check that only looks for '..' concludes
+    // "inside" and the caller then rejects a perfectly valid layout. Asserting
+    // the premise first makes the test self-explanatory when it fails.
+    assert.equal(win32.relative('C:\\repo', 'D:\\checks\\demo').startsWith('..'), false);
+    assert.equal(isInsideRoot('C:\\repo', 'D:\\checks\\demo', win), false);
+  });
+
+  it('accepts a Windows path on the same drive', () => {
+    assert.equal(isInsideRoot('C:\\repo', 'C:\\repo\\checks', win), true);
+  });
+});
+
+describe('scriptDiscovery.discover: check folder outside the repository', () => {
+  // Every other test in this file puts the check folder INSIDE the repo, so the
+  // outside-repo branch went unexercised — and a bug in it reached CI.
+  //
+  // The branch guards a defence-in-depth assertion that the script also lives
+  // under the repo root. That assertion must only apply when the check folder
+  // is itself inside the repo; otherwise a perfectly valid layout is rejected.
+  //
+  // Two real layouts take this branch:
+  //   1. Local dev, where checks-config/ sits beside the target repo (this test).
+  //   2. Windows with the repo and the config dir on different drives, where
+  //      `relative()` returns an absolute path instead of a `..` chain. That is
+  //      not reproducible cross-platform, but it resolves through this same
+  //      branch, so covering the layout here guards both.
+  it('runs a script whose check folder is a sibling of the repo', async () => {
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'aghast-outside-checks-'));
+    try {
+      const outsideCheckDir = join(outsideRoot, 'checks', 'demo');
+      await mkdir(outsideCheckDir, { recursive: true });
+      await writeFile(
+        join(outsideCheckDir, 'list.cjs'),
+        `console.log("src/outside.ts");\n`,
+      );
+
+      const targets = await scriptDiscovery.discover(
+        {
+          id: 'outside-check',
+          name: 'Outside Check',
+          repositories: [],
+          checkDir: outsideCheckDir,
+          instructionsFile: 'demo.md',
+          checkTarget: {
+            type: 'targeted',
+            discovery: 'script',
+            script: 'list.cjs',
+            scriptType: 'node',
+            outputFormat: 'lines',
+          },
+        } as SecurityCheck,
+        repoDir,
+      );
+
+      assert.equal(targets.length, 1);
+      assert.equal(targets[0].file, 'src/outside.ts');
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Adds a `script` discovery provider, letting a check find its own targets by running a small Node.js or bash script and parsing the output. This covers cases that are too custom for Semgrep, SARIF or OpenAnt — parsing an OpenAPI spec to enumerate endpoints, querying a build manifest, walking a schema definition.

## Configuring

Set `checkTarget.discovery: "script"` on a `targeted` check, then:

- `checkTarget.script` — path to the script, resolved inside the repository
- `checkTarget.scriptType` — `node` or `bash`
- output format — `lines`, `json-array`, or `json-object`

The script writes targets to stdout; aghast parses them into discovery targets and the AI analyses each one as with any other targeted check.

## Trust model

**Discovery scripts are not sandboxed.** They run as child processes with the full privileges of the aghast process. A script referenced by a check definition is trusted code in exactly the same sense as the aghast source itself — only enable script checks whose scripts you have read and audited. This is stated plainly in the docs rather than implied.

## Defences

These apply regardless of the trust model, to contain mistakes and narrow the blast radius:

- Script path and working directory must resolve inside the repository, checked **after** symlink resolution so a symlink cannot escape the repo
- Spawned with `shell: false` and array arguments — no shell interpretation of the path or args
- Curated child environment with credentials stripped
- Hard timeout on execution
- Bounded stdout, so a runaway script cannot exhaust memory
- File paths in the output validated before use
- Output is parsed as data and **never** evaluated

## Platform support

`bash` scripts are unsupported on Windows and fail with a clear error rather than a confusing spawn failure. `node` scripts work everywhere.

## Diff filtering

Script discovery declares `supportsDiffFilter: false` and does not participate in diff filtering. A script may legitimately emit whole-file targets or explicit ranges that have no reliable relationship to diff hunks, so narrowing its output to a diff would silently drop targets the script intended to surface.

## Error codes

New `E71xx` range for script discovery failures:

| Code | Meaning |
| --- | --- |
| `E7101` | Script discovery timeout |
| `E7102` | Script discovery non-zero exit |
| `E7103` | Script discovery stdout overflow |
| `E7104` | Script discovery spawn/IO failure |
| `E7105` | Script discovery output parse failure |
| `E7106` | Unsupported `scriptType` for platform |

## Testing

Full suite passes locally: 1170 tests, 0 failures (3 skipped — Semgrep not installed). Adds `tests/script-discovery.test.ts` plus CLI-level integration coverage in `tests/cli-mock-mode.test.ts` and fixtures under `tests/fixtures/cli-configs/script-discovery/`.
