### PR TITLE
feat: retry transient provider failures instead of erroring the check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ npm run scan -- /path/to/target --config-dir checks-config
 - `AGHAST_MOCK_JUDGE` — Enables mock judge provider. Set to `true` for default `true_positive` response, or set to a file path
 - `AGHAST_HISTORY_FILE` — Override the scan history file path (default: `~/.aghast/history.json`)
 - `AGHAST_MOCK_TOKENS` — Format `<input>,<output>`; injects token usage into the mock agent provider for cost/budget tests
+- `AGHAST_MOCK_FAIL_TIMES` — Makes the mock agent provider fail its first N calls with a retryable (503) error before succeeding, so retry behaviour can be exercised end-to-end through the real CLI
 - `AGHAST_MOCK_LOCAL_LOGIN` — Test hook for the Claude Code provider's local-login probe: `true` reports a logged-in session, `false` reports not-logged-in, both without spawning the agent SDK (keeps CLI auth tests hermetic)
 - `AGHAST_MOCK_CLAUDE_MODELS` — Test hook for the Claude Code provider's supported-model list: comma-separated model IDs, used to keep CLI model-validation tests hermetic
 - `AGHAST_DEBUG_PRINTPROMPT` — Print full prompts (requires `--debug`)
@@ -183,6 +184,7 @@ listed instead of its contents.
 - `src/provider-registry.ts` + `src/*-provider.ts` — Agent providers (`claude-code-provider.ts`, `opencode-provider.ts`, `mock-agent-provider.ts`); `provider-utils.ts` holds the shared OUTPUT_SCHEMA
 - `src/diff-filter.ts` — Diff filter (`applyDiffFilter`), applied post-discovery whenever a diff source exists and the check hasn't opted out via `checkTarget.diffFilter: false`. Narrows targets using the OpenAnt call graph (depth-1), falling back to file+line overlap (depth-0) when OpenAnt is unavailable. Supported by `diff-parser.ts` and `diff-unit-matcher.ts`
 - `src/*-runner.ts` — External tool execution with mock support (semgrep, opengrep, openant). `semgrep-runner.ts` exports the shared `runSarifScanner`/`verifySarifScannerInstalled` helpers that `opengrep-runner.ts` delegates to
+- `src/retry.ts` — Retry with exponential backoff and jitter (`withRetry`), a shared per-scan `CircuitBreaker`, and `defaultIsRetryable`. Errors already classified terminal (`FatalProviderError`, `BudgetExceededError`) are never retried, even though their messages mention rate limits
 - `src/cost-calculator.ts`, `src/budget.ts`, `src/scan-history.ts` — Cost/budget subsystem: token→USD estimation from `config/pricing.json`, per-scan and per-period limits, and persisted history at `~/.aghast/history.json`
 - `src/result-handlers/` — Post-scan delivery of findings to external systems. Currently `pr-comment-handler.ts` (GitHub PR inline review comments, spec E.7 Phase 1); issue trackers and notifications are the intended future siblings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,6 +313,17 @@ If no diff source is set, checks run full-repo as usual — no filter, no error.
 
 Diff filtering uses OpenAnt for the call graph (depth-1 mode). If OpenAnt isn't installed and no `AGHAST_OPENANT_DATASET` is provided, the filter falls back to **depth-0 mode** — keep only findings whose file and line range overlap a diff hunk, no call-graph flow. aghast logs a clear warning when this happens so the mode is visible. Install OpenAnt (or supply a prebuilt dataset) to enable depth-1 filtering with caller/callee adjacency. Useful in PR/CI pipelines to focus analysis on changed code. See [Scanning → CI usage](scanning.md#ci-usage--diff-scoped-scans-on-prs) for GitHub Actions / GitLab CI recipes.
 
+### Retry and resilience
+
+Transient provider failures — a dropped stream, a 5xx, a network reset — are retried with exponential backoff and jitter rather than failing the check outright. Defaults are three attempts starting at a one second delay.
+
+Errors that have already been classified as terminal are **never** retried, regardless of these settings:
+
+- `FatalProviderError` — quota exhaustion and authentication failures. The provider raises this for messages like *"you've hit your limit"*; a subscription limit resets on a schedule, not in seconds, so retrying only burns the remaining attempts.
+- Budget aborts — the scan has spent what it was allowed to spend.
+
+A single circuit breaker is shared across the whole scan. Once `retry.circuitBreakerThreshold` consecutive transient failures have occurred anywhere, retrying stops for the remainder of the run: if the provider is failing repeatedly then every remaining target will fail too, and retrying each one wastes both wall-clock time and quota.
+
 ## Check Instructions (`<id>.md`)
 
 The markdown file contains instructions for the AI. It is prepended with a generic prompt template before being sent. A typical structure:
@@ -435,6 +446,10 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | `budget.perPeriod.maxCostUsd`   | `number`   | (none) | Abort when total cost across the period (history + current scan) exceeds this USD value |
 | `budget.thresholds.warnAt`      | `number`   | `0.8` | Fraction of a limit at which a warning is logged (0.0–1.0) |
 | `budget.thresholds.abortAt`     | `number`   | `1.0` | Fraction of a limit at which the scan aborts (0.0–1.0) |
+| `retry.maxAttempts`             | `number`   | `3` | Total attempts per AI call, including the first. Applies to transient provider failures only |
+| `retry.baseDelayMs`             | `number`   | `1000` | Initial backoff before jitter |
+| `retry.maxDelayMs`              | `number`   | `16000` | Cap on backoff before jitter |
+| `retry.circuitBreakerThreshold` | `number`   | `5` | Consecutive transient failures across the whole scan before retrying stops. Shared by every check and target |
 | `pricing.currency`              | `string`   | `USD` | Currency for cost estimates |
 | `pricing.models`                | `object`   | (built-in) | Per-model overrides: `{ "<model>": { "inputPerMillion": <usd>, "outputPerMillion": <usd> } }`. Merges with built-in defaults |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,14 @@ async function createMockProvider(): Promise<AgentProvider> {
     }
   }
 
-  const provider = new MockAgentProvider({ rawResponse, tokenUsage });
+  // Test hook: AGHAST_MOCK_FAIL_TIMES=<n> makes the mock fail its first n calls
+  // with a retryable (503) error before succeeding, so retry behaviour can be
+  // exercised end-to-end through the real CLI.
+  const failTimesRaw = process.env.AGHAST_MOCK_FAIL_TIMES;
+  const parsedFailTimes = failTimesRaw ? Number(failTimesRaw) : 0;
+  const failTimes = Number.isInteger(parsedFailTimes) && parsedFailTimes > 0 ? parsedFailTimes : 0;
+
+  const provider = new MockAgentProvider({ rawResponse, tokenUsage, failTimes });
   await provider.initialize({});
   return provider;
 }
