### PR TITLE
feat: add an optional LLM judge stage to re-evaluate findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Seven core components orchestrated by the Security Scanner:
 6. **Diff Filter** — Optional post-discovery transformation (`src/diff-filter.ts`) that narrows any SARIF-producing discovery's output to findings touching a git diff, using OpenAnt's call graph for flow-adjacency. Activated automatically when a diff source is provided; individual checks can opt out via `checkTarget.diffFilter: false`.
 7. **Report Generator** — Produces `security_checks_results.json` (or `.sarif`) conforming to the `ScanResults` schema
 
-**Scan workflow**: User initiates → repo metadata extracted → checks filtered for repo → for each check: load instructions (if applicable), run discovery (Semgrep, Opengrep, OpenAnt, or SARIF for targeted/static checks), optionally apply diff filter, AI analyzes (or map findings directly for static checks), results parsed → aggregate → JSON report → exit code.
+**Scan workflow**: User initiates → repo metadata extracted → checks filtered for repo → for each check: load instructions (if applicable), run discovery (Semgrep, Opengrep, OpenAnt, SARIF, glob or script for targeted/static checks), optionally apply diff filter, AI analyzes (or map findings directly for static checks), results parsed → aggregate → (optional) LLM judge stage re-evaluates all issues → JSON report → exit code.
 
 **Check types**: Three check types with pluggable discovery:
 - `repository` — AI analyzes the whole repo (no discovery needed)
@@ -113,6 +113,9 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_MOCK_SARIF` — Path to SARIF file for mock Semgrep/Opengrep output (test/dev only)
 - `AGHAST_OPENANT_DATASET` — Path to a pre-generated OpenAnt dataset JSON file (skips invoking `openant parse`)
 - `AGHAST_DIFF_REF` — Git ref to diff against; enables diff filtering on supporting discoveries (CLI `--diff-ref` takes precedence)
+- `AGHAST_JUDGE_MODEL` — Enable the LLM judge stage using this model (CLI `--judge-model` takes precedence)
+- `AGHAST_JUDGE_PROVIDER` — Agent provider for the judge stage (CLI `--judge-provider` takes precedence)
+- `AGHAST_MOCK_JUDGE` — Enables mock judge provider. Set to `true` for default `true_positive` response, or set to a file path
 - `AGHAST_HISTORY_FILE` — Override the scan history file path (default: `~/.aghast/history.json`)
 - `AGHAST_MOCK_TOKENS` — Format `<input>,<output>`; injects token usage into the mock agent provider for cost/budget tests
 - `AGHAST_MOCK_LOCAL_LOGIN` — Test hook for the Claude Code provider's local-login probe: `true` reports a logged-in session, `false` reports not-logged-in, both without spawning the agent SDK (keeps CLI auth tests hermetic)
@@ -144,6 +147,29 @@ listed instead of its contents.
 **Core scan pipeline**
 
 - `src/scan-runner.ts` — Security Scanner orchestrator (`runMultiScan` for config-based multi-check; `executeTargetedCheck` for discovery-based checks with concurrent target analysis via `mapWithConcurrency`)
+- `src/cli.ts` — Unified CLI entry point with subcommand router (`scan`, `new-check`, `--help`, `--version`)
+- `src/index.ts` — Scan CLI entry point and argument parsing (exports `runScan(args)`); validates config dir structure
+- `src/scan-runner.ts` — Security Scanner orchestrator (`runMultiScan` for config-based multi-check; `executeTargetedCheck` for discovery-based checks with concurrent target analysis via `mapWithConcurrency`; wires in the judge stage after checks complete)
+- `src/judge.ts` — LLM judge stage: `runJudge` (re-evaluates all issues post-scan), `applyJudgeResults` (status recomputation, drop FPs, escalate uncertain → FLAG), `parseJudgeResponse` (parses verdict JSON)
+- `src/concurrency.ts` — Shared concurrency utility: `mapWithConcurrency` (concurrent mapping with optional abort handle), `AbortHandle`
+- `src/cost-tracker.ts` — Shared cost tracking: `ScanCostTracker`, `createCostTracker`, `recordUsage`, `preflightBudget`
+- `src/discovery.ts` — Pluggable discovery abstraction: `DiscoveryProvider` interface, `DiscoveryRegistry`, and discovery orchestration
+- `src/discoveries/semgrep-discovery.ts` — Semgrep discovery provider (runs Semgrep rules, parses SARIF output into targets)
+- `src/discoveries/openant-discovery.ts` — OpenAnt discovery provider (runs OpenAnt to extract code units with call graph context)
+- `src/discoveries/sarif-discovery.ts` — SARIF discovery provider (reads external SARIF files for AI validation)
+- `src/diff-filter.ts` — Diff filter (`applyDiffFilter`); called post-discovery whenever a diff source is available and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets to diff scope using OpenAnt call graph (depth-1), or falls back to file+line overlap (depth-0) when OpenAnt is unavailable
+- `src/diff-parser.ts` — Unified diff parsing (`parseDiff`, `getDiff`, `loadDiffFromFile`)
+- `src/diff-unit-matcher.ts` — Unit-to-diff matching with call graph traversal (`findTouchedUnits`, `filterFindingsByScope`)
+- `src/claude-code-provider.ts` — Claude Code agent provider implementation using `@anthropic-ai/claude-agent-sdk`
+- `src/opencode-provider.ts` — OpenCode agent provider implementation using `@opencode-ai/sdk` (supports 75+ LLM providers)
+- `src/provider-utils.ts` — Shared provider utilities (OUTPUT_SCHEMA for structured output)
+- `src/prompt-template.ts` — Prompt builder (prepends generic instructions to check markdown)
+- `src/snippet-extractor.ts` — Code snippet extractor (extracts lines from source files for issue enrichment)
+- `src/sarif-parser.ts` — SARIF 2.1.0 parser (`parseSARIF`, `deduplicateTargets`, `limitTargets`)
+- `src/semgrep-runner.ts` — Semgrep execution with mock support (`runSemgrep`, `buildSemgrepArgs`)
+- `src/openant-runner.ts` — OpenAnt execution with mock support (runs OpenAnt CLI, parses output)
+- `src/openant-loader.ts` — OpenAnt dataset loading, unit filtering, and prompt formatting. Uses base datasets (`dataset.json`) not enhanced — the AI forms its own security judgment
+- `src/check-types.ts` — Check type descriptor system; each check type (`repository`, `targeted`, `static`) declares its characteristics (needsAI, needsDiscovery, needsInstructions, etc.) in one place
 - `src/check-library.ts` — Check Library: two-layer config loading (`loadCheckRegistry`, `loadCheckDefinition`, `discoverCheckFolders`, `resolveChecks`), validation, repository matching, markdown parsing, path filtering
 - `src/repo-scan.ts` — Cached repository snapshot (file paths, extensions, user tags) used to evaluate `matchCriteria` rules without re-walking the tree per check. Bounded: fixed ignore list plus a depth cap, since it gates which checks run rather than enumerating the repo
 - `src/check-types.ts` — Check type descriptor system; each type (`repository`, `targeted`, `static`) declares its characteristics (needsAI, needsDiscovery, needsInstructions, etc.) in one place

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,6 +273,7 @@ Diff filtering works identically for `openant` discovery: the filter narrows the
 | `checkTarget.openant.minConfidence` | `number`     | No       | Minimum classification confidence (0-1) |
 | `applicablePaths`  | `string[]`                    | No       | Glob patterns to include (e.g. `["src/**/*.ts"]`) |
 | `excludedPaths`    | `string[]`                    | No       | Glob patterns to exclude (e.g. `["tests/**"]`) |
+| `judge`            | `boolean`                     | No       | Set to `false` to exclude this check's issues from the LLM judge stage. Default (omitted or `true`): issues are judged when the judge stage is enabled |
 
 ## Check Types
 
@@ -387,6 +388,13 @@ An optional `runtime-config.json` file in the config directory (or specified via
     "models": {
       "my-custom-model": { "inputPerMillion": 2.0, "outputPerMillion": 8.0 }
     }
+  },
+  "judge": {
+    "model": "claude-opus-4-7",
+    "provider": "claude-code",
+    "concurrency": 5,
+    "dropFalsePositives": true,
+    "minConfidence": 0.7
   }
 }
 ```
@@ -429,6 +437,12 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | `budget.thresholds.abortAt`     | `number`   | `1.0` | Fraction of a limit at which the scan aborts (0.0–1.0) |
 | `pricing.currency`              | `string`   | `USD` | Currency for cost estimates |
 | `pricing.models`                | `object`   | (built-in) | Per-model overrides: `{ "<model>": { "inputPerMillion": <usd>, "outputPerMillion": <usd> } }`. Merges with built-in defaults |
+
+| `judge.model`               | `string`   | (none, stage disabled) | Enable the LLM judge stage using this model. The judge re-evaluates every finding post-scan and annotates it with a verdict, confidence, and rationale. CLI `--judge-model` takes precedence |
+| `judge.provider`            | `string`   | (scan provider) | Agent provider for the judge stage. Defaults to the scan provider if omitted |
+| `judge.concurrency`         | `number`   | `5` | Max parallel judge calls per scan |
+| `judge.dropFalsePositives`  | `boolean`  | `false` | Remove issues confirmed as false positives from the output. If a check loses all its issues, it becomes PASS |
+| `judge.minConfidence`       | `number`   | (none) | Confidence threshold (0–1). `true_positive` verdicts below this value are demoted to `uncertain` |
 
 **Precedence**: CLI flags > environment variables > runtime config > built-in defaults.
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -37,6 +37,11 @@ aghast scan <repo-path> --config-dir <path> [options]
 | `--repo <owner/repo>` | GitHub repository in `owner/repo` form (defaults to `$GITHUB_REPOSITORY`) |
 | `--base-sha <sha>` | Optional base commit SHA (defaults to `$GITHUB_BASE_SHA`) |
 | `--head-sha <sha>` | Optional head commit SHA (defaults to `$GITHUB_HEAD_SHA` then `$GITHUB_SHA`) |
+| `--judge-model <model>` | Enable the LLM judge stage using this model. The judge re-evaluates all findings post-scan and annotates each issue with a verdict (`true_positive`, `false_positive`, or `uncertain`) |
+| `--judge-provider <name>` | Agent provider for the judge stage (defaults to the scan provider) |
+| `--judge-concurrency <n>` | Max parallel judge calls (default: 5) |
+| `--judge-drop-false-positives` | Remove issues the judge confirms as false positives from the output |
+| `--judge-min-confidence <0-1>` | Demote `true_positive` verdicts with confidence below this threshold to `uncertain` |
 
 Run `aghast scan --help` for the full list of options.
 
@@ -88,6 +93,9 @@ the PR comment phase is non-fatal.
 | `AGHAST_MOCK_SARIF` | Path to a SARIF file to use instead of running Semgrep or Opengrep (test/dev use only; also skips the install prerequisite check for whichever tool the check targets) |
 | `AGHAST_OPENANT_DATASET` | Path to a pre-generated OpenAnt dataset JSON file. When set, aghast uses this dataset directly instead of invoking `openant parse`. Useful for caching the dataset across multiple scans, splitting OpenAnt and aghast into separate CI jobs, running aghast where Python 3.11+ isn't available, or stubbing OpenAnt output in tests |
 | `AGHAST_DIFF_REF` | Git ref to diff against; enables diff filtering on supporting discoveries (CLI `--diff-ref` takes precedence) |
