### PR TITLE
feat: select and order checks dynamically per repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ listed instead of its contents.
 
 - `src/scan-runner.ts` — Security Scanner orchestrator (`runMultiScan` for config-based multi-check; `executeTargetedCheck` for discovery-based checks with concurrent target analysis via `mapWithConcurrency`)
 - `src/check-library.ts` — Check Library: two-layer config loading (`loadCheckRegistry`, `loadCheckDefinition`, `discoverCheckFolders`, `resolveChecks`), validation, repository matching, markdown parsing, path filtering
+- `src/repo-scan.ts` — Cached repository snapshot (file paths, extensions, user tags) used to evaluate `matchCriteria` rules without re-walking the tree per check. Bounded: fixed ignore list plus a depth cap, since it gates which checks run rather than enumerating the repo
 - `src/check-types.ts` — Check type descriptor system; each type (`repository`, `targeted`, `static`) declares its characteristics (needsAI, needsDiscovery, needsInstructions, etc.) in one place
 - `src/types.ts` — Shared type definitions (`ScanResults`, `RepositoryInfo`, `SecurityIssue`, `RuntimeConfig`, …). `ScanMetadata` is deliberately a **closed** type — add explicit fields rather than widening it, so typos fail at compile time
 - `src/ci-metadata.ts` — CI/CD pipeline detection (spec E.4): reads platform env vars for GitHub Actions, GitLab CI and CircleCI into `ScanResults.metadata.ciMetadata`. Read-only and never throws; adding a platform means adding one collector function

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,8 +59,62 @@ The check registry controls which checks are available and which repositories th
 | `repositories`        | `string[]` | Yes      | Repository URLs this check applies to. Empty array `[]` means all repositories |
 | `excludeRepositories` | `string[]` | No       | Repository URLs to skip for this check. Exclusion wins over inclusion. Useful with `"repositories": []` for "all repos except these" |
 | `enabled`             | `boolean`  | No       | Set to `false` to disable a check (default: `true`) |
+| `priority`            | `number`   | No       | Execution order. Non-negative integer; lower values run first. Checks without a priority sort to the end (stable order). Useful for running fast/cheap checks before expensive ones |
+| `matchCriteria`       | `object`   | No       | Dynamic repository-matching rules. Evaluated *in addition* to `repositories` — an explicit repository match always wins; criteria can only ADD matches. See [Dynamic repository matching](#dynamic-repository-matching) below |
 
 Repository matching (for both `repositories` and `excludeRepositories`) uses bidirectional substring matching on normalized paths — so `"foo"` matches both `org/foo` and `org/foobar`. If the same string appears in both lists, exclusion wins.
+
+### Dynamic repository matching
+
+Set `matchCriteria` on a Layer 1 entry to apply the check based on repository
+characteristics rather than (or in addition to) an explicit `repositories`
+list. Multiple criteria are AND'd together — a check matches when every
+configured criterion matches the target repo.
+
+```json
+{
+  "id": "aghast-typescript-only",
+  "repositories": [],
+  "matchCriteria": {
+    "hasFileTypes": [".ts", ".tsx"],
+    "hasFiles": ["package.json"],
+    "hasPaths": ["src/api/**", "src/routes/**"],
+    "tags": ["backend", "api-service"]
+  }
+}
+```
+
+| Criterion       | Type       | Match when |
+|-----------------|------------|------------|
+| `hasFileTypes`  | `string[]` | The repo contains at least one file with one of the listed extensions (leading dot optional, e.g. `".ts"` or `"ts"`) |
+| `hasFiles`      | `string[]` | EVERY listed entry exists. Each entry is matched as a literal repo-relative path first; if it contains glob metacharacters, falls back to glob (`picomatch`) |
+| `hasPaths`      | `string[]` | At least one file in the repo matches at least one of the supplied glob patterns |
+| `tags`          | `string[]` | EVERY listed tag appears in `<repo>/.aghast-tags` (newline-separated, `#` comments) and/or `<repo>/.aghast.json` `tags` array. Tag matching is **case-sensitive** — use the same casing in both files and your `matchCriteria.tags` |
+
+**Notes**
+
+- Explicit-list matches always win: if a check's `repositories` list matches
+  the target repo, the check is included regardless of `matchCriteria`. Criteria
+  only *add* matches.
+- The repository filesystem walk skips a sensible default ignore list
+  (`node_modules`, `.git`, `dist`, `build`, `.worktrees`, `.next`, `.nuxt`,
+  `.venv`, `venv`, `__pycache__`, `target`, `coverage`). As a result,
+  `hasFiles` / `hasPaths` cannot reference files inside these directories
+  (e.g. `hasFiles: [".git/HEAD"]` will never match).
+- The walk results are **cached** per repository for the duration of a scan,
+  so multiple checks consulting `matchCriteria` for the same repo trigger
+  the filesystem traversal only once. Successive programmatic invocations of
+  `runScan` reset the cache so scans never reuse a stale snapshot.
+- The walk is **bounded**: at most ~50,000 files and 12 levels of directory
+  depth are inspected. On extremely large monorepos, files past the cap are
+  not considered when evaluating `matchCriteria`. Run with `--debug` to see
+  a log line if the cap is hit.
+- `.aghast.json` is reserved for future aghast repo-level configuration. Today
+  only its `tags` array is consumed by dynamic matching; other fields are
+  ignored.
+- An empty `matchCriteria` object (`{}`) is rejected by config validation —
+  every populated `matchCriteria` must specify at least one of `hasFileTypes`,
+  `hasFiles`, `hasPaths`, or `tags`.
 
 ## Layer 2: Check Definition (`<id>.json`)
 

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -17,6 +17,7 @@ import type {
 } from './types.js';
 import { getCheckType, getValidCheckTypes } from './check-types.js';
 import { getRegisteredDiscoveries } from './discovery.js';
+import { evaluateMatchCriteria, getRepoSnapshot } from './repo-scan.js';
 
 // --- Layer 1: Check Registry ---
 
@@ -96,6 +97,63 @@ export async function loadCheckRegistry(configDir: string): Promise<CheckRegistr
     }
     if (obj.enabled !== undefined && typeof obj.enabled !== 'boolean') {
       throw new Error(`Config file "${configPath}": checks[${i}].enabled must be a boolean`);
+    }
+    if (obj.priority !== undefined) {
+      if (typeof obj.priority !== 'number' || !Number.isInteger(obj.priority) || obj.priority < 0) {
+        throw new Error(
+          `Config file "${configPath}": checks[${i}].priority must be a non-negative integer`,
+        );
+      }
+    }
+    if (obj.matchCriteria !== undefined) {
+      if (typeof obj.matchCriteria !== 'object' || obj.matchCriteria === null || Array.isArray(obj.matchCriteria)) {
+        throw new Error(
+          `Config file "${configPath}": checks[${i}].matchCriteria must be an object`,
+        );
+      }
+      const mc = obj.matchCriteria as Record<string, unknown>;
+      const stringArrayFields = ['hasFileTypes', 'hasFiles', 'hasPaths', 'tags'] as const;
+      let populatedFieldCount = 0;
+      for (const field of stringArrayFields) {
+        const val = mc[field];
+        if (val === undefined) continue;
+        if (!Array.isArray(val)) {
+          throw new Error(
+            `Config file "${configPath}": checks[${i}].matchCriteria.${field} must be an array of strings`,
+          );
+        }
+        for (let k = 0; k < val.length; k++) {
+          if (typeof val[k] !== 'string') {
+            throw new Error(
+              `Config file "${configPath}": checks[${i}].matchCriteria.${field}[${k}] must be a string`,
+            );
+          }
+          if ((val[k] as string).trim() === '') {
+            throw new Error(
+              `Config file "${configPath}": checks[${i}].matchCriteria.${field}[${k}] must be a non-empty string`,
+            );
+          }
+        }
+        if (val.length > 0) populatedFieldCount++;
+      }
+      // Reject unknown keys to surface typos
+      const allowed = new Set(stringArrayFields as readonly string[]);
+      for (const key of Object.keys(mc)) {
+        if (!allowed.has(key)) {
+          throw new Error(
+            `Config file "${configPath}": checks[${i}].matchCriteria has unknown field "${key}". ` +
+              `Allowed: ${[...allowed].join(', ')}`,
+          );
+        }
+      }
+      // Reject empty / all-empty matchCriteria — would silently match nothing
+      // and is almost always a config typo.
+      if (populatedFieldCount === 0) {
+        throw new Error(
+          `Config file "${configPath}": checks[${i}].matchCriteria must specify at least one of: ` +
+            `${[...allowed].join(', ')}`,
+        );
+      }
     }
   }
 