@@ -988,6 +995,8 @@ export async function runScan(args: string[]): Promise<void> {
       // fall back to the env var for providers without the concept (e.g. mock).
       isLocalClaude: provider?.isLocalMode?.() ?? (process.env.AGHAST_LOCAL_CLAUDE === 'true'),
       judge: judgeOptions,
+      // Undefined when absent, which leaves the scan runner on its defaults.
+      retry: runtimeConfig.retry,
     };
     const outcome = await runMultiScanWithCost(scanOptions);
     const results = outcome.results;

--- a/src/mock-agent-provider.ts
+++ b/src/mock-agent-provider.ts
@@ -11,10 +11,13 @@ export class MockAgentProvider implements AgentProvider {
   private rawResponse: string;
   private model: string = 'mock';
   private tokenUsage: TokenUsage | undefined;
+  /** Remaining calls that should fail before the mock starts succeeding. */
+  private failuresRemaining: number;
 
-  constructor(options: { rawResponse: string; tokenUsage?: TokenUsage }) {
+  constructor(options: { rawResponse: string; tokenUsage?: TokenUsage; failTimes?: number }) {
     this.rawResponse = options.rawResponse;
     this.tokenUsage = options.tokenUsage;
+    this.failuresRemaining = options.failTimes ?? 0;
   }
 
   async initialize(_config: ProviderConfig): Promise<void> {
@@ -27,6 +30,20 @@ export class MockAgentProvider implements AgentProvider {
     _logPrefix?: string,
     _options?: { maxTurns?: number },
   ): Promise<AgentResponse> {
+    // Test hook: fail the first N calls with a retryable error, then succeed.
+    // Lets CLI-level tests prove that a transient provider failure is retried
+    // and the scan still completes, which cannot be observed from unit tests of
+    // withRetry alone. The error carries a 503 status so it is classified
+    // retryable by the real classifier rather than a test-only special case.
+    if (this.failuresRemaining > 0) {
+      this.failuresRemaining--;
+      const err = Object.assign(
+        new Error('Mock transient provider failure (AGHAST_MOCK_FAIL_TIMES)'),
+        { status: 503 },
+      );
+      throw err;
+    }
+
     const response: AgentResponse = {
       raw: this.rawResponse,
       parsed: undefined,

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,281 @@
+/**
+ * Retry helper with exponential backoff and an optional shared circuit breaker.
+ *
+ * Spec Appendix E.6 — Retry and Resilience.
+ *
+ * Default classifier retries on rate-limit (429), 5xx, network/timeout errors;
+ * does NOT retry auth errors (401/403) or validation errors. Callers can override
+ * via `isRetryable`.
+ *
+ * The circuit breaker is shared across every `withRetry` invocation that
+ * receives the same `CircuitBreaker` instance. Within a single scan that
+ * means concurrent target analyses share one breaker; across multiple
+ * `runMultiScan` invocations the scope depends on whether the caller hoists
+ * the breaker to module scope or constructs a fresh one per scan (currently
+ * `runMultiScan` does the latter, so the breaker is per-scan, not per-process).
+ * When `consecutiveFailures` reaches the configured threshold, subsequent
+ * calls fail-fast with `CircuitOpenError` without invoking the wrapped
+ * function. A successful call resets the counter.
+ */
+
+import { logDebug } from './logging.js';
+
+const TAG = 'retry';
+
+export interface RetryOptions {
+  /** Maximum total attempts (initial + retries). Must be >= 1. */
+  maxAttempts: number;
+  /** Initial backoff delay in ms (before jitter). */
+  baseDelayMs: number;
+  /** Cap on the backoff delay in ms (before jitter). */
+  maxDelayMs: number;
+  /** Optional classifier — return true to retry, false to give up immediately. */
+  isRetryable?: (err: unknown) => boolean;
+  /** Optional shared circuit breaker. */
+  breaker?: CircuitBreaker;
+  /** Optional sleep override (for testing). Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional jitter source returning [0, 1). Defaults to Math.random. */
+  random?: () => number;
+  /** Optional label for log lines. */
+  label?: string;
+}
+
+/** Default retry options used when callers don't supply a value. */
+export const DEFAULT_RETRY: Required<Pick<RetryOptions, 'maxAttempts' | 'baseDelayMs' | 'maxDelayMs'>> = {
+  maxAttempts: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 16000,
+};
+
+/**
+ * Default retryable-error classifier.
+ *
+ * Decision order (first match wins):
+ *   1. HTTP status / statusCode property — authoritative when present.
+ *      4xx (except 429) → not retryable; 429 and 5xx → retryable.
+ *   2. errno-style `code` property (ECONNRESET, ETIMEDOUT, etc.) → retryable.
+ *   3. Free-text message fallback — only consulted when neither status nor
+ *      code matched. Looks for explicit substrings like "rate limit",
+ *      "timed out", "socket hang up". We deliberately do NOT pattern-match
+ *      bare 5xx digits in messages (too prone to false positives — e.g.
+ *      "failed at 500ms timeout" would otherwise be classified retryable).
+ *
+ * Does NOT retry:
+ *   - 401 / 403 (auth)
+ *   - 400 / 404 / 422 (client/validation)
+ *   - Anything classified as fatal by the agent provider (the scan runner
+ *     handles FatalProviderError separately — those never reach this classifier).
+ *   - Unknown errors (callers can pass a custom `isRetryable` to widen this).
+ */
+export function defaultIsRetryable(err: unknown): boolean {
+  if (err === null || err === undefined) return false;
+
+  // Inspect error properties without coupling to a specific SDK
+  const e = err as { name?: string; code?: string; status?: number; statusCode?: number; message?: string };
+
+  // 0. Errors the rest of the system has already decided are terminal. This has
+  //    to come first, and it has to be here rather than relying on the caller.
+  //
+  //    `claude-code-provider` raises FatalProviderError for quota exhaustion
+  //    ("you've hit your limit" / 429) and for 401s, with the explicit reasoning
+  //    that retrying cannot help — a subscription limit resets on a schedule,
+  //    not in seconds. Those messages contain "rate limit", so the message
+  //    fallback below would otherwise classify them as retryable and we would
+  //    spend the remaining attempts re-hitting an exhausted quota.
+  //
+  //    BudgetExceededError is the same shape of decision: the scan has spent
+  //    what it was allowed to spend, and retrying is precisely wrong.
+  //
+  //    Matched by name rather than instanceof so this holds for errors that
+  //    crossed a serialization boundary and lost their prototype.
+  if (e.name === 'FatalProviderError' || e.name === 'BudgetExceededError') return false;
+
+  // 1. Status code (authoritative). If present, this short-circuits message inspection.
+  const status = e.status ?? e.statusCode;
+  if (typeof status === 'number') {
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    if (status >= 400 && status < 500) return false; // includes 401/403/422/etc
+  }
+
+  // 2. errno-style code (authoritative when present).
+  const code = e.code;
+  if (typeof code === 'string') {
+    const retryableCodes = new Set([
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+      'ECONNREFUSED',
+      'ENETUNREACH',
+      'EPIPE',
+      'ENOTFOUND',
+    ]);
+    if (retryableCodes.has(code)) return true;
+  }
+
+  // 3. Message-substring fallback. Only reached when neither status nor code
+  // matched. Keep this list narrow — bare numeric ranges like "5xx" or `\d{3}`
+  // are too easy to match incidentally (e.g. ports, byte counts). The `\b429\b`
+  // pattern is the one numeric exception: providers that surface rate-limit
+  // errors as plain text (e.g. "HTTP 429: too many requests") still need to
+  // retry, and 429 with word-boundaries is unambiguous enough.
+  const msg = (e.message ?? '').toLowerCase();
+  if (msg.includes('rate limit') || /\b429\b/.test(msg)) return true;
+  if (msg.includes('timed out') || msg.includes('timeout')) return true;
+  if (msg.includes('econnreset') || msg.includes('etimedout') || msg.includes('socket hang up')) return true;
+
+  // Default: don't retry unknown errors. Better to surface unexpected failures than
+  // to mask them by silently retrying — caller can pass a custom classifier if needed.
+  return false;
+}
+
+// ─── Circuit breaker ──────────────────────────────────────────────────────────
+
+export interface CircuitBreakerOptions {
+  /** Maximum consecutive total failures before tripping. Must be >= 1. */
+  threshold: number;
+}
+
+/** Thrown by `withRetry` when the breaker is open (failing fast). */
+export class CircuitOpenError extends Error {
+  constructor(consecutiveFailures: number, threshold: number) {
+    super(
+      `Circuit breaker open: ${consecutiveFailures} consecutive failures reached threshold ${threshold}. Failing fast — wrapped function will not be invoked.`,
+    );
+    this.name = 'CircuitOpenError';
+  }
+}
+
+/**
+ * Process-level circuit breaker. Shared across all `withRetry` calls that
+ * receive the same instance. Counts only TOTAL failures (after all retries
+ * for a single call exhausted), not individual attempts.
+ */
+export class CircuitBreaker {
+  private consecutiveFailures = 0;
+  readonly threshold: number;
+
+  constructor(options: CircuitBreakerOptions) {
+    if (options.threshold < 1) {
+      throw new Error(`CircuitBreaker threshold must be >= 1 (got ${options.threshold})`);
+    }
+    this.threshold = options.threshold;
+  }
+
+  /** True when the breaker is open (further calls should fail-fast). */
+  isOpen(): boolean {
+    return this.consecutiveFailures >= this.threshold;
+  }
+
+  /** Increment the failure counter. */
+  recordFailure(): void {
+    this.consecutiveFailures++;
+  }
+
+  /** Reset the failure counter. Called on any successful `withRetry` call. */
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  /** Force-reset the counter (useful for tests or manual recovery). */
+  reset(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  /** Current consecutive-failure count (for diagnostics/tests). */
+  getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+}
+
+// ─── Backoff ──────────────────────────────────────────────────────────────────
+
+/** Compute the next backoff delay given an attempt number (1-based). */
+export function computeBackoff(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+): number {
+  // Exponential growth: base * 2^(attempt-1), capped at maxDelayMs
+  const exp = baseDelayMs * Math.pow(2, attempt - 1);
+  const capped = Math.min(maxDelayMs, exp);
+  // Jitter factor in [0.5, 1.0)
+  const jitter = 0.5 + random() * 0.5;
+  return Math.floor(capped * jitter);
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn` with retry on transient errors. Returns its result on success;
+ * throws on the final failure (or `CircuitOpenError` if the breaker is open).
+ */
+export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions): Promise<T> {
+  const {
+    maxAttempts,
+    baseDelayMs,
+    maxDelayMs,
+    isRetryable = defaultIsRetryable,
+    breaker,
+    sleep = defaultSleep,
+    random = Math.random,
+    label,
+  } = options;
+
+  if (maxAttempts < 1) {
+    throw new Error(`withRetry: maxAttempts must be >= 1 (got ${maxAttempts})`);
+  }
+
+  if (breaker?.isOpen()) {
+    throw new CircuitOpenError(breaker.getConsecutiveFailures(), breaker.threshold);
+  }
+
+  const prefix = label ? `[${label}] ` : '';
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    // Re-check breaker on each iteration so a concurrent caller tripping the
+    // breaker mid-sleep aborts subsequent retries instead of pushing further
+    // load onto a known-broken downstream. We do NOT count this fail-fast as
+    // a fresh failure (the breaker already counted the failures that opened it).
+    if (attempt > 1 && breaker?.isOpen()) {
+      logDebug(
+        TAG,
+        `${prefix}Breaker opened during retry sleep; aborting further attempts.`,
+      );
+      throw new CircuitOpenError(breaker.getConsecutiveFailures(), breaker.threshold);
+    }
+    try {
+      const result = await fn();
+      breaker?.recordSuccess();
+      return result;
+    } catch (err) {
+      lastError = err;
+      const retryable = isRetryable(err);
+      const isLast = attempt === maxAttempts;
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (!retryable || isLast) {
+        if (!retryable) {
+          logDebug(TAG, `${prefix}Non-retryable error on attempt ${attempt}: ${errMsg}`);
+        } else {
+          logDebug(TAG, `${prefix}Exhausted ${maxAttempts} attempts; final error: ${errMsg}`);
+        }
+        // Total failure for this call — increment breaker (if any) and rethrow.
+        breaker?.recordFailure();
+        throw err;
+      }
+      const delay = computeBackoff(attempt, baseDelayMs, maxDelayMs, random);
+      logDebug(
+        TAG,
+        `${prefix}Attempt ${attempt}/${maxAttempts} failed (${errMsg}); retrying in ${delay}ms`,
+      );
+      await sleep(delay);
+    }
+  }
+  // Unreachable — the loop either returns or throws — but TypeScript doesn't know that.
+  /* istanbul ignore next */
+  throw lastError;
+}

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -40,6 +40,7 @@ import {
   type ScanSummary,
   type TokenUsage,
   type ValidationRecord,
+  type AgentResponse,
 } from './types.js';
 import type { PricingConfig, CostBreakdown } from './cost-calculator.js';
 import { BudgetExceededError, type BudgetLimits } from './budget.js';
@@ -47,6 +48,7 @@ import type { ScanRecord } from './scan-history.js';
 import { collectCIMetadata } from './ci-metadata.js';
 import { type ScanCostTracker, createCostTracker, recordUsage, preflightBudget } from './cost-tracker.js';
 import { type AbortHandle, mapWithConcurrency } from './concurrency.js';
+import { withRetry, defaultIsRetryable, CircuitBreaker, DEFAULT_RETRY, type RetryOptions } from './retry.js';
 import { type JudgeOptions, runJudge, applyJudgeResults } from './judge.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -55,6 +57,11 @@ const DEFAULT_CONCURRENCY = 5;
 // Per-target AI call timeout. Without this, a single hung provider request stalls
 // the worker indefinitely; with concurrency=N hangs, the entire check freezes.
 const DEFAULT_TARGET_TIMEOUT_MS = 5 * 60 * 1000;
+// Consecutive transient failures across the whole scan before we stop retrying.
+// Scan-wide rather than per-target: if the provider is failing repeatedly,
+// every remaining target will fail too, and retrying each one wastes both
+// wall-clock time and quota.
+const DEFAULT_CIRCUIT_BREAKER_THRESHOLD = 5;
 
 // --- Register built-in discovery implementations ---
 registerDiscovery(semgrepDiscovery);
@@ -183,9 +190,21 @@ async function getVersion(): Promise<string> {
 }
 
 
+/** Scan-level resilience settings. Omit for the defaults. */
+export interface ScanRetryOptions extends Partial<RetryOptions> {
+  /**
+   * Consecutive transient failures across the whole scan before retrying stops.
+   * The breaker is shared by every check and target, so this counts failures
+   * anywhere, not per target.
+   */
+  circuitBreakerThreshold?: number;
+}
+
 export interface MultiScanOptions {
   repositoryPath: string;
   checks: Array<{ check: SecurityCheck; details: CheckDetails }>;
+  /** Retry/backoff settings for transient provider failures. */
+  retry?: ScanRetryOptions;
   agentProvider?: AgentProvider;
   modelName?: string;
   agentProviderName?: string;
@@ -434,6 +453,7 @@ async function executeSingleCheck(
   diffRef?: string,
   diffFile?: string,
   openantAvailable: boolean = true,
+  resilience?: { retry: RetryOptions; breaker?: CircuitBreaker },
 ): Promise<CheckExecutionResult> {
   const checkId = check.id;
 
@@ -456,6 +476,7 @@ async function executeSingleCheck(
       diffRef,
       diffFile,
       openantAvailable,
+      resilience,
     );
   }
 
@@ -469,6 +490,9 @@ async function executeSingleCheck(
     throw new Error(`Check "${checkId}" requires an agent provider but none was configured`);
   }
 
+  const retryConfig = resilience?.retry ?? DEFAULT_RETRY;
+  const breaker = resilience?.breaker;
+
   logProgress(TAG, `Running check: ${checkName}`);
 
   const prompt = await buildPrompt(checkInstructions, configDir, genericPrompt);
@@ -481,7 +505,12 @@ async function executeSingleCheck(
 
   try {
     preflightBudget(costTracker);
-    const agentResponse = await agentProvider.executeCheck(prompt, repositoryPath);
+    // Repository checks retry on the same terms as targeted ones — a transient
+    // provider failure should not turn a whole-repo check into an ERROR.
+    const agentResponse = await withRetry(
+      () => agentProvider.executeCheck(prompt, repositoryPath),
+      { ...retryConfig, breaker, label: checkId },
+    );
     const model = agentProvider.getModelName?.() ?? DEFAULT_MODEL;
     recordUsage(costTracker, agentResponse.tokenUsage, model);
     const executionTime = checkTimer.elapsed();
@@ -579,9 +608,14 @@ async function executeTargetedCheck(
   diffRef?: string,
   diffFile?: string,
   openantAvailable: boolean = true,
+  // Bundled rather than two more positional parameters — this signature is
+  // already long enough that another pair would be easy to mis-order.
+  resilience?: { retry: RetryOptions; breaker?: CircuitBreaker },
 ): Promise<CheckExecutionResult> {
   const checkId = check.id;
   const checkTarget = check.checkTarget!;
+  const retryConfig = resilience?.retry ?? DEFAULT_RETRY;
+  const breaker = resilience?.breaker;
 
   const discoveryName = checkTarget.discovery;
   if (!discoveryName) {
@@ -704,24 +738,41 @@ async function executeTargetedCheck(
           const prompt = basePrompt + (target.promptEnrichment ?? '');
 
           logDebug(TAG, `${target.label} Analyzing: ${target.file}:${target.startLine}-${target.endLine}`);
-          let timeoutHandle: NodeJS.Timeout | undefined;
-          const agentResponse = await Promise.race([
-            agentProvider.executeCheck(
-              prompt,
-              repositoryPath,
-              target.label,
-              target.agentOptions,
-            ),
-            new Promise<never>((_, reject) => {
-              timeoutHandle = setTimeout(
-                () => reject(new Error(
-                  `Agent provider timed out after ${DEFAULT_TARGET_TIMEOUT_MS / 1000}s on target ${target.label}`,
-                )),
-                DEFAULT_TARGET_TIMEOUT_MS,
-              );
-            }),
-          ]).finally(() => {
-            if (timeoutHandle) clearTimeout(timeoutHandle);
+
+          // One attempt: the provider call raced against a per-target timeout.
+          // Declared as a function so each retry gets a fresh timer — reusing a
+          // single handle across attempts would leave the first attempt's
+          // timeout armed and abort a later, healthy one.
+          const analyzeOnce = async (): Promise<AgentResponse> => {
+            let timeoutHandle: NodeJS.Timeout | undefined;
+            return Promise.race([
+              agentProvider.executeCheck(
+                prompt,
+                repositoryPath,
+                target.label,
+                target.agentOptions,
+              ),
+              new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(
+                  () => reject(new Error(
+                    `Agent provider timed out after ${DEFAULT_TARGET_TIMEOUT_MS / 1000}s on target ${target.label}`,
+                  )),
+                  DEFAULT_TARGET_TIMEOUT_MS,
+                );
+              }),
+            ]).finally(() => {
+              if (timeoutHandle) clearTimeout(timeoutHandle);
+            });
+          };
+
+          const agentResponse = await withRetry(analyzeOnce, {
+            ...retryConfig,
+            breaker,
+            label: target.label,
+            // Stop retrying the moment another worker has aborted the scan
+            // (budget exceeded, or a fatal provider error). Without this a
+            // long backoff would keep a doomed scan alive.
+            isRetryable: (err) => !abortHandle.aborted && defaultIsRetryable(err),
           });
           const model = agentProvider.getModelName?.() ?? DEFAULT_MODEL;
           recordUsage(costTracker, agentResponse.tokenUsage, model);
@@ -1072,6 +1123,16 @@ export async function runMultiScan(options: MultiScanOptions): Promise<ScanResul
 export async function runMultiScanWithCost(options: MultiScanOptions): Promise<MultiScanOutcome> {
   const { repositoryPath, checks, agentProvider, modelName, agentProviderName, concurrency, configDir, genericPrompt, diffRef, diffFile } = options;
   const openantAvailable = options.openantAvailable ?? true;
+
+  // Resilience is scan-scoped. One breaker is shared across every check and
+  // every target, so N consecutive transient failures anywhere stop the scan
+  // retrying rather than each target independently burning its own attempts
+  // against a provider that is plainly unwell.
+  const retryOptions: RetryOptions = { ...DEFAULT_RETRY, ...options.retry };
+  const scanBreaker = new CircuitBreaker({
+    threshold: options.retry?.circuitBreakerThreshold ?? DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+  });
+
   const scanTimer = createTimer();
   const scanId = generateScanId();
   const startTime = new Date();
@@ -1136,6 +1197,7 @@ export async function runMultiScanWithCost(options: MultiScanOptions): Promise<M
         diffRef,
         diffFile,
         openantAvailable,
+        { retry: retryOptions, breaker: scanBreaker },
       );
 
       allCheckSummaries.push(checkSummary);

--- a/src/types.ts
+++ b/src/types.ts
@@ -471,8 +471,32 @@ export interface RuntimeConfig {
   diffRef?: string;
   budget?: RuntimeBudgetConfig;
   pricing?: RuntimePricingConfig;
+  /** Retry behaviour for transient provider failures. Omit for the defaults. */
+  retry?: RuntimeRetryConfig;
   /** LLM judge stage configuration. Setting judge.model enables the stage. */
   judge?: RuntimeJudgeConfig;
+}
+
+/**
+ * Retry settings for transient provider failures.
+ *
+ * Applies only to errors the system has not already classified as terminal:
+ * `FatalProviderError` (quota exhausted, auth failure) and budget aborts are
+ * never retried regardless of these values, because retrying them cannot help.
+ */
+export interface RuntimeRetryConfig {
+  /** Total attempts including the first (default: 3). */
+  maxAttempts?: number;
+  /** Initial backoff in ms before jitter (default: 1000). */
+  baseDelayMs?: number;
+  /** Cap on backoff in ms before jitter (default: 16000). */
+  maxDelayMs?: number;
+  /**
+   * Consecutive transient failures across the whole scan before retrying
+   * stops (default: 5). Shared by every check and target, so this counts
+   * failures anywhere rather than per target.
+   */
+  circuitBreakerThreshold?: number;
 }
 
 // --- A.6 Aggregated Report ---

--- a/tests/cli-mock-mode-2.test.ts
+++ b/tests/cli-mock-mode-2.test.ts
@@ -1018,3 +1018,39 @@ describe('CLI mock mode: matchCriteria and priority (issue #122)', () => {
     );
   });
 });
+
+// ─── Retry on transient provider failures (issue #118) ───────────────────────
+
+describe('CLI: retry on transient provider failures', () => {
+  afterEach(cleanupOutput);
+
+  it('recovers when the provider fails fewer times than the retry budget', async () => {
+    // AGHAST_MOCK_FAIL_TIMES makes the mock throw a 503 for its first N calls.
+    // Two failures against a default budget of three attempts must still PASS —
+    // this is the whole point of the feature, and it cannot be observed from
+    // unit tests of withRetry alone.
+    const { exitCode } = await runCLI({
+      AGHAST_MOCK_AI: 'true',
+      AGHAST_MOCK_FAIL_TIMES: '2',
+    });
+    assert.equal(exitCode, 0);
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'PASS', 'transient failures should not fail the check');
+  });
+
+  it('still errors when failures exhaust the retry budget', async () => {
+    // Five failures against three attempts: retry must give up rather than
+    // loop, and the check must surface as ERROR rather than a false PASS.
+    const { exitCode } = await runCLI({
+      AGHAST_MOCK_AI: 'true',
+      AGHAST_MOCK_FAIL_TIMES: '5',
+    });
+    assert.equal(exitCode, 0, 'scan completes; the check itself carries the error');
+
+    const results = await readResults();
+    const checks = results.checks as Array<Record<string, unknown>>;
+    assert.equal(checks[0].status, 'ERROR');
+  });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for src/retry.ts (withRetry, CircuitBreaker, defaultIsRetryable, computeBackoff).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  withRetry,
+  CircuitBreaker,
+  CircuitOpenError,
+  defaultIsRetryable,
+  computeBackoff,
+} from '../src/retry.js';
+import { FatalProviderError } from '../src/types.js';
+import { BudgetExceededError } from '../src/budget.js';
+
+// ─── withRetry ────────────────────────────────────────────────────────────────
+
+test('withRetry: succeeds on first attempt', async () => {
+  let calls = 0;
+  const result = await withRetry(async () => { calls++; return 'ok'; }, {
+    maxAttempts: 3,
+    baseDelayMs: 10,
+    maxDelayMs: 100,
+    sleep: async () => { /* no-op */ },
+  });
+  assert.equal(result, 'ok');
+  assert.equal(calls, 1);
+});
+
+test('withRetry: fails N times then succeeds', async () => {
+  let calls = 0;
+  const result = await withRetry(async () => {
+    calls++;
+    if (calls < 3) {
+      const err = new Error('rate limit exceeded') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }
+    return 42;
+  }, {
+    maxAttempts: 5,
+    baseDelayMs: 1,
+    maxDelayMs: 10,
+    sleep: async () => { /* no-op */ },
+  });
+  assert.equal(result, 42);
+  assert.equal(calls, 3);
+});
+
+test('withRetry: throws after exhausting attempts', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(async () => {
+      calls++;
+      const err = new Error('rate limit') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+      sleep: async () => { /* no-op */ },
+    }),
+    /rate limit/,
+  );
+  assert.equal(calls, 3);
+});
+
+test('withRetry: does NOT retry on non-retryable errors (401)', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(async () => {
+      calls++;
+      const err = new Error('unauthorized') as Error & { status?: number };
+      err.status = 401;
+      throw err;
+    }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+      sleep: async () => { /* no-op */ },
+    }),
+    /unauthorized/,
+  );
+  assert.equal(calls, 1, 'auth errors should not be retried');
+});
+
+test('withRetry: custom isRetryable overrides default', async () => {
+  let calls = 0;
+  const result = await withRetry(async () => {
+    calls++;
+    if (calls < 2) throw new Error('always retry me');
+    return 'done';
+  }, {
+    maxAttempts: 3,
+    baseDelayMs: 1,
+    maxDelayMs: 10,
+    isRetryable: () => true,
+    sleep: async () => { /* no-op */ },
+  });
+  assert.equal(result, 'done');
+  assert.equal(calls, 2);
+});
+
+test('withRetry: backoff delays grow between attempts', async () => {
+  const delays: number[] = [];
+  const sleep = async (ms: number) => { delays.push(ms); };
+  let calls = 0;
+  await assert.rejects(
+    withRetry(async () => {
+      calls++;
+      const err = new Error('timeout');
+      throw err;
+    }, {
+      maxAttempts: 4,
+      baseDelayMs: 100,
+      maxDelayMs: 10000,
+      sleep,
+      // Deterministic jitter: always returns 1.0 (no jitter cap), so delays are exactly base*2^(n-1).
+      random: () => 1 - Number.EPSILON,
+    }),
+  );
+  // 3 retries -> 3 sleeps. Expected approximate delays: 100, 200, 400.
+  assert.equal(delays.length, 3);
+  assert.ok(delays[0] >= 50 && delays[0] <= 100);
+  assert.ok(delays[1] >= 100 && delays[1] <= 200);
+  assert.ok(delays[2] >= 200 && delays[2] <= 400);
+  assert.ok(delays[1] > delays[0], `delay ${delays[1]} should be > ${delays[0]}`);
+  assert.ok(delays[2] > delays[1], `delay ${delays[2]} should be > ${delays[1]}`);
+  assert.equal(calls, 4);
+});
+
+test('withRetry: maxAttempts < 1 throws', async () => {
+  await assert.rejects(
+    withRetry(async () => 'never', {
+      maxAttempts: 0,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      sleep: async () => { /* no-op */ },
+    }),
+    /maxAttempts must be >= 1/,
+  );
+});
+
+// ─── CircuitBreaker ───────────────────────────────────────────────────────────
+
+test('CircuitBreaker: trips after threshold consecutive failures', async () => {
+  const breaker = new CircuitBreaker({ threshold: 2 });
+  // First call: fails all retries → recordFailure() bumps to 1
+  await assert.rejects(
+    withRetry(async () => {
+      const err = new Error('rate limit') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }, {
+      maxAttempts: 1,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep: async () => { /* no-op */ },
+    }),
+    /rate limit/,
+  );
+  assert.equal(breaker.getConsecutiveFailures(), 1);
+  assert.equal(breaker.isOpen(), false);
+
+  // Second call: same → bumps to 2, breaker opens
+  await assert.rejects(
+    withRetry(async () => {
+      const err = new Error('rate limit') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }, {
+      maxAttempts: 1,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep: async () => { /* no-op */ },
+    }),
+    /rate limit/,
+  );
+  assert.equal(breaker.isOpen(), true);
+
+  // Third call: fail-fast with CircuitOpenError, fn never invoked
+  let invoked = false;
+  await assert.rejects(
+    withRetry(async () => { invoked = true; return 'should not run'; }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep: async () => { /* no-op */ },
+    }),
+    (err: unknown) => err instanceof CircuitOpenError,
+  );
+  assert.equal(invoked, false);
+});
+
+test('CircuitBreaker: success resets the counter', async () => {
+  const breaker = new CircuitBreaker({ threshold: 3 });
+  await assert.rejects(
+    withRetry(async () => {
+      const err = new Error('rate limit') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }, {
+      maxAttempts: 1,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep: async () => { /* no-op */ },
+    }),
+    /rate limit/,
+  );
+  assert.equal(breaker.getConsecutiveFailures(), 1);
+
+  const result = await withRetry(async () => 'success', {
+    maxAttempts: 1,
+    baseDelayMs: 1,
+    maxDelayMs: 1,
+    breaker,
+    sleep: async () => { /* no-op */ },
+  });
+  assert.equal(result, 'success');
+  assert.equal(breaker.getConsecutiveFailures(), 0);
+});
+
+test('CircuitBreaker: threshold < 1 rejected', () => {
+  assert.throws(() => new CircuitBreaker({ threshold: 0 }), /threshold must be >= 1/);
+});
+
+test('CircuitBreaker: reset clears counter', () => {
+  const breaker = new CircuitBreaker({ threshold: 2 });
+  breaker.recordFailure();
+  breaker.recordFailure();
+  assert.equal(breaker.isOpen(), true);
+  breaker.reset();
+  assert.equal(breaker.isOpen(), false);
+  assert.equal(breaker.getConsecutiveFailures(), 0);
+});
+
+test('CircuitBreaker: pre-tripped breaker fail-fasts before invoking fn', async () => {
+  const breaker = new CircuitBreaker({ threshold: 2 });
+  breaker.recordFailure();
+  breaker.recordFailure();
+  assert.equal(breaker.isOpen(), true);
+
+  let invoked = false;
+  await assert.rejects(
+    withRetry(async () => { invoked = true; return 'should not run'; }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep: async () => { /* no-op */ },
+    }),
+    (err: unknown) => err instanceof CircuitOpenError,
+  );
+  assert.equal(invoked, false, 'fn must not be invoked when breaker is open at entry');
+});
+
+test('withRetry: aborts mid-loop when concurrent caller trips the breaker during sleep', async () => {
+  const breaker = new CircuitBreaker({ threshold: 1 });
+  let calls = 0;
+  // Use a sleep override that trips the breaker while we're "sleeping",
+  // simulating a concurrent withRetry call that recorded a fatal failure.
+  const sleep = async () => {
+    breaker.recordFailure(); // trips the breaker (threshold=1)
+  };
+  await assert.rejects(
+    withRetry(async () => {
+      calls++;
+      const err = new Error('rate limit') as Error & { status?: number };
+      err.status = 429;
+      throw err;
+    }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      breaker,
+      sleep,
+    }),
+    (err: unknown) => err instanceof CircuitOpenError,
+  );
+  // First attempt runs, fails, sleeps (during which breaker trips), second iteration
+  // detects the open breaker and throws CircuitOpenError without invoking fn again.
+  assert.equal(calls, 1, 'fn should only run once before the breaker aborts the retry loop');
+  // The fail-fast path must NOT increment the breaker further — only the in-loop
+  // catch records failures. The sleep override recorded one failure (which tripped
+  // the breaker); the abort path should not double-count.
+  assert.equal(
+    breaker.getConsecutiveFailures(),
+    1,
+    'CircuitOpenError abort path must not record an additional failure',
+  );
+});
+
+// ─── defaultIsRetryable ───────────────────────────────────────────────────────
+
+test('defaultIsRetryable: 429 is retryable', () => {
+  assert.equal(defaultIsRetryable({ status: 429 }), true);
+});
+
+test('defaultIsRetryable: 500-599 are retryable', () => {
+  assert.equal(defaultIsRetryable({ status: 500 }), true);
+  assert.equal(defaultIsRetryable({ status: 503 }), true);
+  assert.equal(defaultIsRetryable({ status: 599 }), true);
+});
+
+test('defaultIsRetryable: 401/403 are NOT retryable', () => {
+  assert.equal(defaultIsRetryable({ status: 401 }), false);
+  assert.equal(defaultIsRetryable({ status: 403 }), false);
+});
+
+test('defaultIsRetryable: 400/404/422 are NOT retryable', () => {
+  assert.equal(defaultIsRetryable({ status: 400 }), false);
+  assert.equal(defaultIsRetryable({ status: 404 }), false);
+  assert.equal(defaultIsRetryable({ status: 422 }), false);
+});
+
+test('defaultIsRetryable: ECONNRESET / ETIMEDOUT retryable', () => {
+  assert.equal(defaultIsRetryable({ code: 'ECONNRESET' }), true);
+  assert.equal(defaultIsRetryable({ code: 'ETIMEDOUT' }), true);
+  assert.equal(defaultIsRetryable({ code: 'EAI_AGAIN' }), true);
+  assert.equal(defaultIsRetryable({ code: 'ENOTFOUND' }), true);
+});
+
+test('defaultIsRetryable: timeout messages retryable', () => {
+  assert.equal(defaultIsRetryable(new Error('Agent provider timed out after 300s')), true);
+  assert.equal(defaultIsRetryable(new Error('socket hang up')), true);
+});
+
+test('defaultIsRetryable: 429 in message text (no status field) is retryable', () => {
+  // Providers that surface rate-limit errors as plain text without setting
+  // err.status / err.statusCode still need to be retryable.
+  assert.equal(defaultIsRetryable(new Error('HTTP 429: too many requests')), true);
+  // Word-boundary guard: "4290" or "429th" should not match.
+  assert.equal(defaultIsRetryable(new Error('saw 4290ms latency on the wire')), false);
+});
+
+test('defaultIsRetryable: bare 500-style numbers in message do NOT trigger retry', () => {
+  // Without "rate limit" / "timed out" / errno-code / status field, a numeric
+  // mention like "got status 500 from upstream" must NOT be classified retryable.
+  // (Real 5xx errors should set err.status; the message-text path is intentionally narrow.)
+  assert.equal(defaultIsRetryable(new Error('got status 500 from upstream')), false);
+});
+
+test('defaultIsRetryable: unknown errors NOT retryable by default', () => {
+  assert.equal(defaultIsRetryable(new Error('something weird happened')), false);
+  assert.equal(defaultIsRetryable(null), false);
+  assert.equal(defaultIsRetryable(undefined), false);
+});
+
+// ─── computeBackoff ───────────────────────────────────────────────────────────
+
+test('computeBackoff: caps at maxDelayMs', () => {
+  // attempt 10 -> 1000 * 2^9 = 512000, but capped at 5000
+  const d = computeBackoff(10, 1000, 5000, () => 1 - Number.EPSILON);
+  assert.ok(d <= 5000, `expected <= 5000, got ${d}`);
+  assert.ok(d >= 2500, `expected >= 2500 (jitter floor), got ${d}`);
+});
+
+test('computeBackoff: jitter in [0.5, 1.0)', () => {
+  const lo = computeBackoff(1, 1000, 100000, () => 0);
+  const hi = computeBackoff(1, 1000, 100000, () => 1 - Number.EPSILON);
+  assert.equal(lo, 500);
+  assert.ok(hi <= 1000);
+  assert.ok(hi >= 999);
+});
+
+// ─── Errors the system has already decided are terminal ──────────────────────
+//
+// These matter because their *messages* look retryable. `claude-code-provider`
+// raises FatalProviderError for quota exhaustion with text like
+// "you've hit your limit", and the message fallback in defaultIsRetryable
+// matches "rate limit". Without an explicit guard the classifier would retry an
+// exhausted quota until it ran out of attempts.
+
+test('defaultIsRetryable: FatalProviderError is never retried, despite a rate-limit message', () => {
+  const err = new FatalProviderError('Agent provider rate limit reached: you\'ve hit your limit');
+  // Premise: the message alone would otherwise be classified retryable.
+  assert.equal(defaultIsRetryable(new Error(err.message)), true);
+  // Guard: the fatal classification wins.
+  assert.equal(defaultIsRetryable(err), false);
+});
+
+test('defaultIsRetryable: BudgetExceededError is never retried', () => {
+  const err = new BudgetExceededError('Budget limit exceeded: timed out waiting for spend');
+  assert.equal(defaultIsRetryable(new Error(err.message)), true);
+  assert.equal(defaultIsRetryable(err), false);
+});
+
+test('defaultIsRetryable: fatal errors are matched by name across a realm boundary', () => {
+  // Errors that crossed a serialization boundary lose their prototype, so
+  // instanceof would not hold. Name-matching still does.
+  const plain = Object.assign(new Error('rate limit exceeded'), { name: 'FatalProviderError' });
+  assert.equal(defaultIsRetryable(plain), false);
+});
+
+test('withRetry: a fatal error is surfaced on the first attempt without retrying', async () => {
+  let calls = 0;
+  const sleep = async (): Promise<void> => { throw new Error('sleep should not be called'); };
+  await assert.rejects(
+    () => withRetry(
+      async () => {
+        calls++;
+        throw new FatalProviderError('Agent provider authentication failed (401)');
+      },
+      { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 1, sleep },
+    ),
+    /authentication failed/,
+  );
+  assert.equal(calls, 1, 'fatal errors must not consume retry attempts');
+});

--- a/tests/scan-runner.test.ts
+++ b/tests/scan-runner.test.ts
@@ -9,6 +9,7 @@ import {
   sumTokenUsage,
 } from '../src/scan-runner.js';
 import { getRegisteredDiscoveries, registerDiscovery, unregisterDiscovery } from '../src/discovery.js';
+import { DEFAULT_RETRY } from '../src/retry.js';
 import type { SecurityCheck, CheckDetails } from '../src/types.js';
 import type { AgentProvider, AgentResponse, CheckResponse } from '../src/types.js';
 import { FatalProviderError } from '../src/types.js';
@@ -1239,7 +1240,15 @@ describe('runMultiScan (FLAG status)', () => {
       async validateConfig() { return true; },
       async executeCheck(_instructions: string, _repositoryPath: string) {
         const n = callCount++;
-        if (n === 0) throw new Error('Agent provider request timed out after 60000ms');
+        // Fail for the first check's full retry budget (3 attempts) rather than
+        // once. A "timed out" message is classified retryable, so a single
+        // failure is now recovered — which is the point of retry, but would
+        // make this test assert nothing. Exhausting the budget keeps the
+        // original subject intact: a check that genuinely ERRORs must not stop
+        // the checks after it from running.
+        if (n < DEFAULT_RETRY.maxAttempts) {
+          throw new Error('Agent provider request timed out after 60000ms');
+        }
         const response = { issues: [] };
         return { raw: JSON.stringify(response), parsed: response };
       },
@@ -1252,6 +1261,8 @@ describe('runMultiScan (FLAG status)', () => {
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
       agentProvider: mixedProvider,
+      // Keep the backoff out of the test's wall-clock time.
+      retry: { baseDelayMs: 1, maxDelayMs: 1 },
     });
 
     assert.equal(results.checks.length, 2);
@@ -1655,7 +1666,13 @@ describe('runMultiScan (fatal error abort)', () => {
       async validateConfig() { return true; },
       async executeCheck() {
         const n = callCount++;
-        if (n === 0) throw new Error('Agent provider request timed out after 60000ms');
+        // Exhaust the first check's retry budget — see the note on the
+        // "provider throws → ERROR" test above. A single retryable failure is
+        // now recovered, so failing once would no longer produce an ERROR to
+        // regress against.
+        if (n < DEFAULT_RETRY.maxAttempts) {
+          throw new Error('Agent provider request timed out after 60000ms');
+        }
         const response = { issues: [] };
         return { raw: JSON.stringify(response), parsed: response };
       },
@@ -1668,12 +1685,22 @@ describe('runMultiScan (fatal error abort)', () => {
         makeCheckAndDetails('check-2', 'Check Two'),
       ],
       agentProvider: mixedProvider,
+      retry: { baseDelayMs: 1, maxDelayMs: 1 },
     });
 
     assert.equal(results.checks.length, 2);
     assert.equal(results.checks[0].status, 'ERROR');
     assert.equal(results.checks[1].status, 'PASS');
-    assert.equal(callCount, 2, 'Provider should be called for both checks');
+    // Check one exhausts its retry budget, then check two succeeds on one call.
+    // The statuses above are what this test is really about — that a failing
+    // check does not stop the next one — but the call count is worth pinning
+    // too, since a regression that skipped the second check entirely would
+    // otherwise still satisfy the status assertions.
+    assert.equal(
+      callCount,
+      DEFAULT_RETRY.maxAttempts + 1,
+      'check one should use its full retry budget, then check two runs once',
+    );
   });
 
   it('FatalProviderError on first check aborts all remaining', async () => {


### PR DESCRIPTION
A dropped stream, a 5xx or a network reset would turn a check into an `ERROR` on the first failure. Those are exactly the failures worth retrying.

## What retries

Both AI call sites — the per-target loop and whole-repository checks — with exponential backoff and jitter. Three attempts by default, starting at one second.

Configurable in `runtime-config.json`:

```json
{
  "retry": {
    "maxAttempts": 3,
    "baseDelayMs": 1000,
    "maxDelayMs": 16000,
    "circuitBreakerThreshold": 5
  }
}
```

## What deliberately does not retry

Errors already classified as terminal are excluded **inside the classifier**, not left to callers. This matters because their messages look retryable:

- **Quota exhaustion and auth failures.** The Claude provider raises a fatal error for text like *"you''ve hit your limit"*, with the explicit reasoning that retrying cannot help — a subscription limit resets on a schedule, not in seconds. A message-based classifier would match `rate limit` and spend every remaining attempt re-hitting the wall.
- **Budget aborts.** The scan has spent what it was allowed to spend; retrying is precisely wrong.

These are matched by error *name* rather than `instanceof`, so the guard still holds for errors that crossed a serialization boundary and lost their prototype.

## Circuit breaker

One breaker shared by the whole scan, not one per target. If the provider is failing repeatedly then every remaining target will fail too, and retrying each one independently wastes both wall-clock time and quota. Default threshold is 5 consecutive failures.

Retry is also abandoned as soon as another worker aborts the scan, so a long backoff cannot keep a doomed run alive.

## Tests

`tests/retry.test.ts` covers backoff, jitter, the breaker, and the terminal-error guard. The guard tests **assert the premise first** — that the same message *without* the fatal name is classified retryable — so the guard is demonstrably doing the work rather than passing vacuously.

Two CLI-level tests exercise the whole path through the real binary via a new `AGHAST_MOCK_FAIL_TIMES` hook: two failures against a three-attempt budget still `PASS`; five failures `ERROR` rather than looping.

`npm run build` clean. **1289 tests, 0 failures** (3 skipped — Semgrep not installed).

## Scope

CLI flags are deferred; the defaults are sensible and runtime config covers the configurable cases. Resume-from-state is a separate, larger feature and is not included here.