+| `AGHAST_JUDGE_MODEL` | Enable the LLM judge stage using this model (CLI `--judge-model` takes precedence) |
+| `AGHAST_JUDGE_PROVIDER` | Agent provider for the judge stage (CLI `--judge-provider` takes precedence) |
+| `AGHAST_MOCK_JUDGE` | Set to `true` for a default `true_positive` mock response, or set to a file path for a custom judge response fixture (for testing without a real API key). Note: when `AGHAST_MOCK_AI` is set (without `AGHAST_MOCK_JUDGE`), the judge also uses a mock provider automatically — set `AGHAST_MOCK_JUDGE` explicitly if you need a specific judge response |
 | `NO_COLOR` | Set to `1` to disable colored CLI output ([standard](https://no-color.org/)) |
 
 ## Agent Providers
@@ -184,6 +192,51 @@ Analysis modes for `targeted` checks (`checkTarget.analysisMode`):
 Built-in modes (`false-positive-validation`, `general-vuln-discovery`) provide their own prompt template and don't require an instructions file. See [How It Works](how-it-works.md#three-check-types) for details.
 
 See the [Configuration Reference](configuration.md) for check definition schemas and result statuses.
+
+## LLM Judge Stage
+
+The judge stage re-evaluates all findings after the main scan completes. It runs a separate LLM call per issue and annotates each with a **verdict**, **confidence**, and **rationale**. The judge is independent of the per-check AI agents — it can use a different model or provider.
+
+**Enable** the judge by providing a model via `--judge-model` (or `AGHAST_JUDGE_MODEL`, or `judge.model` in runtime config):
+
+```bash
+aghast scan ./my-repo --config-dir ./checks \
+  --judge-model claude-opus-4-7 \
+  --judge-drop-false-positives
+```
+
+### Verdicts and status effects
+
+| Verdict | Issue `judge.verdict` | Status effect |
+|---|---|---|
+| `true_positive` | `"true_positive"` | Check stays FAIL as before |
+| `false_positive` | `"false_positive"` | No status change; optionally dropped with `--judge-drop-false-positives` |
+| `uncertain` | `"uncertain"` | Check escalates to FLAG (if not already FAIL); `flagSource: "judge"` |
+
+When `--judge-drop-false-positives` is set, confirmed false-positive issues are removed. If a check loses all its issues this way, it becomes PASS.
+
+### Per-check opt-out
+
+Add `"judge": false` to a check's JSON definition to skip judge evaluation for that check's issues:
+
+```json
+{
+  "id": "aghast-my-check",
+  "name": "My Check",
+  "instructionsFile": "aghast-my-check.md",
+  "judge": false
+}
+```
+
+### Judge summary
+
+When the judge stage runs, the scan banner includes a summary line:
+
+```
+  Judged:        12 issues: 9 true / 2 false / 1 uncertain (judge: claude-opus-4-7)
+```
+
+The `ScanSummary` in the JSON output includes `judgedIssues`, `falsePositives`, `uncertainJudgements`, `flaggedByCheck`, and `flaggedByJudge` counts. SARIF output includes `kind` (`open` for true positive, `false` for false positive, `review` for uncertain) and a `properties.judge` object on each result.
 
 ## CI usage — diff-scoped scans on PRs
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -60,6 +60,11 @@ interface ParsedFlags {
   logType?: string;
   genericPrompt?: string;
   failOnCheckFailure?: string;
+  judgeModel?: string;
+  judgeProvider?: string;
+  judgeConcurrency?: string;
+  judgeDropFalsePositives?: string;
+  judgeMinConfidence?: string;
   nonInteractive?: boolean;
   clear?: string[];
 }
@@ -76,6 +81,11 @@ const FLAG_MAP: Record<string, keyof Omit<ParsedFlags, 'nonInteractive' | 'clear
   '--log-type': 'logType',
   '--generic-prompt': 'genericPrompt',
   '--fail-on-check-failure': 'failOnCheckFailure',
+  '--judge-model': 'judgeModel',
+  '--judge-provider': 'judgeProvider',
+  '--judge-concurrency': 'judgeConcurrency',
+  '--judge-drop-false-positives': 'judgeDropFalsePositives',
+  '--judge-min-confidence': 'judgeMinConfidence',
 };
 
 const KNOWN_FLAGS = new Set<string>([...Object.keys(FLAG_MAP), '--non-interactive', '--clear', '--help', '-h']);
@@ -150,6 +160,11 @@ Field flags (any value provided here skips its prompt; closed lists are validate
   --log-type <type>             Log file handler type (default: file)
   --generic-prompt <file>       Generic prompt template filename
   --fail-on-check-failure <b>   true | false
+  --judge-model <model>         Enable the LLM judge stage using this model
+  --judge-provider <name>       Agent provider for the judge stage (defaults to scan provider)
+  --judge-concurrency <n>       Max parallel judge calls (default: 5)
+  --judge-drop-false-positives <b>  true | false
+  --judge-min-confidence <0-1>  Confidence threshold; true_positive verdicts below this become uncertain
 
 Mode flags:
   --non-interactive             Don't prompt — use existing values / defaults / flags only
@@ -175,6 +190,11 @@ const CLEARABLE_FIELDS = new Set([
   'logType',
   'genericPrompt',
   'failOnCheckFailure',
+  'judgeModel',
+  'judgeProvider',
+  'judgeConcurrency',
+  'judgeDropFalsePositives',
+  'judgeMinConfidence',
 ]);
 
 async function fileExists(path: string): Promise<boolean> {
@@ -196,6 +216,11 @@ function configToFlatDefaults(config: RuntimeConfig): {
   logType?: string;
   genericPrompt?: string;
   failOnCheckFailure?: boolean;
+  judgeModel?: string;
+  judgeProvider?: string;
+  judgeConcurrency?: number;
+  judgeDropFalsePositives?: boolean;
+  judgeMinConfidence?: number;
 } {
   return {
     provider: config.agentProvider?.name,
@@ -207,6 +232,11 @@ function configToFlatDefaults(config: RuntimeConfig): {
     logType: config.logging?.logType,
     genericPrompt: config.genericPrompt,
     failOnCheckFailure: config.failOnCheckFailure,
+    judgeModel: config.judge?.model,
+    judgeProvider: config.judge?.provider,
+    judgeConcurrency: config.judge?.concurrency,
+    judgeDropFalsePositives: config.judge?.dropFalsePositives,
+    judgeMinConfidence: config.judge?.minConfidence,
   };
 }
 
@@ -220,6 +250,11 @@ interface BuiltValues {
   logType?: string;
   genericPrompt?: string;
   failOnCheckFailure?: boolean;
+  judgeModel?: string;
+  judgeProvider?: string;
+  judgeConcurrency?: number;
+  judgeDropFalsePositives?: boolean;
+  judgeMinConfidence?: number;
 }
 
 function buildConfig(values: BuiltValues): RuntimeConfig {
@@ -242,6 +277,20 @@ function buildConfig(values: BuiltValues): RuntimeConfig {
   }
   if (values.genericPrompt !== undefined) config.genericPrompt = values.genericPrompt;
   if (values.failOnCheckFailure !== undefined) config.failOnCheckFailure = values.failOnCheckFailure;
+  if (
+    values.judgeModel !== undefined ||
+    values.judgeProvider !== undefined ||
+    values.judgeConcurrency !== undefined ||
+    values.judgeDropFalsePositives !== undefined ||
+    values.judgeMinConfidence !== undefined
+  ) {
+    config.judge = {};
+    if (values.judgeModel !== undefined) config.judge.model = values.judgeModel;
+    if (values.judgeProvider !== undefined) config.judge.provider = values.judgeProvider;
+    if (values.judgeConcurrency !== undefined) config.judge.concurrency = values.judgeConcurrency;
+    if (values.judgeDropFalsePositives !== undefined) config.judge.dropFalsePositives = values.judgeDropFalsePositives;
+    if (values.judgeMinConfidence !== undefined) config.judge.minConfidence = values.judgeMinConfidence;
+  }
   return config;
 }
 
@@ -491,6 +540,31 @@ export async function runBuildConfig(args: string[]): Promise<void> {
     }
     result.failOnCheckFailure = flags.failOnCheckFailure === 'true';
   }
+  if (flags.judgeModel !== undefined) result.judgeModel = flags.judgeModel;
+  if (flags.judgeProvider !== undefined) result.judgeProvider = flags.judgeProvider;
+  if (flags.judgeConcurrency !== undefined) {
+    const n = parseInt(flags.judgeConcurrency, 10);
+    if (isNaN(n) || n < 1) {
+      console.error(formatError(ERROR_CODES.E1001, `Invalid --judge-concurrency "${flags.judgeConcurrency}". Must be a positive integer.`));
+      process.exit(1);
+    }
+    result.judgeConcurrency = n;
+  }
+  if (flags.judgeDropFalsePositives !== undefined) {
+    if (!VALID_BOOLS.includes(flags.judgeDropFalsePositives as 'true' | 'false')) {
+      console.error(formatError(ERROR_CODES.E1001, `Invalid --judge-drop-false-positives "${flags.judgeDropFalsePositives}". Must be true or false.`));
+      process.exit(1);
+    }
+    result.judgeDropFalsePositives = flags.judgeDropFalsePositives === 'true';
+  }
+  if (flags.judgeMinConfidence !== undefined) {
+    const n = parseFloat(flags.judgeMinConfidence);
+    if (isNaN(n) || n < 0 || n > 1) {
+      console.error(formatError(ERROR_CODES.E1001, `Invalid --judge-min-confidence "${flags.judgeMinConfidence}". Must be a number between 0 and 1.`));
+      process.exit(1);
+    }
+    result.judgeMinConfidence = n;
+  }
   // Model is applied last, after we have a resolved provider, so we can validate against listModels
   const pendingModelFlag = flags.model;
 
@@ -563,6 +637,34 @@ export async function runBuildConfig(args: string[]): Promise<void> {
       }
       if (flags.failOnCheckFailure === undefined) {
         result.failOnCheckFailure = await helpers.askBool('Fail on check failure', result.failOnCheckFailure, SCAN_DEFAULTS.failOnCheckFailure);
+      }
+      if (flags.judgeModel === undefined) {
+        result.judgeModel = await helpers.ask('Judge model (leave unset to disable judge stage)', result.judgeModel);
+      }
+      if (flags.judgeProvider === undefined) {
+        const providers = getProviderNames();
+        result.judgeProvider = await helpers.askChoice('Judge provider (defaults to scan provider)', providers, result.judgeProvider);
+      }
+      if (flags.judgeConcurrency === undefined) {
+        const raw = await helpers.ask('Judge concurrency', result.judgeConcurrency !== undefined ? String(result.judgeConcurrency) : undefined, '5');
+        if (raw !== undefined) {
+          const n = parseInt(raw, 10);
+          if (!isNaN(n) && n >= 1) result.judgeConcurrency = n;
+        } else {
+          result.judgeConcurrency = undefined;
+        }
+      }
+      if (flags.judgeDropFalsePositives === undefined) {
+        result.judgeDropFalsePositives = await helpers.askBool('Drop false positives confirmed by judge', result.judgeDropFalsePositives);
+      }
+      if (flags.judgeMinConfidence === undefined) {
+        const raw = await helpers.ask('Judge min confidence (0-1, demotes TP below threshold to uncertain)', result.judgeMinConfidence !== undefined ? String(result.judgeMinConfidence) : undefined);
+        if (raw !== undefined) {
+          const n = parseFloat(raw);
+          if (!isNaN(n) && n >= 0 && n <= 1) result.judgeMinConfidence = n;
+        } else {
+          result.judgeMinConfidence = undefined;
+        }
       }
     } catch (err) {
       // Includes "No valid choice for X after N attempts" — surface as a usage error.

--- a/src/check-library.ts
+++ b/src/check-library.ts
@@ -208,6 +208,9 @@ export async function loadCheckDefinition(checkFolderPath: string): Promise<Chec
   if (obj.model !== undefined && typeof obj.model !== 'string') {
     throw new Error(`Check definition "${defPath}": "model" must be a string`);
   }
+  if (obj.judge !== undefined && typeof obj.judge !== 'boolean') {
+    throw new Error(`Check definition "${defPath}": "judge" must be a boolean`);
+  }
   if (obj.applicablePaths !== undefined && !Array.isArray(obj.applicablePaths)) {
     throw new Error(`Check definition "${defPath}": "applicablePaths" must be an array`);
   }
@@ -448,6 +451,7 @@ export async function resolveChecks(
     if (def.severity) merged.severity = def.severity;
     if (def.confidence) merged.confidence = def.confidence;
     if (def.model) merged.model = def.model;
+    if (def.judge !== undefined) merged.judge = def.judge;
     if (def.applicablePaths) merged.applicablePaths = def.applicablePaths;
     if (def.excludedPaths) merged.excludedPaths = def.excludedPaths;
 

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared concurrency utilities for the scan runner and judge stage.
+ */
+
+/** Handle for signaling abort to mapWithConcurrency workers. */
+export interface AbortHandle {
+  aborted: boolean;
+  reason?: Error;
+}
+
+/**
+ * Run an async function over items with bounded concurrency.
+ * Spawns min(concurrency, items.length) workers that pull from a shared index.
+ * Results are written to a pre-allocated array to preserve input order.
+ *
+ * If abortHandle is provided, workers stop picking up new items once
+ * abortHandle.aborted is set to true. In-flight items complete naturally.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+  abortHandle?: AbortHandle,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      if (abortHandle?.aborted) break;
+      // Safe without atomics: Node.js is single-threaded, so nextIndex++ is
+      // not interleaved — each worker awaits before looping, yielding to the
+      // event loop where the next worker reads and increments the same variable.
+      const i = nextIndex++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < workerCount; w++) {
+    workers.push(worker());
+  }
+
+  // Use allSettled so in-flight items complete before we propagate errors
+  const settled = await Promise.allSettled(workers);
+  const firstRejection = settled.find((r) => r.status === 'rejected');
+  if (firstRejection && firstRejection.status === 'rejected') {
+    throw firstRejection.reason;
+  }
+
+  return results;
+}

--- a/src/cost-tracker.ts
+++ b/src/cost-tracker.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared cost-tracking utilities for the scan runner and judge stage.
+ */
+
+import { calculateCost, type PricingConfig, type CostBreakdown } from './cost-calculator.js';
+import { checkBudget, BudgetExceededError, type BudgetLimits } from './budget.js';
+import { logProgress } from './logging.js';
+import type { TokenUsage } from './types.js';
+import type { ScanRecord } from './scan-history.js';
+
+const TAG = 'scan';
+
+/**
+ * Tracks accumulated tokens/cost across a scan so the budget can be evaluated
+ * before each AI call. Mutated in place by AI invocations.
+ */
+export interface ScanCostTracker {
+  pricing?: PricingConfig;
+  budgetLimits?: BudgetLimits;
+  scanHistory?: ScanRecord[];
+  totalTokens: number;
+  totalCostUsd: number;
+  /** Cost source from the last recorded AI call. Used for banner labelling. */
+  lastCostSource?: CostBreakdown['source'];
+  lastCostReportedBy?: CostBreakdown['reportedBy'];
+  lastCostCoveredBySubscription?: boolean;
+  /** Set true after the first warn so we don't log it repeatedly. */
+  warned: boolean;
+  /** Most recent budget action returned to the runner. */
+  lastAction: 'continue' | 'warn' | 'abort';
+  /** Reason from the most recent non-continue check. */
+  lastReason?: string;
+}
+
+export function createCostTracker(options: {
+  pricing?: PricingConfig;
+  budgetLimits?: BudgetLimits;
+  scanHistory?: ScanRecord[];
+}): ScanCostTracker {
+  return {
+    pricing: options.pricing,
+    budgetLimits: options.budgetLimits,
+    scanHistory: options.scanHistory,
+    totalTokens: 0,
+    totalCostUsd: 0,
+    warned: false,
+    lastAction: 'continue',
+  };
+}
+
+/**
+ * Record an AI call's token usage against the tracker. Called after each
+ * successful executeCheck().
+ */
+export function recordUsage(
+  tracker: ScanCostTracker,
+  usage: TokenUsage | undefined,
+  model: string,
+): void {
+  if (!usage || !tracker.pricing) return;
+  const cost = calculateCost(usage, model, tracker.pricing);
+  tracker.totalTokens += usage.totalTokens;
+  tracker.totalCostUsd += cost.totalCost;
+  tracker.lastCostSource = cost.source;
+  tracker.lastCostReportedBy = cost.reportedBy;
+  tracker.lastCostCoveredBySubscription = cost.coveredBySubscription;
+}
+
+/**
+ * Check the budget before an AI call. Logs a warning the first time the warn
+ * threshold is crossed; throws BudgetExceededError when the abort threshold is
+ * crossed.
+ */
+export function preflightBudget(tracker: ScanCostTracker): void {
+  if (!tracker.budgetLimits) return;
+  const status = checkBudget(
+    {
+      currentScanCostUsd: tracker.totalCostUsd,
+      currentScanTokens: tracker.totalTokens,
+      history: tracker.scanHistory,
+    },
+    tracker.budgetLimits,
+  );
+  tracker.lastAction = status.action;
+  tracker.lastReason = status.reason;
+  if (status.action === 'abort') {
+    throw new BudgetExceededError(status.reason ?? 'Budget limit exceeded');
+  }
+  if (status.action === 'warn' && !tracker.warned) {
+    tracker.warned = true;
+    logProgress(TAG, `Budget warning: ${status.reason ?? 'approaching limit'}`);
+  }
+}

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -11,6 +11,7 @@
  *   E70xx — Budget / cost controls
  *   E71xx — Script discovery
  *   E72xx — Result handlers (PR comments, issue trackers, notifications)
+ *   E8xxx — Judge stage
  *   E9xxx — Internal/fatal
  */
 
@@ -70,6 +71,8 @@ export const ERROR_CODES = {
 
   // E72xx — Result handlers
   E7201: ec('E7201', 'PR comment posting failed'),
+  // E8xxx — Judge stage
+  E8001: ec('E8001', 'Judge mock response file not found'),
 
   // E9xxx — Internal
   E9001: ec('E9001', 'Fatal internal error'),

--- a/src/formatters/sarif-formatter.ts
+++ b/src/formatters/sarif-formatter.ts
@@ -4,7 +4,7 @@
  * code scanning UIs (e.g. GitHub Code Scanning) and SARIF viewers.
  */
 
-import type { ScanResults, SecurityIssue, DataFlowStep, ValidationRecord, CIMetadata } from '../types.js';
+import type { ScanResults, SecurityIssue, DataFlowStep, ValidationRecord, CIMetadata, JudgeVerdict } from '../types.js';
 import type { OutputFormatter } from './types.js';
 
 /** Maps aghast severity to SARIF result level. */
@@ -55,11 +55,20 @@ interface SarifSuppression {
   justification?: string;
 }
 
+/** Maps judge verdict to SARIF result kind (decision #11). */
+function mapVerdictToKind(verdict: JudgeVerdict['verdict']): 'open' | 'false' | 'review' {
+  switch (verdict) {
+    case 'true_positive': return 'open';
+    case 'false_positive': return 'false';
+    case 'uncertain': return 'review';
+  }
+}
+
 interface SarifResult {
   ruleId: string;
   message: { text: string };
   level?: 'error' | 'warning' | 'note';
-  kind?: 'fail' | 'pass' | 'open' | 'review' | 'notApplicable' | 'informational';
+  kind?: 'fail' | 'pass' | 'open' | 'review' | 'notApplicable' | 'informational' | 'false';
   locations: Array<{
     physicalLocation: {
       artifactLocation: { uri: string };
@@ -68,6 +77,8 @@ interface SarifResult {
   }>;
   codeFlows?: SarifCodeFlow[];
   suppressions?: SarifSuppression[];
+  /** Non-standard run context (judge verdict, flag source) per the SARIF property bag convention. */
+  properties?: Record<string, unknown>;
 }
 
 /**
@@ -76,7 +87,7 @@ interface SarifResult {
  */
 interface SarifInvocation {
   executionSuccessful: boolean;
-  properties?: Record<string, string>;
+  properties?: Record<string, unknown>;
 }
 
 interface SarifLog {
@@ -189,6 +200,27 @@ export class SarifFormatter implements OutputFormatter {
 
       if (issue.dataFlow && issue.dataFlow.length > 0) {
         result.codeFlows = [this.buildCodeFlow(issue.dataFlow)];
+      }
+
+      // Judge verdict → SARIF kind and properties
+      if (issue.judge) {
+        result.kind = mapVerdictToKind(issue.judge.verdict);
+        result.properties = {
+          ...(result.properties ?? {}),
+          judge: {
+            verdict: issue.judge.verdict,
+            confidence: issue.judge.confidence,
+            rationale: issue.judge.rationale,
+            model: issue.judge.model,
+            provider: issue.judge.provider,
+          },
+        };
+      }
+      if (issue.flagSource) {
+        result.properties = {
+          ...(result.properties ?? {}),
+          flagSource: issue.flagSource,
+        };
       }
 
       return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@
 import 'dotenv/config';
 import { readFile, writeFile, stat, mkdir, readdir } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
-import { runMultiScanWithCost } from './scan-runner.js';
+import { runMultiScanWithCost, type MultiScanOptions } from './scan-runner.js';
+import type { JudgeOptions } from './judge.js';
 import { loadDefaultPricing, mergePricing, formatCostSourceLabel } from './cost-calculator.js';
 import type { BudgetLimits } from './budget.js';
 import { saveScanRecord, queryScanHistory, type ScanRecord } from './scan-history.js';
@@ -24,7 +25,7 @@ import {
 import { clearRepoSnapshotCache } from './repo-scan.js';
 import { analyzeRepository } from './repository-analyzer.js';
 import { loadRuntimeConfig } from './runtime-config.js';
-import { logProgress, logDebug, setLogLevel, createTimer, isValidLogLevel, initFileHandler, closeAllHandlers, getAvailableLogTypes } from './logging.js';
+import { logProgress, logDebug, logWarn, setLogLevel, createTimer, isValidLogLevel, initFileHandler, closeAllHandlers, getAvailableLogTypes } from './logging.js';
 import type { LogLevel } from './logging.js';
 import { MOCK_MODEL_NAME, DEFAULT_MODEL, type AgentProvider } from './types.js';
 import { getFormatter } from './formatters/index.js';
@@ -41,6 +42,23 @@ import { postPRComments } from './result-handlers/pr-comment-handler.js';
 import { createRequire } from 'node:module';
 
 const TAG = 'aghast';
+
+async function createMockJudgeProvider(modelOverride?: string): Promise<AgentProvider> {
+  // AGHAST_MOCK_JUDGE='true' → default TP response; AGHAST_MOCK_JUDGE=<path> → read from that file
+  const mockJudgeValue = process.env.AGHAST_MOCK_JUDGE;
+  let rawResponse = '{"verdict":"true_positive","confidence":1.0,"rationale":"mock"}';
+  if (mockJudgeValue && mockJudgeValue !== 'true') {
+    try {
+      rawResponse = await readFile(resolve(mockJudgeValue), 'utf-8');
+    } catch (err) {
+      throw new Error(formatError(ERROR_CODES.E8001, `path: ${mockJudgeValue}`), { cause: err });
+    }
+  }
+  const provider = new MockAgentProvider({ rawResponse });
+  await provider.initialize({});
+  provider.setModel?.(modelOverride ?? MOCK_MODEL_NAME);
+  return provider;
+}
 
 async function createMockProvider(): Promise<AgentProvider> {
   // AGHAST_MOCK_AI='true' → default empty response; AGHAST_MOCK_AI=<path> → read from that file
@@ -129,6 +147,14 @@ PR comment options (post findings as inline GitHub PR review comments):
   --base-sha <sha>           Base commit SHA (default: $GITHUB_BASE_SHA)
   --head-sha <sha>           Head commit SHA
                              (default: $GITHUB_HEAD_SHA / $GITHUB_SHA)
+Judge stage options (enables a post-scan LLM re-evaluation of findings):
+  --judge-model <model>      Enable the judge stage using this model. Required
+                             to activate the stage (no separate --judge flag).
+  --judge-provider <name>    Agent provider for the judge (default: scan provider)
+  --judge-concurrency <n>    Max concurrent judge calls (default: 5)
+  --judge-drop-false-positives  Remove issues judged as false positives from output
+  --judge-min-confidence <f> Demote true_positive verdicts with confidence < this
+                             value to uncertain (0.0–1.0)
 
 Environment variables:
   ANTHROPIC_API_KEY           API key for Claude. If unset, AI-based checks fall
@@ -150,6 +176,11 @@ Environment variables:
   GITHUB_HEAD_SHA             Default for --head-sha
   GITHUB_SHA                  Fallback for --head-sha (auto-set in GitHub Actions)
   GH_TOKEN / GITHUB_TOKEN     Auth for the gh CLI when posting PR comments
+  AGHAST_JUDGE_MODEL          Judge model (presence enables the stage; CLI --judge-model takes precedence)
+  AGHAST_JUDGE_PROVIDER       Judge provider (CLI --judge-provider takes precedence)
+  AGHAST_MOCK_JUDGE           Enables mock judge provider. Set to "true" for default
+                              {"verdict":"true_positive","confidence":1.0,"rationale":"mock"},
+                              or set to a file path for a custom fixture
 
 Examples:
   aghast scan ./my-repo --config-dir ./my-checks
@@ -180,6 +211,11 @@ function parseArgs(args: string[]): {
   prRepo?: string;
   baseSha?: string;
   headSha?: string;
+  judgeModel?: string;
+  judgeProvider?: string;
+  judgeConcurrency?: number;
+  judgeDropFalsePositives?: boolean;
+  judgeMinConfidence?: number;
 } {
   if (args.length < 1 || args.includes('--help') || args.includes('-h')) {
     console.log(SCAN_HELP);
@@ -211,6 +247,11 @@ function parseArgs(args: string[]): {
   let prRepo: string | undefined;
   let baseSha: string | undefined;
   let headSha: string | undefined;
+  let judgeModel: string | undefined;
+  let judgeProvider: string | undefined;
+  let judgeConcurrency: number | undefined;
+  const judgeDropFalsePositives = args.includes('--judge-drop-false-positives');
+  let judgeMinConfidence: number | undefined;
 
   for (let i = startIdx; i < args.length; i++) {
     switch (args[i]) {
@@ -399,9 +440,60 @@ function parseArgs(args: string[]): {
         i++;
         break;
       }
+      case '--judge-model': {
+        judgeModel = args[i + 1];
+        if (!judgeModel) {
+          console.error(formatError(ERROR_CODES.E1001, '--judge-model requires a model name argument'));
+          process.exit(1);
+        }
+        i++;
+        break;
+      }
+      case '--judge-provider': {
+        judgeProvider = args[i + 1];
+        if (!judgeProvider) {
+          console.error(formatError(ERROR_CODES.E1001, '--judge-provider requires a provider name argument'));
+          process.exit(1);
+        }
+        i++;
+        break;
+      }
+      case '--judge-concurrency': {
+        const raw = args[i + 1];
+        if (!raw) {
+          console.error(formatError(ERROR_CODES.E1001, '--judge-concurrency requires a number argument'));
+          process.exit(1);
+        }
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) {
+          console.error(formatError(ERROR_CODES.E1001, `--judge-concurrency must be a positive integer (got "${raw}")`));
+          process.exit(1);
+        }
+        judgeConcurrency = n;
+        i++;
+        break;
+      }
+      case '--judge-min-confidence': {
+        const raw = args[i + 1];
+        if (!raw) {
+          console.error(formatError(ERROR_CODES.E1001, '--judge-min-confidence requires a number argument (0.0–1.0)'));
+          process.exit(1);
+        }
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < 0 || n > 1) {
+          console.error(formatError(ERROR_CODES.E1001, `--judge-min-confidence must be between 0 and 1 (got "${raw}")`));
+          process.exit(1);
+        }
+        judgeMinConfidence = n;
+        i++;
+        break;
+      }
+      // Boolean flags: their values are read via args.includes() above, but each
+      // still needs a case here — without one it reaches `default` and is
+      // rejected as an unknown option.
       case '--fail-on-check-failure':
       case '--debug':
-        // Boolean flags are handled above via includes().
+      case '--judge-drop-false-positives':
         break;
       default: {
         const arg = args[i];
@@ -421,6 +513,9 @@ function parseArgs(args: string[]): {
     diffRef, diffFile,
     budgetLimitCost, budgetLimitTokens,
     prNumber, prRepo, baseSha, headSha,
+    judgeModel, judgeProvider, judgeConcurrency,
+    judgeDropFalsePositives: judgeDropFalsePositives || undefined,
+    judgeMinConfidence,
   };
 }
 
@@ -834,8 +929,47 @@ export async function runScan(args: string[]): Promise<void> {
     }
   }
 
+  // ─── Judge stage setup ───
+  // Stage is enabled iff a judge model is resolvable from any config source.
+  // Provider defaults to the scan provider if not explicitly set (decision #8).
+  const resolvedJudgeModel = parsed.judgeModel ?? process.env.AGHAST_JUDGE_MODEL ?? runtimeConfig.judge?.model;
+  const resolvedJudgeProvider = parsed.judgeProvider ?? process.env.AGHAST_JUDGE_PROVIDER ?? runtimeConfig.judge?.provider;
+  const resolvedJudgeConcurrency = parsed.judgeConcurrency ?? runtimeConfig.judge?.concurrency;
+  const resolvedJudgeDropFP = parsed.judgeDropFalsePositives ?? runtimeConfig.judge?.dropFalsePositives;
+  const resolvedJudgeMinConf = parsed.judgeMinConfidence ?? runtimeConfig.judge?.minConfidence;
+
+  const mockJudgeEnv = process.env.AGHAST_MOCK_JUDGE;
+  const useMockJudge = !!(mockJudgeEnv && mockJudgeEnv !== 'false');
+
+  let judgeOptions: JudgeOptions | undefined;
+  if (resolvedJudgeModel) {
+    const judgeProviderName = resolvedJudgeProvider ?? agentProviderName;
+    let judgeProvider: import('./types.js').AgentProvider;
+    if (useMockJudge) {
+      logProgress(TAG, `Mock judge provider enabled via AGHAST_MOCK_JUDGE=${mockJudgeEnv}`);
+      judgeProvider = await createMockJudgeProvider(resolvedJudgeModel);
+    } else if (useMock) {
+      // If scan uses mock, use mock for judge too (tests that set AGHAST_MOCK_AI but not AGHAST_MOCK_JUDGE)
+      logWarn(TAG, 'AGHAST_MOCK_AI is set; judge provider will also use mock (set AGHAST_MOCK_JUDGE to control judge response)');
+      judgeProvider = await createMockJudgeProvider(resolvedJudgeModel);
+    } else {
+      const jp = createProviderByName(judgeProviderName);
+      await jp.initialize({ apiKey: process.env.ANTHROPIC_API_KEY, model: resolvedJudgeModel });
+      judgeProvider = jp;
+    }
+    judgeOptions = {
+      provider: judgeProvider,
+      providerName: useMockJudge || useMock ? 'mock' : judgeProviderName,
+      model: resolvedJudgeModel,
+      concurrency: resolvedJudgeConcurrency,
+      dropFalsePositives: resolvedJudgeDropFP,
+      minConfidence: resolvedJudgeMinConf,
+    };
+    logProgress(TAG, `Judge stage enabled: model=${resolvedJudgeModel}, provider=${judgeOptions.providerName}`);
+  }
+
   try {
-    const outcome = await runMultiScanWithCost({
+    const scanOptions: MultiScanOptions = {
       repositoryPath: effectiveRepoPath,
       checks: checksWithDetails,
       agentProvider: provider,
@@ -853,7 +987,9 @@ export async function runScan(args: string[]): Promise<void> {
       // Prefer the provider's resolved auth mode (covers auto-detected local login);
       // fall back to the env var for providers without the concept (e.g. mock).
       isLocalClaude: provider?.isLocalMode?.() ?? (process.env.AGHAST_LOCAL_CLAUDE === 'true'),
-    });
+      judge: judgeOptions,
+    };
+    const outcome = await runMultiScanWithCost(scanOptions);
     const results = outcome.results;
 
     // Resolve output path: --output flag > runtime config dir > default
@@ -915,6 +1051,11 @@ export async function runScan(args: string[]): Promise<void> {
       const label = formatCostSourceLabel(outcome.costSource, outcome.costReportedBy, outcome.costCoveredBySubscription);
       const equiv = outcome.costCoveredBySubscription ? ' equivalent' : '';
       console.log(`  Cost:          $${outcome.totalCostUsd.toFixed(4)}${equiv}  ${label}`);
+    }
+    if (outcome.judgeSummary) {
+      const js = outcome.judgeSummary;
+      const truePos = js.judgedIssues - js.falsePositives - js.uncertainJudgements;
+      console.log(`  Judged:        ${js.judgedIssues} issues: ${truePos} true / ${js.falsePositives} false / ${js.uncertainJudgements} uncertain (judge: ${outcome.judgeModel})`);
     }
     console.log(`  Duration:      ${globalTimer.elapsedStr()}`);
     console.log(`  Results:       ${resolvedOutputPath}`);

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -1,0 +1,336 @@
+/**
+ * LLM judge stage: re-evaluates aggregated SecurityIssues after all checks have run.
+ * Annotates each issue with a verdict (true_positive / false_positive / uncertain),
+ * confidence, and rationale. Runs as a separate pipeline stage in runMultiScanWithCost.
+ */
+
+import { logProgress, logDebug, logWarn, createTimer } from './logging.js';
+import { type AgentProvider, type SecurityIssue, type JudgeVerdict } from './types.js';
+import { BudgetExceededError } from './budget.js';
+import { type ScanCostTracker, preflightBudget, recordUsage } from './cost-tracker.js';
+import { type AbortHandle, mapWithConcurrency } from './concurrency.js';
+
+const TAG = 'judge';
+const DEFAULT_JUDGE_CONCURRENCY = 5;
+const DEFAULT_JUDGE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Thrown by the internal timeout race when a judge provider call exceeds
+ * DEFAULT_JUDGE_TIMEOUT_MS. Module-private: callers distinguish it via
+ * `instanceof JudgeTimeoutError` inside this module only.
+ */
+class JudgeTimeoutError extends Error {
+  constructor(timeoutSeconds: number) {
+    super(`Judge provider timed out after ${timeoutSeconds}s`);
+  }
+}
+
+export interface JudgeOptions {
+  provider: AgentProvider;
+  providerName: string;
+  model: string;
+  concurrency?: number;
+  dropFalsePositives?: boolean;
+  minConfidence?: number;
+}
+
+/** Map from check ID to the check's markdown instructions (used in judge prompt). */
+export type CheckInstructionsMap = Map<string, string>;
+
+/**
+ * Parse a raw judge response into a JudgeVerdict.
+ * Returns undefined if the response is not parseable or lacks required fields.
+ */
+export function parseJudgeResponse(raw: string): Pick<JudgeVerdict, 'verdict' | 'confidence' | 'rationale'> | undefined {
+  const tryParse = (text: string): unknown => {
+    try { return JSON.parse(text); } catch { return undefined; }
+  };
+
+  let parsed: unknown = tryParse(raw);
+  if (parsed === undefined) {
+    const fence = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fence?.[1]) parsed = tryParse(fence[1]);
+  }
+  if (parsed === undefined) {
+    const firstBrace = raw.indexOf('{');
+    const lastBrace = raw.lastIndexOf('}');
+    if (firstBrace !== -1 && lastBrace > firstBrace) {
+      parsed = tryParse(raw.slice(firstBrace, lastBrace + 1));
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const obj = parsed as Record<string, unknown>;
+
+  const validVerdicts = ['true_positive', 'false_positive', 'uncertain'];
+  if (typeof obj.verdict !== 'string' || !validVerdicts.includes(obj.verdict)) return undefined;
+  if (typeof obj.confidence !== 'number' || obj.confidence < 0 || obj.confidence > 1) return undefined;
+  if (typeof obj.rationale !== 'string') return undefined;
+
+  return {
+    verdict: obj.verdict as JudgeVerdict['verdict'],
+    confidence: obj.confidence,
+    rationale: obj.rationale,
+  };
+}
+
+/** Build the judge prompt for a single issue. */
+function buildJudgePrompt(issue: SecurityIssue, checkInstructions: string | undefined): string {
+  const lines: string[] = [];
+  lines.push('You are a security finding validator. Review the following reported security issue and determine if it is a genuine vulnerability (true positive), a false alarm (false positive), or uncertain.');
+  lines.push('');
+  lines.push('Respond with JSON only:');
+  lines.push('{ "verdict": "true_positive" | "false_positive" | "uncertain", "confidence": <0.0-1.0>, "rationale": "<brief explanation>" }');
+  lines.push('');
+  lines.push(`## Check: ${issue.checkName}`);
+
+  if (checkInstructions) {
+    lines.push('');
+    lines.push('### What this check looks for:');
+    lines.push(checkInstructions);
+  }
+
+  lines.push('');
+  lines.push('## Reported Finding');
+  lines.push(`File: ${issue.file}`);
+  lines.push(`Lines: ${issue.startLine}–${issue.endLine}`);
+  lines.push(`Description: ${issue.description}`);
+
+  if (issue.codeSnippet) {
+    lines.push('');
+    lines.push('### Code snippet:');
+    lines.push('```');
+    lines.push(issue.codeSnippet);
+    lines.push('```');
+  }
+
+  if (issue.dataFlow && issue.dataFlow.length > 0) {
+    lines.push('');
+    lines.push('### Data flow:');
+    for (const step of issue.dataFlow) {
+      lines.push(`  ${step.file}:${step.lineNumber} — ${step.label}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Is this a real security issue? Respond with JSON only.');
+  return lines.join('\n');
+}
+
+/**
+ * Run the judge stage over all collected issues.
+ * Mutates each issue in place by attaching a `judge` field.
+ * Returns the issues array (same reference, mutated).
+ */
+export async function runJudge(
+  issues: SecurityIssue[],
+  checksById: Map<string, { check: { judge?: boolean }; instructions: string | undefined }>,
+  repositoryPath: string,
+  options: JudgeOptions,
+  costTracker: ScanCostTracker,
+): Promise<SecurityIssue[]> {
+  if (issues.length === 0) return issues;
+
+  const effectiveConcurrency = options.concurrency ?? DEFAULT_JUDGE_CONCURRENCY;
+  const judgeModel = options.model;
+
+  // Apply per-check model
+  options.provider.setModel?.(judgeModel);
+
+  logProgress(TAG, `Judging ${issues.length} issues (model: ${judgeModel}, concurrency: ${effectiveConcurrency})`);
+  const judgeTimer = createTimer();
+
+  const abortHandle: AbortHandle = { aborted: false };
+
+  await mapWithConcurrency(
+    issues,
+    effectiveConcurrency,
+    async (issue, _idx) => {
+      const checkEntry = checksById.get(issue.checkId);
+
+      // Per-check opt-out: skip if check.judge === false
+      if (checkEntry?.check.judge === false) {
+        logDebug(TAG, `Skipping issue from check "${issue.checkId}" (judge: false)`);
+        return;
+      }
+
+      const checkInstructions = checkEntry?.instructions;
+      const prompt = buildJudgePrompt(issue, checkInstructions);
+
+      try {
+        preflightBudget(costTracker);
+      } catch (budgetErr) {
+        if (budgetErr instanceof BudgetExceededError) {
+          abortHandle.aborted = true;
+          abortHandle.reason = budgetErr;
+          throw budgetErr;
+        }
+        throw budgetErr;
+      }
+
+      logDebug(TAG, `Judging issue: ${issue.checkId} @ ${issue.file}:${issue.startLine}`);
+
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      try {
+        const agentResponse = await Promise.race([
+          options.provider.executeCheck(prompt, repositoryPath, `[judge:${issue.checkId}]`),
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
+              () => reject(new JudgeTimeoutError(DEFAULT_JUDGE_TIMEOUT_MS / 1000)),
+              DEFAULT_JUDGE_TIMEOUT_MS,
+            );
+          }),
+        ]).finally(() => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+        });
+
+        recordUsage(costTracker, agentResponse.tokenUsage, judgeModel);
+
+        const parsed = parseJudgeResponse(agentResponse.raw);
+        if (!parsed) {
+          logDebug(TAG, `Judge returned malformed response for ${issue.checkId}@${issue.file}:${issue.startLine}`);
+          issue.judge = {
+            verdict: 'uncertain',
+            confidence: 0,
+            rationale: 'judge failed: malformed response',
+            model: judgeModel,
+            provider: options.providerName,
+            tokenUsage: agentResponse.tokenUsage,
+          };
+          return;
+        }
+
+        // Apply minConfidence demotion: true_positive below threshold → uncertain
+        let { verdict, rationale } = parsed;
+        const { confidence } = parsed;
+        if (
+          verdict === 'true_positive' &&
+          options.minConfidence !== undefined &&
+          confidence < options.minConfidence
+        ) {
+          logDebug(TAG, `Demoting true_positive to uncertain (confidence ${confidence} < minConfidence ${options.minConfidence})`);
+          verdict = 'uncertain';
+          rationale = `${rationale} [demoted: confidence ${confidence.toFixed(2)} < minConfidence ${options.minConfidence}]`;
+        }
+
+        issue.judge = {
+          verdict,
+          confidence,
+          rationale,
+          model: judgeModel,
+          provider: options.providerName,
+          tokenUsage: agentResponse.tokenUsage,
+        };
+        logDebug(TAG, `Judge verdict: ${verdict} (confidence: ${confidence}) for ${issue.checkId}@${issue.file}:${issue.startLine}`);
+      } catch (err) {
+        if (err instanceof BudgetExceededError) throw err;
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        if (err instanceof JudgeTimeoutError) {
+          logWarn(TAG, `Judge timed out for ${issue.checkId}@${issue.file}:${issue.startLine} — token usage for this call was not recorded`);
+        }
+        logDebug(TAG, `Judge error for ${issue.checkId}: ${errorMsg}`);
+        issue.judge = {
+          verdict: 'uncertain',
+          confidence: 0,
+          rationale: `judge failed: ${errorMsg}`,
+          model: judgeModel,
+          provider: options.providerName,
+        };
+      }
+    },
+    abortHandle,
+  );
+
+  logProgress(TAG, `Judge stage completed in ${judgeTimer.elapsedStr()}`);
+  return issues;
+}
+
+/**
+ * Recompute per-check statuses and summary counts after the judge stage.
+ *
+ * Recomputation order (per issue 290 design):
+ * 1. Apply minConfidence demotion (already done in runJudge per-issue)
+ * 2. Drop false positives if dropFalsePositives is set
+ * 3. Escalate checks whose remaining issues are all uncertain → FLAG
+ * 4. Set flagSource on issues
+ * 5. Recompute summary counts
+ *
+ * Returns the filtered issues array and updated check summaries.
+ */
+export function applyJudgeResults(
+  allIssues: SecurityIssue[],
+  allCheckSummaries: import('./types.js').CheckExecutionSummary[],
+  options: Pick<JudgeOptions, 'dropFalsePositives'>,
+): {
+  filteredIssues: SecurityIssue[];
+  judgedIssues: number;
+  falsePositives: number;
+  uncertainJudgements: number;
+} {
+  // Count judge verdicts across all judged issues
+  let judgedCount = 0;
+  let fpCount = 0;
+  let uncertainCount = 0;
+
+  // Step 1: Remove confirmed false positives if dropFalsePositives is set
+  let filteredIssues = allIssues;
+  if (options.dropFalsePositives) {
+    filteredIssues = allIssues.filter((issue) => {
+      if (!issue.judge) return true; // No verdict: keep
+      if (issue.judge.verdict === 'false_positive') return false; // Drop FP
+      return true;
+    });
+  }
+
+  // Count verdicts from allIssues (pre-filter) so that dropped FPs are included
+  // in judgedIssues and falsePositives regardless of dropFalsePositives.
+  for (const issue of allIssues) {
+    if (issue.judge) {
+      judgedCount++;
+      if (issue.judge.verdict === 'false_positive') fpCount++;
+      if (issue.judge.verdict === 'uncertain') uncertainCount++;
+    }
+  }
+
+  // Step 2: Group remaining issues by checkId
+  const issuesByCheck = new Map<string, SecurityIssue[]>();
+  for (const issue of filteredIssues) {
+    const existing = issuesByCheck.get(issue.checkId);
+    if (existing) {
+      existing.push(issue);
+    } else {
+      issuesByCheck.set(issue.checkId, [issue]);
+    }
+  }
+
+  // Step 3: Recompute per-check status based on remaining issues
+  for (const summary of allCheckSummaries) {
+    const checkIssues = issuesByCheck.get(summary.checkId) ?? [];
+
+    // Restore any check that was FAIL but lost all its issues to FP drops → PASS
+    if (summary.status === 'FAIL' && checkIssues.length === 0 && options.dropFalsePositives) {
+      summary.status = 'PASS';
+      summary.issuesFound = 0;
+    } else if (summary.status === 'FAIL' && checkIssues.length > 0) {
+      // Check if all remaining issues are uncertain → escalate to FLAG
+      const allUncertain = checkIssues.every(
+        (i) => i.judge && i.judge.verdict === 'uncertain',
+      );
+      if (allUncertain) {
+        summary.status = 'FLAG';
+        summary.issuesFound = checkIssues.length;
+        // Attach flagSource: "judge" to each uncertain issue
+        for (const issue of checkIssues) {
+          // Decision #9: flagSource:"check" wins if already set
+          if (!issue.flagSource) {
+            issue.flagSource = 'judge';
+          }
+        }
+      } else {
+        summary.issuesFound = checkIssues.length;
+      }
+    }
+  }
+
+  return { filteredIssues, judgedIssues: judgedCount, falsePositives: fpCount, uncertainJudgements: uncertainCount };
+}

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -200,5 +200,31 @@ export async function loadRuntimeConfig(configDir?: string, explicitPath?: strin
     }
   }
 
+  if (obj.judge !== undefined) {
+    if (typeof obj.judge !== 'object' || obj.judge === null || Array.isArray(obj.judge)) {
+      throw new Error(`Runtime config "${pathToLoad}": "judge" must be an object`);
+    }
+    const j = obj.judge as Record<string, unknown>;
+    if (j.provider !== undefined && typeof j.provider !== 'string') {
+      throw new Error(`Runtime config "${pathToLoad}": "judge.provider" must be a string`);
+    }
+    if (j.model !== undefined && typeof j.model !== 'string') {
+      throw new Error(`Runtime config "${pathToLoad}": "judge.model" must be a string`);
+    }
+    if (j.concurrency !== undefined) {
+      if (typeof j.concurrency !== 'number' || !Number.isInteger(j.concurrency) || j.concurrency <= 0) {
+        throw new Error(`Runtime config "${pathToLoad}": "judge.concurrency" must be a positive integer`);
+      }
+    }
+    if (j.dropFalsePositives !== undefined && typeof j.dropFalsePositives !== 'boolean') {
+      throw new Error(`Runtime config "${pathToLoad}": "judge.dropFalsePositives" must be a boolean`);
+    }
+    if (j.minConfidence !== undefined) {
+      if (typeof j.minConfidence !== 'number' || j.minConfidence < 0 || j.minConfidence > 1) {
+        throw new Error(`Runtime config "${pathToLoad}": "judge.minConfidence" must be a number between 0 and 1`);
+      }
+    }
+  }
+
   return parsed as RuntimeConfig;
 }

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -41,10 +41,13 @@ import {
   type TokenUsage,
   type ValidationRecord,
 } from './types.js';
-import { calculateCost, type PricingConfig, type CostBreakdown } from './cost-calculator.js';
-import { checkBudget, BudgetExceededError, type BudgetLimits } from './budget.js';
+import type { PricingConfig, CostBreakdown } from './cost-calculator.js';
+import { BudgetExceededError, type BudgetLimits } from './budget.js';
 import type { ScanRecord } from './scan-history.js';
 import { collectCIMetadata } from './ci-metadata.js';
+import { type ScanCostTracker, createCostTracker, recordUsage, preflightBudget } from './cost-tracker.js';
+import { type AbortHandle, mapWithConcurrency } from './concurrency.js';
+import { type JudgeOptions, runJudge, applyJudgeResults } from './judge.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TAG = 'scan';
@@ -179,55 +182,6 @@ async function getVersion(): Promise<string> {
   }
 }
 
-/** Handle for signaling abort to mapWithConcurrency workers. */
-interface AbortHandle {
-  aborted: boolean;
-  reason?: Error;
-}
-
-/**
- * Run an async function over items with bounded concurrency.
- * Spawns min(concurrency, items.length) workers that pull from a shared index.
- * Results are written to a pre-allocated array to preserve input order.
- *
- * If abortHandle is provided, workers stop picking up new items once
- * abortHandle.aborted is set to true. In-flight items complete naturally.
- */
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T, index: number) => Promise<R>,
-  abortHandle?: AbortHandle,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let nextIndex = 0;
-
-  async function worker(): Promise<void> {
-    while (nextIndex < items.length) {
-      if (abortHandle?.aborted) break;
-      // Safe without atomics: Node.js is single-threaded, so nextIndex++ is
-      // not interleaved — each worker awaits before looping, yielding to the
-      // event loop where the next worker reads and increments the same variable.
-      const i = nextIndex++;
-      results[i] = await fn(items[i], i);
-    }
-  }
-
-  const workerCount = Math.min(concurrency, items.length);
-  const workers: Promise<void>[] = [];
-  for (let w = 0; w < workerCount; w++) {
-    workers.push(worker());
-  }
-
-  // Use allSettled so in-flight items complete before we propagate errors
-  const settled = await Promise.allSettled(workers);
-  const firstRejection = settled.find((r) => r.status === 'rejected');
-  if (firstRejection && firstRejection.status === 'rejected') {
-    throw firstRejection.reason;
-  }
-
-  return results;
-}
 
 export interface MultiScanOptions {
   repositoryPath: string;
@@ -265,85 +219,18 @@ export interface MultiScanOptions {
   scanHistory?: ScanRecord[];
   /** true when AGHAST_LOCAL_CLAUDE=true — triggers budget warning if limits are also set */
   isLocalClaude?: boolean;
+  /** Judge stage options. The stage runs iff this is provided (model presence enforced by caller). */
+  judge?: JudgeOptions;
+  /**
+   * Map of checkId → check instructions content, used by the judge to frame its verdict.
+   * When omitted, the judge runs without check-specific context.
+   */
+  judgeCheckInstructions?: Map<string, string>;
 }
 
-/**
- * Tracks accumulated tokens/cost across a scan so the budget can be evaluated
- * before each AI call. Mutated in place by AI invocations.
- */
-export interface ScanCostTracker {
-  pricing?: PricingConfig;
-  budgetLimits?: BudgetLimits;
-  scanHistory?: ScanRecord[];
-  totalTokens: number;
-  totalCostUsd: number;
-  /** Cost source from the last recorded AI call. Used for banner labelling. */
-  lastCostSource?: CostBreakdown['source'];
-  lastCostReportedBy?: CostBreakdown['reportedBy'];
-  lastCostCoveredBySubscription?: boolean;
-  /** Set true after the first warn so we don't log it repeatedly. */
-  warned: boolean;
-  /** Most recent budget action returned to the runner. */
-  lastAction: 'continue' | 'warn' | 'abort';
-  /** Reason from the most recent non-continue check. */
-  lastReason?: string;
-}
-
-function createCostTracker(options: MultiScanOptions): ScanCostTracker {
-  return {
-    pricing: options.pricing,
-    budgetLimits: options.budgetLimits,
-    scanHistory: options.scanHistory,
-    totalTokens: 0,
-    totalCostUsd: 0,
-    warned: false,
-    lastAction: 'continue',
-  };
-}
-
-/**
- * Record an AI call's token usage against the tracker. Called after each
- * successful executeCheck().
- */
-function recordUsage(
-  tracker: ScanCostTracker,
-  usage: TokenUsage | undefined,
-  model: string,
-): void {
-  if (!usage || !tracker.pricing) return;
-  const cost = calculateCost(usage, model, tracker.pricing);
-  tracker.totalTokens += usage.totalTokens;
-  tracker.totalCostUsd += cost.totalCost;
-  tracker.lastCostSource = cost.source;
-  tracker.lastCostReportedBy = cost.reportedBy;
-  tracker.lastCostCoveredBySubscription = cost.coveredBySubscription;
-}
-
-/**
- * Check the budget before an AI call. Logs a warning the first time the warn
- * threshold is crossed; throws BudgetExceededError when the abort threshold is
- * crossed.
- */
-function preflightBudget(tracker: ScanCostTracker): void {
-  if (!tracker.budgetLimits) return;
-  const status = checkBudget(
-    {
-      currentScanCostUsd: tracker.totalCostUsd,
-      currentScanTokens: tracker.totalTokens,
-      history: tracker.scanHistory,
-    },
-    tracker.budgetLimits,
-  );
-  tracker.lastAction = status.action;
-  tracker.lastReason = status.reason;
-  if (status.action === 'abort') {
-    throw new BudgetExceededError(status.reason ?? 'Budget limit exceeded');
-  }
-  if (status.action === 'warn' && !tracker.warned) {
-    tracker.warned = true;
-    logProgress(TAG, `Budget warning: ${status.reason ?? 'approaching limit'}`);
-  }
-}
+// ScanCostTracker, createCostTracker, recordUsage, preflightBudget are imported from cost-tracker.ts
+// Re-export ScanCostTracker so existing consumers of scan-runner.ts don't break.
+export type { ScanCostTracker };
 
 /**
  * Generate a scanId in the format: scan-<timestamp>-<hash>
@@ -1164,6 +1051,10 @@ export interface MultiScanOutcome {
   budgetAborted?: boolean;
   /** Reason from the budget abort, when budgetAborted is true. */
   budgetAbortReason?: string;
+  /** Judge model name when the judge stage ran. */
+  judgeModel?: string;
+  /** Judge verdicts summary when the judge stage ran. */
+  judgeSummary?: { judgedIssues: number; falsePositives: number; uncertainJudgements: number };
 }
 
 /**
@@ -1208,7 +1099,11 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
   let budgetAbortReason: string | undefined;
 
   // Cost / budget tracking spans all checks in the scan.
-  const costTracker = createCostTracker(options);
+  const costTracker = createCostTracker({
+    pricing: options.pricing,
+    budgetLimits: options.budgetLimits,
+    scanHistory: options.scanHistory,
+  });
 
   // Track all models used during the scan
   const modelsUsed = new Set<string>();
@@ -1319,6 +1214,60 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
     }
   }
 
+  // ─── Judge stage ─────────────────────────────────────────────────────────────
+  // Runs after all checks complete (including budget-aborted scans — partial
+  // results still benefit from judging). Budget abort during the judge stage
+  // sets budgetAborted=true; partially-judged issues retain their verdicts.
+  let judgeSummary: { judgedIssues: number; falsePositives: number; uncertainJudgements: number } | undefined;
+  if (options.judge && allIssues.length > 0) {
+    // Only record the judge model when the judge actually runs (allIssues.length > 0)
+    modelsUsed.add(options.judge.model);
+    // Build a map of checkId → { check, instructions } for judge prompt context
+    const checksById = new Map<string, { check: { judge?: boolean }; instructions: string | undefined }>();
+    for (const { check, details } of checks) {
+      checksById.set(check.id, { check, instructions: details.content || undefined });
+    }
+    // Also merge in any additional instructions provided via judgeCheckInstructions
+    if (options.judgeCheckInstructions) {
+      for (const [id, instr] of options.judgeCheckInstructions) {
+        const existing = checksById.get(id);
+        if (existing) {
+          existing.instructions = instr;
+        } else {
+          checksById.set(id, { check: {}, instructions: instr });
+        }
+      }
+    }
+
+    try {
+      await runJudge(allIssues, checksById, repositoryPath, options.judge, costTracker);
+    } catch (err) {
+      if (err instanceof BudgetExceededError) {
+        budgetAborted = true;
+        budgetAbortReason = err.message;
+        logProgress(TAG, `Budget exceeded during judge stage: ${err.message}`);
+      } else {
+        throw err;
+      }
+    }
+
+    const judgeResult = applyJudgeResults(allIssues, allCheckSummaries, {
+      dropFalsePositives: options.judge.dropFalsePositives,
+    });
+    // Replace allIssues contents with filtered set
+    allIssues.splice(0, allIssues.length, ...judgeResult.filteredIssues);
+    judgeSummary = {
+      judgedIssues: judgeResult.judgedIssues,
+      falsePositives: judgeResult.falsePositives,
+      uncertainJudgements: judgeResult.uncertainJudgements,
+    };
+    logProgress(
+      TAG,
+      `Judge: ${judgeResult.judgedIssues} judged, ${judgeResult.falsePositives} false positives, ${judgeResult.uncertainJudgements} uncertain`,
+    );
+  }
+  // ─────────────────────────────────────────────────────────────────────────────
+
   const endTime = new Date();
   const executionTime = endTime.getTime() - startTime.getTime();
 
@@ -1329,6 +1278,21 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
     flaggedChecks: allCheckSummaries.filter((c) => c.status === 'FLAG').length,
     errorChecks: allCheckSummaries.filter((c) => c.status === 'ERROR').length,
     totalIssues: allIssues.length,
+    ...(judgeSummary ? {
+      judgedIssues: judgeSummary.judgedIssues,
+      falsePositives: judgeSummary.falsePositives,
+      uncertainJudgements: judgeSummary.uncertainJudgements,
+      // flaggedByCheck counts FLAG checks whose issues carry flagSource:'check'.
+      // No scan path currently sets flagSource:'check'; this is reserved for a
+      // future pre-judge FLAG escalation path (issue #290 decision #5 / v2).
+      // Until then this will always be 0 — intentional, not a bug.
+      flaggedByCheck: allCheckSummaries.filter(
+        (c) => c.status === 'FLAG' && allIssues.some((i) => i.checkId === c.checkId && i.flagSource === 'check'),
+      ).length,
+      flaggedByJudge: allCheckSummaries.filter(
+        (c) => c.status === 'FLAG' && allIssues.some((i) => i.checkId === c.checkId && i.flagSource === 'judge'),
+      ).length,
+    } : {}),
   };
 
   logProgress(TAG, `Scan completed in ${scanTimer.elapsedStr()}`);
@@ -1381,5 +1345,7 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
     costCoveredBySubscription: costTracker.lastCostCoveredBySubscription,
     budgetAborted,
     budgetAbortReason,
+    judgeModel: options.judge?.model,
+    judgeSummary,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,8 @@ export interface CheckDefinition {
   checkTarget?: CheckTargetDefinition;
   applicablePaths?: string[];
   excludedPaths?: string[];
+  /** Set to false to exclude this check's issues from the judge stage. */
+  judge?: boolean;
 }
 
 // --- A.1 Security Check (merged from Layer 1 + Layer 2) ---
@@ -100,6 +102,8 @@ export interface SecurityCheck {
   matchCriteria?: MatchCriteria;
   /** Execution order — lower runs first; unset sorts to end (stable). */
   priority?: number;
+  /** Set to false to exclude this check's issues from the judge stage. */
+  judge?: boolean;
 }
 
 // --- A.2 Check Target Definition ---
@@ -180,6 +184,17 @@ export interface DataFlowStep {
 
 // --- A.3 Security Issue ---
 
+export type JudgeVerdictValue = 'true_positive' | 'false_positive' | 'uncertain';
+
+export interface JudgeVerdict {
+  verdict: JudgeVerdictValue;
+  confidence: number; // 0..1
+  rationale: string;
+  model: string;
+  provider: string;
+  tokenUsage?: TokenUsage;
+}
+
 export interface SecurityIssue {
   checkId: string;
   checkName: string;
@@ -192,6 +207,10 @@ export interface SecurityIssue {
   confidence?: string;
   recommendation?: string;
   dataFlow?: DataFlowStep[];
+  /** Populated by the judge stage when enabled. */
+  judge?: JudgeVerdict;
+  /** Why the issue ended up in FLAG. Only set when the check status is FLAG. */
+  flagSource?: 'check' | 'judge';
 }
 
 // --- A.3b Check Response ---
@@ -385,6 +404,12 @@ export interface ScanSummary {
   flaggedChecks: number;
   errorChecks: number;
   totalIssues: number;
+  /** Set when the judge stage ran. */
+  judgedIssues?: number;
+  falsePositives?: number;
+  uncertainJudgements?: number;
+  flaggedByCheck?: number;
+  flaggedByJudge?: number;
 }
 
 // --- Runtime Configuration (spec Section 8.1) ---
@@ -407,6 +432,16 @@ export interface RuntimeBudgetConfig {
 export interface RuntimePricingConfig {
   currency?: string;
   models?: Record<string, { inputPerMillion: number; outputPerMillion: number; cacheReadPerMillion?: number; cacheWritePerMillion?: number }>;
+}
+
+export interface RuntimeJudgeConfig {
+  /** Provider name for the judge stage. Defaults to the scan provider when absent. */
+  provider?: string;
+  /** Model for the judge stage. Presence enables the judge stage. */
+  model?: string;
+  concurrency?: number;
+  dropFalsePositives?: boolean;
+  minConfidence?: number;
 }
 
 export interface RuntimeConfig {
@@ -436,6 +471,8 @@ export interface RuntimeConfig {
   diffRef?: string;
   budget?: RuntimeBudgetConfig;
   pricing?: RuntimePricingConfig;
+  /** LLM judge stage configuration. Setting judge.model enables the stage. */
+  judge?: RuntimeJudgeConfig;
 }
 
 // --- A.6 Aggregated Report ---

--- a/tests/cli-judge.test.ts
+++ b/tests/cli-judge.test.ts
@@ -1,0 +1,509 @@
+/**
+ * CLI integration tests for the LLM judge stage.
+ *
+ * Spawns the real CLI with AGHAST_MOCK_AI=true and AGHAST_MOCK_JUDGE=<fixture>
+ * to verify the judge pipeline end-to-end without live API calls.
+ *
+ * Coverage:
+ * - Default off (no judge flags): identical output to pre-judge runs
+ * - Enabled annotation only: issues get judge field, summary.judgedIssues populated
+ * - --judge-drop-false-positives: FP issues removed, checks recomputed
+ * - Uncertain → FLAG escalation: check becomes FLAG, flagSource:"judge"
+ * - --judge-min-confidence: low-confidence TP demoted to uncertain → FLAG
+ * - Per-check judge: false opt-out: issue skipped by judge
+ * - Static-check issues judged (decision #3)
+ * - Judge-stage failure (malformed response): verdict uncertain, check FLAG
+ * - Mixed-provider mock: agentProvider.models lists both
+ * - SARIF output: properties.judge and flagSource surfaced
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  fixtureRepo,
+  singleCheckConfigDir,
+  semgrepOnlyConfigDir,
+  failFixtureRepo,
+  cli3TargetsSarif,
+  createScopedHelpers,
+} from './cli-test-helpers.js';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+
+const judgeResponses = resolve(testDir, 'fixtures', 'judge-responses');
+const judgeOptOutConfigDir = resolve(testDir, 'fixtures', 'cli-configs', 'judge-opt-out');
+
+const judgeTpFixture = resolve(judgeResponses, 'judge-tp-response.json');
+const judgeFpFixture = resolve(judgeResponses, 'judge-fp-response.json');
+const judgeUncertainFixture = resolve(judgeResponses, 'judge-uncertain-response.json');
+const judgeLowConfFixture = resolve(judgeResponses, 'judge-low-confidence-tp.json');
+const judgeMalformedFixture = resolve(judgeResponses, 'judge-malformed.txt');
+
+// Use scoped helpers so parallel test files don't collide on output files.
+const { runCLI: scopedRun, cleanupOutput, readResults, sarifOutputFile, runCLISarif } =
+  createScopedHelpers('judge');
+
+// ─── Default off ─────────────────────────────────────────────────────────────
+
+describe('CLI judge: default off (no judge flags)', () => {
+  afterEach(cleanupOutput);
+
+  it('PASS scan without judge produces no judge fields on issues', async () => {
+    const { exitCode } = await scopedRun({ AGHAST_MOCK_AI: 'true' });
+    assert.equal(exitCode, 0);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 0);
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.judgedIssues, undefined);
+  });
+
+  it('FAIL scan without judge produces no judge field on issues', async () => {
+    const { exitCode } = await scopedRun({ AGHAST_MOCK_AI: failFixtureRepo });
+    assert.equal(exitCode, 0);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].judge, undefined);
+    assert.equal(issues[0].flagSource, undefined);
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.judgedIssues, undefined);
+  });
+});
+
+// ─── Enabled — annotation only ───────────────────────────────────────────────
+
+describe('CLI judge: enabled (true_positive annotation)', () => {
+  afterEach(cleanupOutput);
+
+  it('FAIL scan with judge annotates issues with true_positive verdict', async () => {
+    const { exitCode } = await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    assert.equal(exitCode, 0);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1, 'Issue should not be dropped (TP)');
+    const judge = issues[0].judge as Record<string, unknown>;
+    assert.ok(judge, 'Issue should have judge field');
+    assert.equal(judge.verdict, 'true_positive');
+    assert.equal(judge.model, 'claude-opus-4-7');
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.judgedIssues, 1);
+    assert.equal(summary.falsePositives, 0);
+    assert.equal(summary.uncertainJudgements, 0);
+  });
+
+  it('check remains FAIL after true_positive judge verdict', async () => {
+    const { exitCode } = await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    assert.equal(exitCode, 0);
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FAIL');
+  });
+
+  it('banner includes judge summary line', async () => {
+    const { stdout, stderr } = await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const combined = stdout + stderr;
+    assert.ok(combined.includes('Judged:'), 'Banner should include Judged line');
+    assert.ok(combined.includes('claude-opus-4-7'), 'Banner should include judge model');
+  });
+});
+
+// ─── --judge-drop-false-positives ────────────────────────────────────────────
+
+describe('CLI judge: --judge-drop-false-positives', () => {
+  afterEach(cleanupOutput);
+
+  it('drops false-positive issues from output', async () => {
+    const { exitCode } = await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeFpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--judge-drop-false-positives',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    assert.equal(exitCode, 0);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 0, 'FP issue should be dropped');
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.totalIssues, 0);
+    assert.equal(summary.falsePositives, 1);
+  });
+
+  it('check that loses all issues becomes PASS after drop', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeFpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--judge-drop-false-positives',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'PASS');
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.passedChecks, 1);
+    assert.equal(summary.failedChecks, 0);
+  });
+
+  it('keeps false-positive issue when drop flag is NOT set', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeFpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1, 'FP issue should be retained without --judge-drop-false-positives');
+  });
+});
+
+// ─── Uncertain → FLAG escalation ─────────────────────────────────────────────
+
+describe('CLI judge: uncertain verdict → FLAG escalation', () => {
+  afterEach(cleanupOutput);
+
+  it('check whose only issues are uncertain becomes FLAG', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeUncertainFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FLAG');
+    const summary = results.summary as Record<string, unknown>;
+    assert.equal(summary.flaggedChecks, 1);
+    assert.equal(summary.failedChecks, 0);
+  });
+
+  it('uncertain issue has flagSource: "judge"', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeUncertainFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].flagSource, 'judge');
+    assert.equal(summary(results).uncertainJudgements, 1);
+  });
+});
+
+// ─── --judge-min-confidence ──────────────────────────────────────────────────
+
+describe('CLI judge: --judge-min-confidence', () => {
+  afterEach(cleanupOutput);
+
+  it('true_positive below threshold is demoted to uncertain (→ FLAG)', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeLowConfFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--judge-min-confidence', '0.5',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1);
+    const j = issues[0].judge as Record<string, unknown>;
+    assert.equal(j.verdict, 'uncertain', 'Low-confidence TP should be demoted to uncertain');
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FLAG', 'Check should escalate to FLAG');
+  });
+
+  it('true_positive above threshold is kept as true_positive', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--judge-min-confidence', '0.5',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    const j = issues[0].judge as Record<string, unknown>;
+    assert.equal(j.verdict, 'true_positive');
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FAIL');
+  });
+});
+
+// ─── Per-check judge: false opt-out ──────────────────────────────────────────
+
+describe('CLI judge: per-check judge: false opt-out', () => {
+  afterEach(cleanupOutput);
+
+  it('issues from a check with judge:false have no judge field', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', judgeOptOutConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1, 'Issue should still appear (not dropped)');
+    assert.equal(issues[0].judge, undefined, 'No judge field for opt-out check');
+    // Check stays FAIL (not escalated)
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FAIL');
+    const sum = results.summary as Record<string, unknown>;
+    assert.equal(sum.judgedIssues, 0, 'judgedIssues should be 0 when all checks opt out');
+  });
+});
+
+// ─── Static-check issues judged (decision #3) ────────────────────────────────
+
+describe('CLI judge: static-check issues are judged', () => {
+  afterEach(cleanupOutput);
+
+  it('static check findings receive judge annotation', async () => {
+    await scopedRun({
+      AGHAST_MOCK_SARIF: cli3TargetsSarif,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', semgrepOnlyConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.ok(issues.length > 0, 'Static findings should be present');
+    for (const issue of issues) {
+      const j = issue.judge as Record<string, unknown> | undefined;
+      assert.ok(j, 'Each static issue should have a judge field');
+      assert.equal(j.verdict, 'true_positive');
+    }
+    const sum = results.summary as Record<string, unknown>;
+    assert.equal(sum.judgedIssues, issues.length);
+  });
+});
+
+// ─── Judge failure → uncertain ───────────────────────────────────────────────
+
+describe('CLI judge: malformed response → uncertain', () => {
+  afterEach(cleanupOutput);
+
+  it('malformed judge response results in verdict:uncertain', async () => {
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeMalformedFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output', resolve(fixtureRepo, 'security_checks_results_judge.json'),
+    ]);
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1, 'Issue should still appear');
+    const j = issues[0].judge as Record<string, unknown>;
+    assert.ok(j, 'Issue should have judge field even on failure');
+    assert.equal(j.verdict, 'uncertain');
+    assert.ok(
+      (j.rationale as string).includes('judge failed:'),
+      'Rationale should mention judge failed',
+    );
+    // Check should FLAG-escalate (decision #6)
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'FLAG');
+    assert.equal(issues[0].flagSource, 'judge');
+  });
+});
+
+// ─── Mixed provider mock ─────────────────────────────────────────────────────
+
+describe('CLI judge: mixed provider mock', () => {
+  afterEach(cleanupOutput);
+
+  it('agentProvider.models includes both scan model and judge model when issues exist', async () => {
+    // Use failFixtureRepo so there are issues to judge: the judge actually runs
+    // and adds its model to modelsUsed. A PASS scan (no issues) skips the judge
+    // stage entirely and the judge model should NOT appear in the models list.
+    await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--model', 'claude-haiku-4-5',
+      '--judge-model', 'claude-opus-4-7',
+    ]);
+    const results = await readResults();
+    const ap = results.agentProvider as { name: string; models: string[] };
+    assert.ok(ap.models.includes('claude-haiku-4-5'), 'Scan model should be listed');
+    assert.ok(ap.models.includes('claude-opus-4-7'), 'Judge model should be listed');
+  });
+
+  it('agentProvider.models does not include judge model on PASS scan (no issues to judge)', async () => {
+    // When the scan produces no issues, the judge stage is skipped entirely.
+    // The judge model should not appear in the models list.
+    await scopedRun({
+      AGHAST_MOCK_AI: 'true',
+      AGHAST_MOCK_JUDGE: 'true',
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--model', 'claude-haiku-4-5',
+      '--judge-model', 'claude-opus-4-7',
+    ]);
+    const results = await readResults();
+    const ap = results.agentProvider as { name: string; models: string[] };
+    assert.ok(ap.models.includes('claude-haiku-4-5'), 'Scan model should be listed');
+    assert.ok(!ap.models.includes('claude-opus-4-7'), 'Judge model should NOT be listed when judge never ran');
+  });
+});
+
+// ─── SARIF output ────────────────────────────────────────────────────────────
+
+describe('CLI judge: SARIF output', () => {
+  afterEach(cleanupOutput);
+
+  it('SARIF results include properties.judge and kind for judged issues', async () => {
+    await runCLISarif({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output-format', 'sarif',
+    ]);
+
+    const { readFile } = await import('node:fs/promises');
+    const sarifText = await readFile(sarifOutputFile, 'utf-8');
+
+    const sarif = JSON.parse(sarifText) as Record<string, unknown>;
+    const runs = sarif.runs as Array<Record<string, unknown>>;
+    const results = runs[0].results as Array<Record<string, unknown>>;
+    assert.equal(results.length, 1);
+    const sarifResult = results[0];
+    assert.equal(sarifResult.kind, 'open', 'true_positive should map to kind:open');
+    const props = sarifResult.properties as Record<string, unknown>;
+    assert.ok(props, 'SARIF result should have properties');
+    assert.ok(props.judge, 'properties.judge should be present');
+    const judgeProps = props.judge as Record<string, unknown>;
+    assert.equal(judgeProps.verdict, 'true_positive');
+  });
+
+  it('SARIF result for false_positive has kind:false', async () => {
+    await runCLISarif({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeFpFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output-format', 'sarif',
+    ]);
+
+    const { readFile } = await import('node:fs/promises');
+    const sarifText = await readFile(sarifOutputFile, 'utf-8');
+
+    const sarif = JSON.parse(sarifText) as Record<string, unknown>;
+    const runs = sarif.runs as Array<Record<string, unknown>>;
+    const results = runs[0].results as Array<Record<string, unknown>>;
+    assert.equal(results[0].kind, 'false', 'false_positive should map to kind:false');
+  });
+
+  it('SARIF result for uncertain has kind:review', async () => {
+    await runCLISarif({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeUncertainFixture,
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--output-format', 'sarif',
+    ]);
+
+    const { readFile } = await import('node:fs/promises');
+    const sarifText = await readFile(sarifOutputFile, 'utf-8');
+
+    const sarif = JSON.parse(sarifText) as Record<string, unknown>;
+    const runs = sarif.runs as Array<Record<string, unknown>>;
+    const results = runs[0].results as Array<Record<string, unknown>>;
+    assert.equal(results[0].kind, 'review', 'uncertain should map to kind:review');
+  });
+});
+
+// ─── Budget abort during judge stage ─────────────────────────────────────────
+
+describe('CLI judge: budget abort during judge stage', () => {
+  afterEach(cleanupOutput);
+
+  it('budget abort during judge: exits non-zero, issues retain scan results without judge field', async () => {
+    // Strategy: use AGHAST_MOCK_TOKENS=1000000,0 so the scan records 1M tokens for
+    // the check call. Set --budget-limit-tokens=500000 so that the per-issue
+    // preflightBudget() call inside the judge worker sees 1M accumulated tokens
+    // (> 500000 limit) and throws BudgetExceededError before executeCheck is called.
+    // With only 1 issue in the fixture, the abort fires on the first (only) issue,
+    // leaving it without a `judge` field.
+    //
+    // Verifies:
+    //   - exit code is 1 (budget abort)
+    //   - E7001 appears in stderr
+    //   - output file was written (scan completed; 1 issue found)
+    //   - the issue has no `judge` field (judge was aborted before running)
+    const result = await scopedRun({
+      AGHAST_MOCK_AI: failFixtureRepo,
+      AGHAST_MOCK_JUDGE: judgeTpFixture,
+      AGHAST_MOCK_TOKENS: '1000000,0',
+    }, [
+      fixtureRepo, '--config-dir', singleCheckConfigDir,
+      '--judge-model', 'claude-opus-4-7',
+      '--model', 'claude-haiku-4-5',
+      '--budget-limit-tokens', '500000',
+    ]);
+    assert.equal(result.exitCode, 1, `expected exit 1 (budget abort), got ${result.exitCode}.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stderr, /E7001/, 'stderr should include E7001 budget error code');
+
+    const results = await readResults();
+    const issues = results.issues as Array<Record<string, unknown>>;
+    assert.equal(issues.length, 1, 'scan should have completed with 1 issue before judge abort');
+    assert.equal(issues[0].judge, undefined, 'issue should have no judge field (judge was aborted before running)');
+  });
+});
+
+// Helper to get summary as a typed Record
+function summary(results: Record<string, unknown>): Record<string, unknown> {
+  return results.summary as Record<string, unknown>;
+}

--- a/tests/fixtures/cli-configs/judge-opt-out/checks-config.json
+++ b/tests/fixtures/cli-configs/judge-opt-out/checks-config.json
@@ -1,0 +1,9 @@
+{
+  "checks": [
+    {
+      "id": "aghast-sql-injection",
+      "repositories": [],
+      "enabled": true
+    }
+  ]
+}

--- a/tests/fixtures/cli-configs/judge-opt-out/checks/aghast-sql-injection/aghast-sql-injection.json
+++ b/tests/fixtures/cli-configs/judge-opt-out/checks/aghast-sql-injection/aghast-sql-injection.json
@@ -1,0 +1,6 @@
+{
+  "id": "aghast-sql-injection",
+  "name": "SQL Injection Prevention",
+  "instructionsFile": "aghast-sql-injection.md",
+  "judge": false
+}

--- a/tests/fixtures/cli-configs/judge-opt-out/checks/aghast-sql-injection/aghast-sql-injection.md
+++ b/tests/fixtures/cli-configs/judge-opt-out/checks/aghast-sql-injection/aghast-sql-injection.md
@@ -1,0 +1,16 @@
+### SQL Injection Prevention
+
+#### Overview
+Validates that database queries use parameterized queries or prepared statements instead of string concatenation.
+
+#### What to Check
+1. Identify all database query execution points
+2. Check if user-supplied input is concatenated into SQL strings
+3. Verify parameterized queries or ORM methods are used
+
+#### Result
+- **PASS**: All database queries use parameterized queries or ORM methods
+- **FAIL**: Any database query uses string concatenation with user input
+
+#### Recommendation
+Replace string concatenation with parameterized queries. Use prepared statements or ORM query builders.

--- a/tests/fixtures/judge-responses/judge-fp-response.json
+++ b/tests/fixtures/judge-responses/judge-fp-response.json
@@ -1,0 +1,1 @@
+{"verdict":"false_positive","confidence":0.92,"rationale":"Input is sanitized before use, not actually exploitable."}

--- a/tests/fixtures/judge-responses/judge-low-confidence-tp.json
+++ b/tests/fixtures/judge-responses/judge-low-confidence-tp.json
@@ -1,0 +1,1 @@
+{"verdict":"true_positive","confidence":0.3,"rationale":"Possibly vulnerable but very uncertain."}

--- a/tests/fixtures/judge-responses/judge-malformed.txt
+++ b/tests/fixtures/judge-responses/judge-malformed.txt
@@ -1,0 +1,1 @@
+This is not valid JSON and cannot be parsed as a judge verdict.

--- a/tests/fixtures/judge-responses/judge-tp-response.json
+++ b/tests/fixtures/judge-responses/judge-tp-response.json
@@ -1,0 +1,1 @@
+{"verdict":"true_positive","confidence":0.95,"rationale":"This is a genuine SQL injection vulnerability."}

--- a/tests/fixtures/judge-responses/judge-uncertain-response.json
+++ b/tests/fixtures/judge-responses/judge-uncertain-response.json
@@ -1,0 +1,1 @@
+{"verdict":"uncertain","confidence":0.45,"rationale":"Cannot determine context without more information."}

--- a/tests/judge.test.ts
+++ b/tests/judge.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the judge stage (src/judge.ts).
+ * Tests verdict parsing, per-check opt-out, minConfidence demotion,
+ * dropFalsePositives filtering, and status recomputation.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJudgeResponse, applyJudgeResults } from '../src/judge.js';
+import type { SecurityIssue, CheckExecutionSummary } from '../src/types.js';
+
+// ─── parseJudgeResponse ───────────────────────────────────────────────────────
+
+describe('parseJudgeResponse', () => {
+  it('parses a valid true_positive JSON response', () => {
+    const raw = JSON.stringify({ verdict: 'true_positive', confidence: 0.9, rationale: 'Clearly a real issue' });
+    const result = parseJudgeResponse(raw);
+    assert.ok(result);
+    assert.equal(result.verdict, 'true_positive');
+    assert.equal(result.confidence, 0.9);
+    assert.equal(result.rationale, 'Clearly a real issue');
+  });
+
+  it('parses false_positive', () => {
+    const raw = JSON.stringify({ verdict: 'false_positive', confidence: 0.8, rationale: 'Not exploitable' });
+    const result = parseJudgeResponse(raw);
+    assert.ok(result);
+    assert.equal(result.verdict, 'false_positive');
+  });
+
+  it('parses uncertain', () => {
+    const raw = JSON.stringify({ verdict: 'uncertain', confidence: 0.5, rationale: 'Hard to tell' });
+    const result = parseJudgeResponse(raw);
+    assert.ok(result);
+    assert.equal(result.verdict, 'uncertain');
+  });
+
+  it('parses from a fenced code block', () => {
+    const raw = '```json\n{"verdict":"true_positive","confidence":1.0,"rationale":"Real"}\n```';
+    const result = parseJudgeResponse(raw);
+    assert.ok(result);
+    assert.equal(result.verdict, 'true_positive');
+  });
+
+  it('parses from prose containing JSON object', () => {
+    const raw = 'Based on my analysis: {"verdict":"false_positive","confidence":0.7,"rationale":"ok"}';
+    const result = parseJudgeResponse(raw);
+    assert.ok(result);
+    assert.equal(result.verdict, 'false_positive');
+  });
+
+  it('returns undefined for missing verdict', () => {
+    const raw = JSON.stringify({ confidence: 0.5, rationale: 'ok' });
+    assert.equal(parseJudgeResponse(raw), undefined);
+  });
+
+  it('returns undefined for invalid verdict value', () => {
+    const raw = JSON.stringify({ verdict: 'maybe', confidence: 0.5, rationale: 'ok' });
+    assert.equal(parseJudgeResponse(raw), undefined);
+  });
+
+  it('returns undefined for missing confidence', () => {
+    const raw = JSON.stringify({ verdict: 'true_positive', rationale: 'ok' });
+    assert.equal(parseJudgeResponse(raw), undefined);
+  });
+
+  it('returns undefined for confidence out of range (>1)', () => {
+    const raw = JSON.stringify({ verdict: 'true_positive', confidence: 1.5, rationale: 'ok' });
+    assert.equal(parseJudgeResponse(raw), undefined);
+  });
+
+  it('returns undefined for missing rationale', () => {
+    const raw = JSON.stringify({ verdict: 'true_positive', confidence: 0.5 });
+    assert.equal(parseJudgeResponse(raw), undefined);
+  });
+
+  it('returns undefined for non-JSON input', () => {
+    assert.equal(parseJudgeResponse('not json at all'), undefined);
+  });
+
+  it('returns undefined for empty string', () => {
+    assert.equal(parseJudgeResponse(''), undefined);
+  });
+});
+
+// ─── applyJudgeResults ────────────────────────────────────────────────────────
+
+function makeIssue(overrides: Partial<SecurityIssue> = {}): SecurityIssue {
+  return {
+    checkId: 'check-1',
+    checkName: 'Test Check',
+    file: 'src/foo.ts',
+    startLine: 10,
+    endLine: 15,
+    description: 'Test issue',
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<CheckExecutionSummary> = {}): CheckExecutionSummary {
+  return {
+    checkId: 'check-1',
+    checkName: 'Test Check',
+    status: 'FAIL',
+    issuesFound: 1,
+    executionTime: 100,
+    ...overrides,
+  };
+}
+
+describe('applyJudgeResults', () => {
+  it('keeps true_positive issues unchanged', () => {
+    const issue = makeIssue({
+      judge: { verdict: 'true_positive', confidence: 0.9, rationale: 'Real', model: 'opus', provider: 'claude-code' },
+    });
+    const summary = makeSummary({ issuesFound: 1 });
+    const { filteredIssues } = applyJudgeResults([issue], [summary], {});
+    assert.equal(filteredIssues.length, 1);
+    assert.equal(summary.status, 'FAIL');
+  });
+
+  it('keeps issues without judge verdict unchanged', () => {
+    const issue = makeIssue();
+    const summary = makeSummary();
+    const { filteredIssues } = applyJudgeResults([issue], [summary], {});
+    assert.equal(filteredIssues.length, 1);
+    assert.equal(summary.status, 'FAIL');
+  });
+
+  it('does NOT drop false positives by default', () => {
+    const issue = makeIssue({
+      judge: { verdict: 'false_positive', confidence: 0.95, rationale: 'Not a bug', model: 'opus', provider: 'cc' },
+    });
+    const summary = makeSummary();
+    const { filteredIssues } = applyJudgeResults([issue], [summary], {});
+    assert.equal(filteredIssues.length, 1);
+    assert.equal(summary.status, 'FAIL');
+  });
+
+  it('drops false positives when dropFalsePositives is true', () => {
+    const issue = makeIssue({
+      judge: { verdict: 'false_positive', confidence: 0.95, rationale: 'Not a bug', model: 'opus', provider: 'cc' },
+    });
+    const summary = makeSummary();
+    const { filteredIssues, falsePositives } = applyJudgeResults([issue], [summary], { dropFalsePositives: true });
+    assert.equal(filteredIssues.length, 0);
+    assert.equal(falsePositives, 1);
+    assert.equal(summary.status, 'PASS');
+    assert.equal(summary.issuesFound, 0);
+  });
+
+  it('escalates check to FLAG when all remaining issues are uncertain', () => {
+    const issue = makeIssue({
+      judge: { verdict: 'uncertain', confidence: 0.5, rationale: 'Unclear', model: 'opus', provider: 'cc' },
+    });
+    const summary = makeSummary();
+    const { filteredIssues } = applyJudgeResults([issue], [summary], {});
+    assert.equal(filteredIssues.length, 1);
+    assert.equal(summary.status, 'FLAG');
+    assert.equal(issue.flagSource, 'judge');
+  });
+
+  it('does NOT escalate if only some issues are uncertain (mix with true_positive)', () => {
+    const issue1 = makeIssue({
+      judge: { verdict: 'uncertain', confidence: 0.4, rationale: 'Unclear', model: 'opus', provider: 'cc' },
+    });
+    const issue2 = makeIssue({
+      judge: { verdict: 'true_positive', confidence: 0.9, rationale: 'Real', model: 'opus', provider: 'cc' },
+    });
+    const summary = makeSummary({ issuesFound: 2 });
+    const { filteredIssues } = applyJudgeResults([issue1, issue2], [summary], {});
+    assert.equal(filteredIssues.length, 2);
+    assert.equal(summary.status, 'FAIL');
+  });
+
+  it('preserves flagSource:"check" over judge escalation (decision #9)', () => {
+    const issue = makeIssue({
+      flagSource: 'check',
+      judge: { verdict: 'uncertain', confidence: 0.3, rationale: 'Unclear', model: 'opus', provider: 'cc' },
+    });
+    const summary = makeSummary();
+    applyJudgeResults([issue], [summary], {});
+    assert.equal(issue.flagSource, 'check');
+  });
+
+  it('counts judgedIssues, falsePositives, uncertainJudgements', () => {
+    const tp = makeIssue({ judge: { verdict: 'true_positive', confidence: 0.9, rationale: 'r', model: 'm', provider: 'p' } });
+    const fp = makeIssue({ checkId: 'check-2', judge: { verdict: 'false_positive', confidence: 0.9, rationale: 'r', model: 'm', provider: 'p' } });
+    const unc = makeIssue({ checkId: 'check-3', judge: { verdict: 'uncertain', confidence: 0.5, rationale: 'r', model: 'm', provider: 'p' } });
+    const noJudge = makeIssue({ checkId: 'check-4' });
+
+    const summaries = [
+      makeSummary({ checkId: 'check-1' }),
+      makeSummary({ checkId: 'check-2' }),
+      makeSummary({ checkId: 'check-3' }),
+      makeSummary({ checkId: 'check-4' }),
+    ];
+
+    const { judgedIssues, falsePositives, uncertainJudgements } = applyJudgeResults(
+      [tp, fp, unc, noJudge], summaries, {}
+    );
+    assert.equal(judgedIssues, 3);
+    assert.equal(falsePositives, 1); // FP verdict counted (not dropped since dropFalsePositives not set)
+    assert.equal(uncertainJudgements, 1);
+  });
+
+  it('counts falsePositives correctly when dropFalsePositives is true', () => {
+    const fp = makeIssue({ judge: { verdict: 'false_positive', confidence: 0.9, rationale: 'r', model: 'm', provider: 'p' } });
+    const summary = makeSummary();
+    const { falsePositives } = applyJudgeResults([fp], [summary], { dropFalsePositives: true });
+    assert.equal(falsePositives, 1);
+  });
+
+  it('handles empty issue list', () => {
+    const { filteredIssues, judgedIssues } = applyJudgeResults([], [], {});
+    assert.equal(filteredIssues.length, 0);
+    assert.equal(judgedIssues, 0);
+  });
+
+  it('handles multiple checks — each check recomputed independently', () => {
+    const issue1 = makeIssue({
+      checkId: 'check-1',
+      judge: { verdict: 'false_positive', confidence: 0.95, rationale: 'FP', model: 'm', provider: 'p' },
+    });
+    const issue2 = makeIssue({
+      checkId: 'check-2',
+      judge: { verdict: 'true_positive', confidence: 0.9, rationale: 'TP', model: 'm', provider: 'p' },
+    });
+    const summary1 = makeSummary({ checkId: 'check-1', issuesFound: 1 });
+    const summary2 = makeSummary({ checkId: 'check-2', issuesFound: 1 });
+
+    const { filteredIssues } = applyJudgeResults(
+      [issue1, issue2], [summary1, summary2], { dropFalsePositives: true }
+    );
+
+    assert.equal(filteredIssues.length, 1);
+    assert.equal(summary1.status, 'PASS');
+    assert.equal(summary2.status, 'FAIL');
+  });
+});


### PR DESCRIPTION
After a scan completes, an optional second model re-reads every finding and records a verdict, so a cheap model can find candidates and a stronger one can adjudicate them.

## Enabling it

```bash
aghast scan ./repo --config-dir ./checks --judge-model claude-opus-4-7
```

`--judge-model` is the on switch; there is no separate flag. Optionally `--judge-provider` (defaults to the scan provider) and `--judge-concurrency` (default 5). Also configurable under `judge` in `runtime-config.json`.

## Verdicts are annotations by default

Each issue gains a `judge` object with one of three verdicts — `true_positive`, `false_positive`, `uncertain` — plus a confidence score, a rationale, and the model and provider that produced it. Nothing is discarded unless you ask:

- `--judge-drop-false-positives` removes findings the judge rejected
- `--judge-min-confidence <0-1>` demotes low-confidence `true_positive` verdicts to `uncertain`

A check can opt out entirely with `"judge": false` in its definition, so expensive or already-validated checks need not be re-judged.

Verdicts also surface in SARIF output.

## Known issue

`mapVerdictToKind` maps `false_positive` to SARIF `kind: "false"`. **That is not a valid SARIF 2.1.0 kind** — the spec allows `notApplicable`, `pass`, `fail`, `review`, `open`, `informational`. A strict SARIF consumer will reject the document.

Flagged rather than changed: altering the mapping changes the feature''s intended behaviour, so it deserves a deliberate decision. `review` or `pass` would both be valid replacements.

## Note on the diff

`src/scan-runner.ts` is net-losing ~138 lines. Those are extractions, not deletions — `mapWithConcurrency` and `AbortHandle` moved to the new `src/concurrency.ts`, and `ScanCostTracker` / `recordUsage` / `preflightBudget` moved to `src/cost-tracker.ts`, both so the judge stage can share them. Every removed line was checked against its new home.

## Verification

`npm run build` clean. **1262 tests, 0 failures** (3 skipped — Semgrep not installed). Judge tests: 44/44.