@@ -384,6 +442,9 @@ export async function resolveChecks(
       checkDir: folderPath,
     };
 
+    if (entry.matchCriteria) merged.matchCriteria = entry.matchCriteria;
+    if (entry.priority !== undefined) merged.priority = entry.priority;
+
     if (def.severity) merged.severity = def.severity;
     if (def.confidence) merged.confidence = def.confidence;
     if (def.model) merged.model = def.model;
@@ -554,6 +615,10 @@ export function checkMatchesRepository(
 /**
  * Filter checks to those matching the given repository URL/path.
  * Also filters out disabled checks (enabled === false).
+ *
+ * Note: this synchronous variant ignores `matchCriteria` (no filesystem
+ * access). For full dynamic-matching support use
+ * `filterChecksForRepositoryAsync`.
  */
 export function filterChecksForRepository(
   checks: SecurityCheck[],
@@ -563,6 +628,80 @@ export function filterChecksForRepository(
     .filter((check) => check.enabled !== false)
     .filter((check) => checkMatchesRepository(check, repositoryUrl));
 }
+
+/**
+ * Async variant that additionally evaluates `matchCriteria` against the target
+ * repository's filesystem/tags. The repo snapshot is cached so repeated calls
+ * for the same `repositoryPath` walk the tree only once.
+ *
+ * Matching semantics:
+ * - If a check has an explicit repository in its `repositories` list that
+ *   matches `repositoryUrl`, it is included regardless of `matchCriteria`
+ *   (explicit match wins; criteria can only ADD matches).
+ * - Otherwise, if `matchCriteria` is set and evaluates true against the repo
+ *   snapshot, the check is included.
+ */
+export async function filterChecksForRepositoryAsync(
+  checks: SecurityCheck[],
+  repositoryUrl: string,
+  repositoryPath: string,
+): Promise<SecurityCheck[]> {
+  const enabled = checks.filter((c) => c.enabled !== false);
+
+  let needsSnapshot = false;
+  for (const check of enabled) {
+    if (!checkMatchesRepository(check, repositoryUrl) && check.matchCriteria) {
+      needsSnapshot = true;
+      break;
+    }
+  }
+
+  if (!needsSnapshot) {
+    return enabled.filter((c) => checkMatchesRepository(c, repositoryUrl));
+  }
+
+  // One filesystem walk shared across all criteria checks for this repo.
+  // `repositoryPath` is expected to be absolute (CLI resolves it at parse
+  // time); resolving again would double-normalise on Windows and could
+  // produce a second cache entry for the same physical path under a
+  // different drive-letter casing.
+  const snapshot = await getRepoSnapshot(repositoryPath);
+
+  const result: SecurityCheck[] = [];
+  for (const check of enabled) {
+    if (checkMatchesRepository(check, repositoryUrl)) {
+      result.push(check);
+      continue;
+    }
+    if (check.matchCriteria && evaluateMatchCriteria(check.matchCriteria, snapshot)) {
+      result.push(check);
+    }
+  }
+  return result;
+}
+
+/**
+ * Sort checks by `priority` ascending (lower runs first). Stable: checks
+ * without a priority preserve their relative order and sort to the end.
+ *
+ * Returns a new array; does not mutate the input.
+ */
+export function sortChecksByPriority(checks: SecurityCheck[]): SecurityCheck[] {
+  // Decorate with original index for stable sort across all engines.
+  const decorated = checks.map((check, index) => ({ check, index }));
+  decorated.sort((a, b) => {
+    const ap = a.check.priority;
+    const bp = b.check.priority;
+    if (ap === bp) return a.index - b.index;
+    if (ap === undefined) return 1;
+    if (bp === undefined) return -1;
+    return ap - bp;
+  });
+  return decorated.map((d) => d.check);
+}
+
+// Re-export for callers building custom pipelines.
+export type { MatchCriteria } from './types.js';
 
 // --- Markdown Parsing (spec A.7) ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,12 @@ import {
   loadCheckRegistry,
   discoverCheckFolders,
   resolveChecks,
-  filterChecksForRepository,
+  filterChecksForRepositoryAsync,
+  sortChecksByPriority,
   validateCheck,
   loadCheckDetails,
 } from './check-library.js';
+import { clearRepoSnapshotCache } from './repo-scan.js';
 import { analyzeRepository } from './repository-analyzer.js';
 import { loadRuntimeConfig } from './runtime-config.js';
 import { logProgress, logDebug, setLogLevel, createTimer, isValidLogLevel, initFileHandler, closeAllHandlers, getAvailableLogTypes } from './logging.js';
@@ -508,6 +510,17 @@ export async function runScan(args: string[]): Promise<void> {
   const globalTimer = createTimer();
   const parsed = parseArgs(args);
 
+  // Reset the per-process repo-snapshot cache so back-to-back programmatic
+  // invocations of `runScan` don't reuse a stale filesystem snapshot from a
+  // previous run (e.g. when callers edit the target repo between scans).
+  //
+  // Caveat: the cache is module-scoped, so two `runScan` invocations running
+  // *concurrently* in the same Node process will clobber each other's cached
+  // snapshots — each scan still works correctly, it just won't share the
+  // filesystem walk across invocations. Sequential invocations are the
+  // primary supported pattern.
+  clearRepoSnapshotCache();
+
   // --config-dir is required (CLI flag > AGHAST_CONFIG_DIR env var)
   const rawConfigDir = parsed.configDir || process.env.AGHAST_CONFIG_DIR;
   if (!rawConfigDir) {
@@ -606,7 +619,9 @@ export async function runScan(args: string[]): Promise<void> {
   const repoAnalysis = await analyzeRepository(effectiveRepoPath);
   const repoUrl = repoAnalysis?.repository.remoteUrl ?? effectiveRepoPath;
 
-  const matchingChecks = filterChecksForRepository(allChecks, repoUrl);
+  const filtered = await filterChecksForRepositoryAsync(allChecks, repoUrl, effectiveRepoPath);
+  // Run lower-priority checks first; checks without a priority sort to the end.
+  const matchingChecks = sortChecksByPriority(filtered);
   logProgress(TAG, `Found ${matchingChecks.length} matching checks (of ${allChecks.length} total)`);
 
   if (matchingChecks.length === 0) {

--- a/src/repo-scan.ts
+++ b/src/repo-scan.ts
@@ -1,0 +1,305 @@
+/**
+ * Repository scanning for dynamic check-matching.
+ *
+ * Provides a small, cached snapshot of a repository's filesystem (file paths,
+ * extensions present) and any user-supplied tags so that
+ * `MatchCriteria` rules in `checks-config.json` can be evaluated without
+ * re-walking the tree per check.
+ *
+ * Bounded recursion: a fixed ignore list (`node_modules`, `.git`, `dist`,
+ * `build`, `.worktrees`) is always applied and the scan stops at a depth
+ * cap. This is intentionally cheap — `MatchCriteria` is meant to gate which
+ * checks run, not to enumerate the whole repo.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import picomatch from 'picomatch';
+import type { MatchCriteria } from './types.js';
+import { logDebug } from './logging.js';
+
+const TAG = 'repo-scan';
+
+/** Directories always skipped during scanning. */
+const DEFAULT_IGNORE_DIRS: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.worktrees',
+  '.next',
+  '.nuxt',
+  '.venv',
+  'venv',
+  '__pycache__',
+  'target',
+  'coverage',
+]);
+
+/** Cap directory depth to avoid runaway recursion on pathological repos. */
+const MAX_DEPTH = 12;
+/** Cap total files inspected so very large monorepos still match in bounded time. */
+const MAX_FILES = 50_000;
+
+/**
+ * Test-only knobs to exercise the depth/file caps without building a 50k-file
+ * fixture. NOT part of the public API.
+ */
+export interface ScanRepositoryOptions {
+  maxDepth?: number;
+  maxFiles?: number;
+}
+
+/** Cached snapshot of a repository's structure relevant to MatchCriteria. */
+export interface RepoSnapshot {
+  /** Absolute repository path (resolved). */
+  repoPath: string;
+  /** All non-ignored file paths, relative to repoPath, with forward slashes. */
+  files: string[];
+  /** Set of file extensions present (lowercased, including leading dot, e.g. ".ts"). */
+  extensions: Set<string>;
+  /** Tags from `.aghast-tags` (newline-separated) or `.aghast.json` `tags`. */
+  tags: Set<string>;
+}
+
+/**
+ * Build a RepoSnapshot for the given path. Walks the filesystem once,
+ * applying the default ignore list. Errors reading individual entries are
+ * swallowed so a permission issue on a single subtree doesn't kill matching.
+ */
+export async function scanRepository(
+  repoPath: string,
+  options: ScanRepositoryOptions = {},
+): Promise<RepoSnapshot> {
+  const maxDepth = options.maxDepth ?? MAX_DEPTH;
+  const maxFiles = options.maxFiles ?? MAX_FILES;
+  const files: string[] = [];
+  const extensions = new Set<string>();
+  let truncatedByFileCap = false;
+  let truncatedByDepthCap = false;
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > maxDepth) {
+      truncatedByDepthCap = true;
+      return;
+    }
+    if (files.length >= maxFiles) {
+      truncatedByFileCap = true;
+      return;
+    }
+
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (files.length >= maxFiles) {
+        truncatedByFileCap = true;
+        return;
+      }
+      const name = entry.name;
+      if (entry.isDirectory()) {
+        if (DEFAULT_IGNORE_DIRS.has(name)) continue;
+        await walk(join(dir, name), depth + 1);
+      } else if (entry.isFile()) {
+        const full = join(dir, name);
+        const rel = relative(repoPath, full).split(sep).join('/');
+        files.push(rel);
+        const dot = name.lastIndexOf('.');
+        if (dot > 0 && dot < name.length - 1) {
+          extensions.add(name.slice(dot).toLowerCase());
+        }
+      }
+    }
+  }
+
+  await walk(repoPath, 0);
+
+  // Surface truncation: silently dropping files/subtrees can make `matchCriteria`
+  // miss matches in very large or very deep repos. Logged at debug so it's only
+  // visible when the user opts in via --debug / --log-level debug.
+  if (truncatedByFileCap) {
+    logDebug(
+      TAG,
+      `Repo scan truncated at MAX_FILES=${maxFiles} files for "${repoPath}". ` +
+        `matchCriteria evaluation is best-effort beyond this cap.`,
+    );
+  }
+  if (truncatedByDepthCap) {
+    logDebug(
+      TAG,
+      `Repo scan truncated at MAX_DEPTH=${maxDepth} for "${repoPath}". ` +
+        `Subtrees deeper than this were skipped during matchCriteria evaluation.`,
+    );
+  }
+
+  const tags = await loadTags(repoPath);
+
+  return { repoPath, files, extensions, tags };
+}
+
+/**
+ * Read tags from `<repo>/.aghast-tags` (newline-separated) or
+ * `<repo>/.aghast.json` `tags` array. Returns an empty set if neither exists.
+ */
+async function loadTags(repoPath: string): Promise<Set<string>> {
+  const tags = new Set<string>();
+
+  // .aghast-tags
+  try {
+    const tagsFile = join(repoPath, '.aghast-tags');
+    const st = await stat(tagsFile);
+    if (st.isFile()) {
+      const raw = await readFile(tagsFile, 'utf-8');
+      for (const line of raw.split(/\r?\n/)) {
+        const t = line.trim();
+        if (t && !t.startsWith('#')) tags.add(t);
+      }
+    }
+  } catch {
+    // Missing or unreadable; ignore.
+  }
+
+  // .aghast.json -> tags array
+  try {
+    const cfgFile = join(repoPath, '.aghast.json');
+    const st = await stat(cfgFile);
+    if (st.isFile()) {
+      const raw = await readFile(cfgFile, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        Array.isArray((parsed as Record<string, unknown>).tags)
+      ) {
+        for (const t of (parsed as Record<string, unknown>).tags as unknown[]) {
+          if (typeof t === 'string' && t.trim() !== '') tags.add(t.trim());
+        }
+      }
+    }
+  } catch {
+    // Missing or unreadable / invalid JSON; ignore.
+  }
+
+  return tags;
+}
+
+/**
+ * Evaluate MatchCriteria against a repo snapshot.
+ *
+ * Semantics:
+ * - hasFileTypes: at least one extension in the list is present in the repo
+ * - hasFiles: every entry exists (literal path under repo OR glob match)
+ * - hasPaths: at least one file matches at least one of the globs
+ * - tags: every listed tag is present
+ *
+ * If multiple criteria are set, ALL must pass (AND). An empty MatchCriteria
+ * (no fields) matches nothing — explicit opt-in is required.
+ */
+export function evaluateMatchCriteria(
+  criteria: MatchCriteria,
+  snapshot: RepoSnapshot,
+): boolean {
+  const hasAny =
+    !!criteria.hasFileTypes?.length ||
+    !!criteria.hasFiles?.length ||
+    !!criteria.hasPaths?.length ||
+    !!criteria.tags?.length;
+  if (!hasAny) return false;
+
+  if (criteria.hasFileTypes && criteria.hasFileTypes.length > 0) {
+    const wanted = criteria.hasFileTypes
+      .filter((e) => e.trim() !== '')
+      .map((e) => (e.startsWith('.') ? e : '.' + e).toLowerCase());
+    if (wanted.length === 0) return false;
+    const hit = wanted.some((ext) => snapshot.extensions.has(ext));
+    if (!hit) return false;
+  }
+
+  if (criteria.hasFiles && criteria.hasFiles.length > 0) {
+    const fileSet = new Set(snapshot.files);
+    for (const entry of criteria.hasFiles) {
+      const normalized = entry.replace(/\\/g, '/');
+      if (fileSet.has(normalized)) continue;
+      // Literal lookup missed. If `entry` has no glob metacharacters there's
+      // no point compiling a matcher and scanning the file list — it's a
+      // guaranteed miss. Only fall back to glob matching for actual globs.
+      if (!picomatch.scan(normalized).isGlob) {
+        return false;
+      }
+      const matcher = picomatch(normalized, { dot: true });
+      if (!snapshot.files.some((f) => matcher(f))) {
+        return false;
+      }
+    }
+  }
+
+  if (criteria.hasPaths && criteria.hasPaths.length > 0) {
+    const matcher = picomatch(criteria.hasPaths.map((p) => p.replace(/\\/g, '/')), {
+      dot: true,
+    });
+    if (!snapshot.files.some((f) => matcher(f))) return false;
+  }
+
+  if (criteria.tags && criteria.tags.length > 0) {
+    for (const t of criteria.tags) {
+      if (!snapshot.tags.has(t)) return false;
+    }
+  }
+
+  return true;
+}
+
+// --- Cache ---
+
+const snapshotCache = new Map<string, Promise<RepoSnapshot>>();
+
+/**
+ * Return a cached RepoSnapshot for the given path, scanning on first request.
+ * The cache is keyed by absolute repository path so multiple checks reusing
+ * the same repo share one filesystem walk.
+ *
+ * On rejection, the failing promise is evicted so a later caller can retry
+ * (avoids "poisoned cache" where a transient error becomes permanent for the
+ * lifetime of the process). `scanRepository` currently swallows per-entry
+ * errors and always resolves, but the eviction guard keeps that contract from
+ * silently breaking if `scanRepository` ever changes.
+ */
+export function getRepoSnapshot(repoPath: string): Promise<RepoSnapshot> {
+  const existing = snapshotCache.get(repoPath);
+  if (existing) return existing;
+  const promise = scanRepository(repoPath);
+  snapshotCache.set(repoPath, promise);
+  promise.catch(() => {
+    // Only delete if the cached promise is still the one we set (a later call
+    // may have already replaced it).
+    if (snapshotCache.get(repoPath) === promise) {
+      snapshotCache.delete(repoPath);
+    }
+  });
+  return promise;
+}
+
+/**
+ * Clear the snapshot cache. Called by `runScan` at the start of each
+ * invocation (so successive scans don't reuse stale filesystem state) and by
+ * tests between cases.
+ *
+ * Note: the cache is module-scoped, so calling this from concurrent
+ * `runScan` invocations will wipe each other's in-flight entries. Sequential
+ * invocations are the primary supported pattern.
+ */
+export function clearRepoSnapshotCache(): void {
+  snapshotCache.clear();
+}
+
+/**
+ * Test-only: peek at the snapshot cache for a path. NOT part of the public
+ * API. Used by unit tests to assert cache population / eviction behaviour.
+ */
+export function __peekSnapshotCacheForTesting(repoPath: string): Promise<RepoSnapshot> | undefined {
+  return snapshotCache.get(repoPath);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,37 @@ export interface TokenUsage {
 
 // --- A.1a Check Registry Entry (Layer 1) ---
 
+/**
+ * Dynamic repository matching criteria.
+ * Evaluated in addition to the explicit `repositories` list (does not replace it):
+ * an explicit match always wins; criteria add additional repos.
+ *
+ * - hasFileTypes: file extensions (e.g. ".ts"). Matches if the repo contains
+ *   at least one file with one of these extensions.
+ * - hasFiles: literal paths or glob patterns. Matches if all listed paths exist.
+ * - hasPaths: glob patterns. Matches if at least one path matches.
+ * - tags: tags read from `<repo>/.aghast-tags` (newline-separated) or
+ *   `<repo>/.aghast.json` `tags` array. Matches if all listed tags are present.
+ */
+export interface MatchCriteria {
+  hasFileTypes?: string[];
+  hasFiles?: string[];
+  hasPaths?: string[];
+  tags?: string[];
+}
+
 export interface CheckRegistryEntry {
   id: string;
   repositories: string[];
   excludeRepositories?: string[];
   enabled?: boolean;
+  /** Dynamic repository matching criteria. Adds matches; does not exclude explicit ones. */
+  matchCriteria?: MatchCriteria;
+  /**
+   * Execution order. Lower runs first. Checks without a priority sort to the end (stable).
+   * Must be a non-negative integer when set.
+   */
+  priority?: number;
 }
 
 // --- A.1b Check Definition (Layer 2) ---
@@ -70,6 +96,10 @@ export interface SecurityCheck {
   model?: string;
   /** Path to the check folder (set during resolution). */
   checkDir?: string;
+  /** Dynamic repository matching criteria (Layer 1). */
+  matchCriteria?: MatchCriteria;
+  /** Execution order — lower runs first; unset sorts to end (stable). */
+  priority?: number;
 }
 
 // --- A.2 Check Target Definition ---
@@ -272,6 +302,25 @@ export interface CIMetadata {
    * field. Consumers should treat the value as an opaque string and not
    * assume a unified vocabulary across platforms.
    */
+  pipelineSource?: string;
+  /** ISO-8601 timestamp for when the CI/CD job started. */
+  jobStartedAt?: string;
+}
+
+// --- A.5a CI/CD Metadata (spec E.4) ---
+
+/**
+ * CI/CD pipeline context captured during a scan run. Populated automatically
+ * from environment variables when aghast detects it is running inside a
+ * supported CI/CD platform (GitHub Actions, GitLab CI, CircleCI). All fields
+ * are optional in case detection is partial.
+ */
+export interface CIMetadata {
+  /** URL of the CI/CD job that produced this scan. */
+  jobUrl?: string;
+  /** Branch (or ref) that was scanned. */
+  branch?: string;
+  /** What triggered the pipeline (e.g. `push`, `pull_request`, `schedule`). */
   pipelineSource?: string;
   /** ISO-8601 timestamp for when the CI/CD job started. */
   jobStartedAt?: string;

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -32,6 +32,7 @@ import {
   fpValidationConfigDir,
   fpValidationFalsePositiveFixture,
   fpValidationTruePositiveFixture,
+  dynamicMatchingConfigDir,
   createScopedHelpers,
 } from './cli-test-helpers.js';
 
@@ -966,5 +967,54 @@ describe('CLI: individual issue files (runtime config)', () => {
     } finally {
       await rm(outputDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── Dynamic matching + check ordering (issue #122) ─────────────────────────
+
+describe('CLI mock mode: matchCriteria and priority (issue #122)', () => {
+  afterEach(cleanupOutput);
+
+  it('runs checks in priority order, with un-prioritized checks last; matchCriteria adds matches', async () => {
+    const { exitCode } = await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', dynamicMatchingConfigDir],
+    );
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    const ids = checks.map((c) => c.checkId);
+
+    // Expected order:
+    //   priority 1  → aghast-runs-first
+    //   priority 5  → aghast-criteria-only (matched via .ts hasFileTypes)
+    //   priority 20 → aghast-runs-second
+    //   no priority → aghast-no-priority
+    //
+    // aghast-criteria-skipped is filtered out (looks for .rs files).
+    assert.deepEqual(
+      ids,
+      [
+        'aghast-runs-first',
+        'aghast-criteria-only',
+        'aghast-runs-second',
+        'aghast-no-priority',
+      ],
+      `Unexpected order: ${ids.join(', ')}`,
+    );
+  });
+
+  it('omits checks whose matchCriteria do not match the repo', async () => {
+    await runCLI(
+      { AGHAST_MOCK_AI: 'true' },
+      [fixtureRepo, '--config-dir', dynamicMatchingConfigDir],
+    );
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.ok(
+      !checks.some((c) => c.checkId === 'aghast-criteria-skipped'),
+      'aghast-criteria-skipped should be filtered (no .rs files in fixture repo)',
+    );
   });
 });

--- a/tests/cli-test-helpers.ts
+++ b/tests/cli-test-helpers.ts
@@ -77,6 +77,7 @@ export const openantDiffFilterConfigDir = resolve(testDir, 'fixtures', 'cli-conf
 export const fpValidationConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'fp-validation');
 export const globCheckConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'glob-check');
 export const scriptDiscoveryConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'script-discovery');
+export const dynamicMatchingConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'dynamic-matching');
 
 // SARIF fixtures
 export const cli3TargetsSarif = resolve(testDir, 'fixtures', 'sarif', 'cli-3-targets.sarif');

--- a/tests/dynamic-matching.test.ts
+++ b/tests/dynamic-matching.test.ts
@@ -1,0 +1,727 @@
+/**
+ * Unit tests for dynamic repository matching and check ordering (issue #122).
+ *
+ * Covers:
+ *   - repo-scan.scanRepository / evaluateMatchCriteria / cache
+ *   - check-library.filterChecksForRepositoryAsync — explicit + criteria
+ *   - check-library.sortChecksByPriority — stable, undefined-last
+ *   - registry validation rejects malformed matchCriteria / priority
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  loadCheckRegistry,
+  filterChecksForRepository,
+  filterChecksForRepositoryAsync,
+  sortChecksByPriority,
+} from '../src/check-library.js';
+import {
+  scanRepository,
+  evaluateMatchCriteria,
+  getRepoSnapshot,
+  clearRepoSnapshotCache,
+} from '../src/repo-scan.js';
+import type { SecurityCheck } from '../src/types.js';
+
+function makeCheck(overrides: Partial<SecurityCheck> = {}): SecurityCheck {
+  return {
+    id: 'test',
+    name: 'Test',
+    repositories: [],
+    ...overrides,
+  };
+}
+
+/** Build a synthetic repo on disk under a temp directory. */
+async function makeRepo(layout: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'aghast-dyn-'));
+  for (const [rel, contents] of Object.entries(layout)) {
+    const full = join(dir, rel);
+    await mkdir(resolve(full, '..'), { recursive: true });
+    await writeFile(full, contents, 'utf-8');
+  }
+  return dir;
+}
+
+// ─── repo-scan.scanRepository ────────────────────────────────────────────────
+
+describe('scanRepository', () => {
+  let repo: string;
+  before(async () => {
+    repo = await makeRepo({
+      'package.json': '{}',
+      'src/app.ts': 'export {};',
+      'src/api/users.ts': 'export {};',
+      'README.md': '# repo',
+      'node_modules/foo/index.js': '/* should be ignored */',
+      '.git/HEAD': 'ref: refs/heads/main',
+      'dist/bundle.js': '/* should be ignored */',
+    });
+  });
+  after(async () => {
+    await rm(repo, { recursive: true, force: true });
+    clearRepoSnapshotCache();
+  });
+
+  it('collects files relative to repo with forward slashes', async () => {
+    const snap = await scanRepository(repo);
+    assert.ok(snap.files.includes('package.json'));
+    assert.ok(snap.files.includes('src/app.ts'));
+    assert.ok(snap.files.includes('src/api/users.ts'));
+  });
+
+  it('skips default-ignored directories', async () => {
+    const snap = await scanRepository(repo);
+    assert.ok(!snap.files.some((f) => f.startsWith('node_modules/')));
+    assert.ok(!snap.files.some((f) => f.startsWith('.git/')));
+    assert.ok(!snap.files.some((f) => f.startsWith('dist/')));
+  });
+
+  it('records file extensions, lowercased', async () => {
+    const snap = await scanRepository(repo);
+    assert.ok(snap.extensions.has('.ts'));
+    assert.ok(snap.extensions.has('.json'));
+    assert.ok(snap.extensions.has('.md'));
+  });
+});
+
+describe('repo-scan tags loading', () => {
+  it('reads tags from .aghast-tags', async () => {
+    const repo = await makeRepo({
+      'package.json': '{}',
+      '.aghast-tags': 'backend\napi-service\n# comment line\n',
+    });
+    try {
+      const snap = await scanRepository(repo);
+      assert.ok(snap.tags.has('backend'));
+      assert.ok(snap.tags.has('api-service'));
+      // Comment lines should NOT be tags
+      assert.ok(!snap.tags.has('# comment line'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('reads tags from .aghast.json `tags` array', async () => {
+    const repo = await makeRepo({
+      '.aghast.json': JSON.stringify({ tags: ['frontend', 'react'] }),
+    });
+    try {
+      const snap = await scanRepository(repo);
+      assert.ok(snap.tags.has('frontend'));
+      assert.ok(snap.tags.has('react'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('merges tags from both sources', async () => {
+    const repo = await makeRepo({
+      '.aghast-tags': 'backend',
+      '.aghast.json': JSON.stringify({ tags: ['api-service'] }),
+    });
+    try {
+      const snap = await scanRepository(repo);
+      assert.ok(snap.tags.has('backend'));
+      assert.ok(snap.tags.has('api-service'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('tolerates malformed .aghast.json (no throw)', async () => {
+    const repo = await makeRepo({
+      '.aghast.json': 'not json',
+      'package.json': '{}',
+    });
+    try {
+      const snap = await scanRepository(repo);
+      assert.equal(snap.tags.size, 0);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── evaluateMatchCriteria ───────────────────────────────────────────────────
+
+describe('evaluateMatchCriteria', () => {
+  let repo: string;
+  before(async () => {
+    repo = await makeRepo({
+      'package.json': '{}',
+      'src/api/users.ts': 'x',
+      'src/routes/login.ts': 'x',
+      'README.md': '#',
+      '.aghast-tags': 'backend\napi-service',
+    });
+  });
+  after(async () => {
+    await rm(repo, { recursive: true, force: true });
+    clearRepoSnapshotCache();
+  });
+
+  it('hasFileTypes matches when at least one extension is present', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ hasFileTypes: ['.ts'] }, snap), true);
+    assert.equal(evaluateMatchCriteria({ hasFileTypes: ['.go'] }, snap), false);
+    // First match in list wins
+    assert.equal(evaluateMatchCriteria({ hasFileTypes: ['.go', '.ts'] }, snap), true);
+  });
+
+  it('hasFileTypes accepts entries without leading dot', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ hasFileTypes: ['ts'] }, snap), true);
+  });
+
+  it('hasFiles matches literal paths', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ hasFiles: ['package.json'] }, snap), true);
+    assert.equal(evaluateMatchCriteria({ hasFiles: ['missing.txt'] }, snap), false);
+  });
+
+  it('hasFiles requires ALL listed entries to be present', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(
+      evaluateMatchCriteria({ hasFiles: ['package.json', 'README.md'] }, snap),
+      true,
+    );
+    assert.equal(
+      evaluateMatchCriteria({ hasFiles: ['package.json', 'missing.txt'] }, snap),
+      false,
+    );
+  });
+
+  it('hasFiles falls back to glob matching', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ hasFiles: ['src/api/*.ts'] }, snap), true);
+  });
+
+  it('hasPaths matches if any glob hits any file', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ hasPaths: ['src/api/**'] }, snap), true);
+    assert.equal(evaluateMatchCriteria({ hasPaths: ['src/missing/**'] }, snap), false);
+    // OR semantics across globs
+    assert.equal(
+      evaluateMatchCriteria({ hasPaths: ['src/missing/**', 'src/routes/**'] }, snap),
+      true,
+    );
+  });
+
+  it('tags requires ALL listed tags', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({ tags: ['backend'] }, snap), true);
+    assert.equal(
+      evaluateMatchCriteria({ tags: ['backend', 'api-service'] }, snap),
+      true,
+    );
+    assert.equal(
+      evaluateMatchCriteria({ tags: ['backend', 'missing'] }, snap),
+      false,
+    );
+  });
+
+  it('combines criteria with AND', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(
+      evaluateMatchCriteria(
+        { hasFileTypes: ['.ts'], tags: ['backend'] },
+        snap,
+      ),
+      true,
+    );
+    assert.equal(
+      evaluateMatchCriteria(
+        { hasFileTypes: ['.ts'], tags: ['missing'] },
+        snap,
+      ),
+      false,
+    );
+  });
+
+  it('empty criteria object matches nothing', async () => {
+    const snap = await scanRepository(repo);
+    assert.equal(evaluateMatchCriteria({}, snap), false);
+  });
+});
+
+// ─── snapshot cache ──────────────────────────────────────────────────────────
+
+describe('getRepoSnapshot caching', () => {
+  it('returns the same snapshot for repeated calls (single walk)', async () => {
+    const repo = await makeRepo({ 'a.ts': '' });
+    try {
+      clearRepoSnapshotCache();
+      const a = await getRepoSnapshot(resolve(repo));
+      const b = await getRepoSnapshot(resolve(repo));
+      assert.strictEqual(a, b, 'cache hit should reuse the same object');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      clearRepoSnapshotCache();
+    }
+  });
+
+  it('populates the cache after the first call (positive guard)', async () => {
+    const { __peekSnapshotCacheForTesting } = await import('../src/repo-scan.js');
+    const repo = await makeRepo({ 'a.ts': '' });
+    try {
+      clearRepoSnapshotCache();
+      assert.equal(
+        __peekSnapshotCacheForTesting(resolve(repo)),
+        undefined,
+        'cache should be empty after clear',
+      );
+      await getRepoSnapshot(resolve(repo));
+      assert.notEqual(
+        __peekSnapshotCacheForTesting(resolve(repo)),
+        undefined,
+        'cache should be populated after first call',
+      );
+      clearRepoSnapshotCache();
+      assert.equal(
+        __peekSnapshotCacheForTesting(resolve(repo)),
+        undefined,
+        'cache should be empty after clear again',
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      clearRepoSnapshotCache();
+    }
+  });
+
+  it('a fresh scan replaces the cached snapshot after clearRepoSnapshotCache (same code path the eviction-on-rejection guard relies on)', async () => {
+    // scanRepository currently swallows per-entry errors and always resolves,
+    // so we cannot easily provoke a real rejection to exercise the
+    // eviction-on-rejection guard in getRepoSnapshot directly. Instead we
+    // verify the same code path the guard relies on: after the cache is
+    // cleared, a subsequent getRepoSnapshot returns a freshly walked
+    // snapshot (a different object reference) rather than re-using the
+    // previous one.
+    clearRepoSnapshotCache();
+    const repo = await makeRepo({ 'a.ts': '' });
+    try {
+      // First call succeeds and populates the cache.
+      const first = await getRepoSnapshot(resolve(repo));
+      assert.ok(first.files.includes('a.ts'));
+      // Second call returns the cached promise (same object).
+      const second = await getRepoSnapshot(resolve(repo));
+      assert.strictEqual(second, first);
+      // Clearing wipes the cache so a third call gets a fresh scan.
+      clearRepoSnapshotCache();
+      const third = await getRepoSnapshot(resolve(repo));
+      assert.notStrictEqual(third, first, 'after clear, expect a freshly walked snapshot');
+      assert.ok(third.files.includes('a.ts'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      clearRepoSnapshotCache();
+    }
+  });
+});
+
+// ─── filterChecksForRepository (sync) — backward compatibility ──────────────
+
+describe('filterChecksForRepository (sync) — backward compat', () => {
+  it('ignores matchCriteria entirely', () => {
+    const checks = [
+      makeCheck({
+        id: 'criteria-only',
+        repositories: [],
+        matchCriteria: { hasFileTypes: ['.ts'] },
+      }),
+    ];
+    // The sync function applies the existing "empty repositories matches all"
+    // rule and does not consult matchCriteria. Behavior unchanged.
+    const out = filterChecksForRepository(checks, 'org/repo');
+    assert.equal(out.length, 1);
+  });
+});
+
+// ─── filterChecksForRepositoryAsync ─────────────────────────────────────────
+
+describe('filterChecksForRepositoryAsync', () => {
+  let repo: string;
+  before(async () => {
+    repo = await makeRepo({
+      'package.json': '{}',
+      'src/api/users.ts': 'x',
+      '.aghast-tags': 'backend',
+    });
+  });
+  after(async () => {
+    await rm(repo, { recursive: true, force: true });
+    clearRepoSnapshotCache();
+  });
+
+  it('explicit repository match still wins regardless of matchCriteria', async () => {
+    const checks = [
+      makeCheck({
+        id: 'explicit',
+        repositories: ['org/foo'],
+        matchCriteria: { hasFileTypes: ['.go'] }, // would not match
+      }),
+    ];
+    const out = await filterChecksForRepositoryAsync(checks, 'org/foo', repo);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, 'explicit');
+  });
+
+  it('adds matches via matchCriteria when explicit list does not match', async () => {
+    const checks = [
+      makeCheck({
+        id: 'criteria',
+        repositories: ['some/other-repo'], // explicit list does not include our repo
+        matchCriteria: { hasFileTypes: ['.ts'] },
+      }),
+    ];
+    const out = await filterChecksForRepositoryAsync(
+      checks,
+      'org/unrelated',
+      repo,
+    );
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, 'criteria');
+  });
+
+  it('omits checks whose criteria do not match', async () => {
+    const checks = [
+      makeCheck({
+        id: 'no-match',
+        repositories: ['some/other-repo'],
+        matchCriteria: { hasFileTypes: ['.go'] },
+      }),
+    ];
+    const out = await filterChecksForRepositoryAsync(
+      checks,
+      'org/unrelated',
+      repo,
+    );
+    assert.equal(out.length, 0);
+  });
+
+  it('skips disabled checks even if criteria match', async () => {
+    const checks = [
+      makeCheck({
+        id: 'disabled',
+        repositories: ['some/other-repo'],
+        matchCriteria: { hasFileTypes: ['.ts'] },
+        enabled: false,
+      }),
+    ];
+    const out = await filterChecksForRepositoryAsync(checks, 'org/x', repo);
+    assert.equal(out.length, 0);
+  });
+
+  it('does NOT trigger a filesystem walk when no check has matchCriteria', async () => {
+    const checks = [makeCheck({ id: 'a', repositories: ['org/foo'] })];
+    // Use a path that does not exist; the function must not try to scan it.
+    const fakeRepo = '/aghast/no/such/path/__missing__';
+    const out = await filterChecksForRepositoryAsync(
+      checks,
+      'org/foo',
+      fakeRepo,
+    );
+    assert.equal(out.length, 1);
+  });
+
+  it('uses tags via .aghast-tags', async () => {
+    const checks = [
+      makeCheck({
+        id: 'tagged',
+        repositories: ['some/other-repo'],
+        matchCriteria: { tags: ['backend'] },
+      }),
+    ];
+    const out = await filterChecksForRepositoryAsync(
+      checks,
+      'org/unrelated',
+      repo,
+    );
+    assert.equal(out.length, 1);
+  });
+
+  it('produces identical output to sync filter for legacy registries (no matchCriteria)', async () => {
+    // Backward-compat guard: a registry without any matchCriteria should
+    // give the same result through the async path as through the sync one.
+    const checks: SecurityCheck[] = [
+      makeCheck({ id: 'a', repositories: ['org/foo'] }),
+      makeCheck({ id: 'b', repositories: [] }),
+      makeCheck({ id: 'c', repositories: ['org/bar'], enabled: false }),
+      makeCheck({ id: 'd', repositories: ['some/other'] }),
+    ];
+    const sync = filterChecksForRepository(checks, 'org/foo');
+    const asyncOut = await filterChecksForRepositoryAsync(
+      checks,
+      'org/foo',
+      // Use a path that does not exist; the function must not try to scan
+      // it because no check has matchCriteria.
+      '/aghast/no/such/path/__legacy_test__',
+    );
+    assert.deepEqual(
+      asyncOut.map((c) => c.id),
+      sync.map((c) => c.id),
+    );
+  });
+});
+
+// ─── sortChecksByPriority ───────────────────────────────────────────────────
+
+describe('sortChecksByPriority', () => {
+  it('sorts ascending by priority', () => {
+    const checks = [
+      makeCheck({ id: 'b', priority: 10 }),
+      makeCheck({ id: 'a', priority: 1 }),
+      makeCheck({ id: 'c', priority: 5 }),
+    ];
+    const sorted = sortChecksByPriority(checks);
+    assert.deepEqual(
+      sorted.map((c) => c.id),
+      ['a', 'c', 'b'],
+    );
+  });
+
+  it('checks without priority sort to the end', () => {
+    const checks = [
+      makeCheck({ id: 'no1' }),
+      makeCheck({ id: 'p2', priority: 2 }),
+      makeCheck({ id: 'no2' }),
+      makeCheck({ id: 'p1', priority: 1 }),
+    ];
+    const sorted = sortChecksByPriority(checks);
+    assert.deepEqual(
+      sorted.map((c) => c.id),
+      ['p1', 'p2', 'no1', 'no2'],
+    );
+  });
+
+  it('is stable for equal priorities and for both-undefined', () => {
+    const checks = [
+      makeCheck({ id: 'first' }),
+      makeCheck({ id: 'second' }),
+      makeCheck({ id: 'third' }),
+      makeCheck({ id: 'p1a', priority: 1 }),
+      makeCheck({ id: 'p1b', priority: 1 }),
+    ];
+    const sorted = sortChecksByPriority(checks);
+    assert.deepEqual(
+      sorted.map((c) => c.id),
+      ['p1a', 'p1b', 'first', 'second', 'third'],
+    );
+  });
+
+  it('does not mutate the input', () => {
+    const checks = [
+      makeCheck({ id: 'b', priority: 2 }),
+      makeCheck({ id: 'a', priority: 1 }),
+    ];
+    const before = checks.map((c) => c.id).join(',');
+    sortChecksByPriority(checks);
+    const after = checks.map((c) => c.id).join(',');
+    assert.equal(before, after);
+  });
+
+  it('preserves original order when no check has a priority (legacy registry)', () => {
+    // Backward-compat guard: configs without priority should not have their
+    // execution order shuffled by the new sortChecksByPriority pass.
+    const checks = [
+      makeCheck({ id: 'one' }),
+      makeCheck({ id: 'two' }),
+      makeCheck({ id: 'three' }),
+      makeCheck({ id: 'four' }),
+    ];
+    const sorted = sortChecksByPriority(checks);
+    assert.deepEqual(
+      sorted.map((c) => c.id),
+      ['one', 'two', 'three', 'four'],
+    );
+  });
+});
+
+// ─── scanRepository caps ─────────────────────────────────────────────────────
+
+describe('scanRepository caps (test-only knobs)', () => {
+  it('truncates at maxFiles and still returns a usable snapshot', async () => {
+    const repo = await makeRepo({
+      'a.ts': '',
+      'b.ts': '',
+      'c.ts': '',
+      'd.ts': '',
+      'e.ts': '',
+    });
+    try {
+      const snap = await scanRepository(repo, { maxFiles: 2 });
+      // The first two files are inspected; the rest are dropped silently.
+      assert.equal(snap.files.length, 2);
+      // Even with truncation, file extensions seen so far are recorded.
+      assert.ok(snap.extensions.has('.ts'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates at maxDepth and skips deeper subtrees', async () => {
+    // Build nested directory tree: lvl0/lvl1/lvl2/lvl3/file.ts
+    const repo = await makeRepo({
+      'top.ts': '',
+      'lvl1/lvl2/lvl3/deep.ts': '',
+    });
+    try {
+      // maxDepth=1 lets us see top.ts and the lvl1 directory's immediate
+      // contents, but not anything past lvl1/lvl2/...
+      const snap = await scanRepository(repo, { maxDepth: 1 });
+      assert.ok(snap.files.includes('top.ts'));
+      assert.ok(!snap.files.some((f) => f.includes('deep.ts')),
+        `deep.ts should be truncated, got: ${JSON.stringify(snap.files)}`);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── registry validation ────────────────────────────────────────────────────
+
+describe('loadCheckRegistry — matchCriteria + priority validation', () => {
+  it('accepts valid matchCriteria and priority', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [
+            {
+              id: 'a',
+              repositories: [],
+              matchCriteria: {
+                hasFileTypes: ['.ts'],
+                hasFiles: ['package.json'],
+                hasPaths: ['src/**'],
+                tags: ['backend'],
+              },
+              priority: 5,
+            },
+          ],
+        }),
+        'utf-8',
+      );
+      const reg = await loadCheckRegistry(dir);
+      assert.equal(reg.checks[0].priority, 5);
+      assert.deepEqual(reg.checks[0].matchCriteria?.hasFileTypes, ['.ts']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects priority that is not a non-negative integer', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [{ id: 'a', repositories: [], priority: -1 }],
+        }),
+      );
+      await assert.rejects(
+        loadCheckRegistry(dir),
+        /priority must be a non-negative integer/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects non-integer priority', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [{ id: 'a', repositories: [], priority: 1.5 }],
+        }),
+      );
+      await assert.rejects(
+        loadCheckRegistry(dir),
+        /priority must be a non-negative integer/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects matchCriteria that is not an object', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [{ id: 'a', repositories: [], matchCriteria: 'oops' }],
+        }),
+      );
+      await assert.rejects(
+        loadCheckRegistry(dir),
+        /matchCriteria must be an object/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unknown matchCriteria fields (catches typos)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [
+            { id: 'a', repositories: [], matchCriteria: { hasFileType: ['.ts'] } },
+          ],
+        }),
+      );
+      await assert.rejects(
+        loadCheckRegistry(dir),
+        /matchCriteria has unknown field/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects matchCriteria array fields with non-string entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [
+            { id: 'a', repositories: [], matchCriteria: { hasFileTypes: [42] } },
+          ],
+        }),
+      );
+      await assert.rejects(
+        loadCheckRegistry(dir),
+        /matchCriteria\.hasFileTypes\[0\] must be a string/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('omitting both fields preserves backward compatibility', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'aghast-reg-'));
+    try {
+      await writeFile(
+        join(dir, 'checks-config.json'),
+        JSON.stringify({
+          checks: [{ id: 'a', repositories: ['org/repo'], enabled: true }],
+        }),
+      );
+      const reg = await loadCheckRegistry(dir);
+      assert.equal(reg.checks[0].priority, undefined);
+      assert.equal(reg.checks[0].matchCriteria, undefined);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/fixtures/cli-configs/dynamic-matching/checks-config.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks-config.json
@@ -1,0 +1,38 @@
+{
+  "checks": [
+    {
+      "id": "aghast-no-priority",
+      "repositories": [],
+      "enabled": true
+    },
+    {
+      "id": "aghast-runs-second",
+      "repositories": [],
+      "enabled": true,
+      "priority": 20
+    },
+    {
+      "id": "aghast-criteria-only",
+      "repositories": ["does-not-match-this-repo"],
+      "enabled": true,
+      "priority": 5,
+      "matchCriteria": {
+        "hasFileTypes": [".ts"]
+      }
+    },
+    {
+      "id": "aghast-criteria-skipped",
+      "repositories": ["does-not-match-either"],
+      "enabled": true,
+      "matchCriteria": {
+        "hasFileTypes": [".rs"]
+      }
+    },
+    {
+      "id": "aghast-runs-first",
+      "repositories": [],
+      "enabled": true,
+      "priority": 1
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-only/aghast-criteria-only.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-only/aghast-criteria-only.json
@@ -1,0 +1,5 @@
+{
+  "id": "aghast-criteria-only",
+  "name": "Criteria-Only Match",
+  "instructionsFile": "aghast-criteria-only.md"
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-only/aghast-criteria-only.md
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-only/aghast-criteria-only.md
@@ -1,0 +1,4 @@
+### Criteria-Only Match
+
+#### Overview
+Check that matches the repo via matchCriteria (`.ts` files present).

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-skipped/aghast-criteria-skipped.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-skipped/aghast-criteria-skipped.json
@@ -1,0 +1,5 @@
+{
+  "id": "aghast-criteria-skipped",
+  "name": "Criteria Skipped",
+  "instructionsFile": "aghast-criteria-skipped.md"
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-skipped/aghast-criteria-skipped.md
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-criteria-skipped/aghast-criteria-skipped.md
@@ -1,0 +1,4 @@
+### Criteria Skipped
+
+#### Overview
+Check that should be filtered out — looks for `.rs` which the fixture repo does not contain.

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-no-priority/aghast-no-priority.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-no-priority/aghast-no-priority.json
@@ -1,0 +1,5 @@
+{
+  "id": "aghast-no-priority",
+  "name": "No Priority",
+  "instructionsFile": "aghast-no-priority.md"
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-no-priority/aghast-no-priority.md
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-no-priority/aghast-no-priority.md
@@ -1,0 +1,4 @@
+### No Priority
+
+#### Overview
+Check without a priority — should sort to the end.

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-first/aghast-runs-first.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-first/aghast-runs-first.json
@@ -1,0 +1,5 @@
+{
+  "id": "aghast-runs-first",
+  "name": "Runs First",
+  "instructionsFile": "aghast-runs-first.md"
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-first/aghast-runs-first.md
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-first/aghast-runs-first.md
@@ -1,0 +1,4 @@
+### Runs First
+
+#### Overview
+Lowest priority check.

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-second/aghast-runs-second.json
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-second/aghast-runs-second.json
@@ -1,0 +1,5 @@
+{
+  "id": "aghast-runs-second",
+  "name": "Runs Second",
+  "instructionsFile": "aghast-runs-second.md"
+}

--- a/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-second/aghast-runs-second.md
+++ b/tests/fixtures/cli-configs/dynamic-matching/checks/aghast-runs-second/aghast-runs-second.md
@@ -1,0 +1,4 @@
+### Runs Second
+
+#### Overview
+Mid-priority check.


### PR DESCRIPTION
Adds two optional fields to `checks-config.json` so a check library can adapt to the repository being scanned, instead of enumerating every repository by hand.

## `matchCriteria`

Lets a check opt in based on what the repository actually contains — for example the file extensions or paths present.

```json
{
  "id": "python-subprocess-injection",
  "enabled": true,
  "matchCriteria": { "extensions": [".py"] },
  "priority": 10
}
```

**Criteria can only ADD matches.** An explicit `repositories` entry always wins, so a check that already lists its repositories behaves exactly as before. Existing configurations are unaffected — both fields are optional, and omitting them preserves current behaviour.

## `priority`

Sets execution order, **lowest first**. Checks without a `priority` run last, in a stable order relative to one another. Useful for running cheap, fast checks before expensive ones, so a scan surfaces obvious findings early.

## Performance

The repository snapshot backing `matchCriteria` is built once and cached for the duration of a scan, and is bounded by a fixed ignore list and a depth cap. Adding criteria to many checks therefore costs a single tree traversal rather than one traversal per check.

## Testing

New `tests/dynamic-matching.test.ts` plus CLI-level integration coverage in `tests/cli-mock-mode-2.test.ts`, with fixtures under `tests/fixtures/cli-configs/dynamic-matching/` covering criteria-only matches, criteria skipped in favour of an explicit `repositories` entry, prioritised ordering, and unprioritised checks falling to the end.

Full suite: 1218 tests, 0 failures (3 skipped — Semgrep not installed).
