### PR TITLE
fix: emit a valid SARIF kind for judged false positives

### DIFF
--- a/src/formatters/sarif-formatter.ts
+++ b/src/formatters/sarif-formatter.ts
@@ -55,11 +55,23 @@ interface SarifSuppression {
   justification?: string;
 }
 
-/** Maps judge verdict to SARIF result kind (decision #11). */
-function mapVerdictToKind(verdict: JudgeVerdict['verdict']): 'open' | 'false' | 'review' {
+/**
+ * Maps a judge verdict to a SARIF result kind.
+ *
+ * `false_positive` maps to `pass` rather than the more obvious `false`, because
+ * `false` is not a member of the SARIF 2.1.0 `kind` enum — the spec allows only
+ * `notApplicable`, `pass`, `fail`, `review`, `open` and `informational`, and a
+ * validating consumer rejects the whole document otherwise.
+ *
+ * `pass` is also what this formatter already emits for false positives found by
+ * false-positive-validation checks (see `buildValidationResults`), so both paths
+ * now describe a dismissed finding the same way: `kind: "pass"` plus a
+ * suppression carrying the rationale.
+ */
+function mapVerdictToKind(verdict: JudgeVerdict['verdict']): 'open' | 'pass' | 'review' {
   switch (verdict) {
     case 'true_positive': return 'open';
-    case 'false_positive': return 'false';
+    case 'false_positive': return 'pass';
     case 'uncertain': return 'review';
   }
 }
@@ -68,7 +80,10 @@ interface SarifResult {
   ruleId: string;
   message: { text: string };
   level?: 'error' | 'warning' | 'note';
-  kind?: 'fail' | 'pass' | 'open' | 'review' | 'notApplicable' | 'informational' | 'false';
+  // SARIF 2.1.0 section 3.27.9 — this is the complete, closed set. Note that
+  // "false" is NOT a member, despite reading like the obvious opposite of
+  // "open"; see mapVerdictToKind.
+  kind?: 'notApplicable' | 'pass' | 'fail' | 'review' | 'open' | 'informational';
   locations: Array<{
     physicalLocation: {
       artifactLocation: { uri: string };
@@ -215,6 +230,22 @@ export class SarifFormatter implements OutputFormatter {
             provider: issue.judge.provider,
           },
         };
+
+        if (issue.judge.verdict === 'false_positive') {
+          // Match how false-positive-validation dismissals are already
+          // represented: a suppression carries the reason, so a consumer that
+          // only understands standard SARIF still learns why the finding was
+          // dismissed without reading our `properties` bag.
+          result.suppressions = [
+            ...(result.suppressions ?? []),
+            { kind: 'external', justification: issue.judge.rationale },
+          ];
+          // `level` is meaningless alongside `kind: "pass"` per SARIF 2.1.0, and
+          // `buildValidationResults` omits it for the same reason. Leaving a
+          // severity-derived level here would tell a consumer the finding is
+          // both dismissed and an error.
+          delete result.level;
+        }
       }
       if (issue.flagSource) {
         result.properties = {

--- a/tests/cli-judge.test.ts
+++ b/tests/cli-judge.test.ts
@@ -426,7 +426,7 @@ describe('CLI judge: SARIF output', () => {
     assert.equal(judgeProps.verdict, 'true_positive');
   });
 
-  it('SARIF result for false_positive has kind:false', async () => {
+  it('SARIF result for false_positive has kind:pass with a suppression', async () => {
     await runCLISarif({
       AGHAST_MOCK_AI: failFixtureRepo,
       AGHAST_MOCK_JUDGE: judgeFpFixture,
@@ -442,7 +442,15 @@ describe('CLI judge: SARIF output', () => {
     const sarif = JSON.parse(sarifText) as Record<string, unknown>;
     const runs = sarif.runs as Array<Record<string, unknown>>;
     const results = runs[0].results as Array<Record<string, unknown>>;
-    assert.equal(results[0].kind, 'false', 'false_positive should map to kind:false');
+    // "false" is not a member of the SARIF 2.1.0 kind enum, so it is mapped to
+    // "pass" — the same representation this formatter already uses for
+    // false-positive-validation dismissals — with the reason in a suppression.
+    assert.equal(results[0].kind, 'pass', 'false_positive maps to kind:pass, not the invalid kind:false');
+    const suppressions = results[0].suppressions as Array<Record<string, unknown>>;
+    assert.equal(suppressions.length, 1);
+    assert.equal(suppressions[0].kind, 'external');
+    assert.ok(suppressions[0].justification, 'the judge rationale should be carried as the justification');
+    assert.equal(results[0].level, undefined, 'level is meaningless alongside kind:pass');
   });
 
   it('SARIF result for uncertain has kind:review', async () => {

--- a/tests/sarif-formatter.test.ts
+++ b/tests/sarif-formatter.test.ts
@@ -281,3 +281,92 @@ describe('mapSeverityToLevel', () => {
   it('informational → note', () => assert.equal(mapSeverityToLevel('informational'), 'note'));
   it('undefined → note', () => assert.equal(mapSeverityToLevel(undefined), 'note'));
 });
+
+// ─── Judge verdicts → SARIF ──────────────────────────────────────────────────
+//
+// This path had no coverage, which is how an invalid `kind` shipped. The last
+// test here is the structural guard: it rejects any kind outside the SARIF
+// 2.1.0 enum, so a future verdict cannot reintroduce the problem.
+
+describe('SarifFormatter — judge verdicts', () => {
+  const formatter = new SarifFormatter();
+
+  /** SARIF 2.1.0 section 3.27.9. The complete, closed set. */
+  const VALID_KINDS = new Set([
+    'notApplicable', 'pass', 'fail', 'review', 'open', 'informational',
+  ]);
+
+  function withVerdict(verdict: 'true_positive' | 'false_positive' | 'uncertain') {
+    return makeResults({
+      checks: [{ checkId: 'c1', checkName: 'Check One', status: 'FAIL', issuesFound: 1, executionTime: 10 }],
+      issues: [{
+        checkId: 'c1', checkName: 'Check One',
+        file: 'src/a.ts', startLine: 1, endLine: 2,
+        description: 'Possible SQLi', severity: 'critical',
+        judge: {
+          verdict,
+          confidence: 0.9,
+          rationale: 'Input is an allowlisted column name.',
+          model: 'claude-opus-4-7',
+          provider: 'claude-code',
+        },
+      }],
+    });
+  }
+
+  it('false_positive → kind "pass" with a suppression carrying the rationale', () => {
+    const sarif = JSON.parse(formatter.format(withVerdict('false_positive')));
+    const result = sarif.runs[0].results[0];
+
+    assert.equal(result.kind, 'pass', '"false" is not a valid SARIF kind');
+    assert.equal(result.suppressions.length, 1);
+    assert.equal(result.suppressions[0].kind, 'external');
+    assert.equal(result.suppressions[0].justification, 'Input is an allowlisted column name.');
+  });
+
+  it('false_positive omits level, which is meaningless alongside kind "pass"', () => {
+    const sarif = JSON.parse(formatter.format(withVerdict('false_positive')));
+    // The issue carries severity: 'critical', so without the delete this would
+    // be 'error' — telling a consumer the finding is both dismissed and severe.
+    assert.equal(sarif.runs[0].results[0].level, undefined);
+  });
+
+  it('true_positive → kind "open", keeping its severity-derived level', () => {
+    const sarif = JSON.parse(formatter.format(withVerdict('true_positive')));
+    const result = sarif.runs[0].results[0];
+    assert.equal(result.kind, 'open');
+    assert.equal(result.level, 'error');
+    assert.equal(result.suppressions, undefined, 'a confirmed finding must not be suppressed');
+  });
+
+  it('uncertain → kind "review", keeping its level', () => {
+    const sarif = JSON.parse(formatter.format(withVerdict('uncertain')));
+    const result = sarif.runs[0].results[0];
+    assert.equal(result.kind, 'review');
+    assert.equal(result.level, 'error');
+  });
+
+  it('the verdict detail is preserved in the property bag', () => {
+    const sarif = JSON.parse(formatter.format(withVerdict('false_positive')));
+    const judge = sarif.runs[0].results[0].properties.judge;
+    assert.equal(judge.verdict, 'false_positive');
+    assert.equal(judge.confidence, 0.9);
+    assert.equal(judge.model, 'claude-opus-4-7');
+    assert.equal(judge.provider, 'claude-code');
+  });
+
+  it('every emitted kind is a member of the SARIF 2.1.0 enum', () => {
+    // Structural guard. Covers all three verdicts plus the false-positive
+    // validation path, so adding a verdict without checking the spec fails here.
+    for (const verdict of ['true_positive', 'false_positive', 'uncertain'] as const) {
+      const sarif = JSON.parse(formatter.format(withVerdict(verdict)));
+      for (const result of sarif.runs[0].results) {
+        if (result.kind === undefined) continue;
+        assert.ok(
+          VALID_KINDS.has(result.kind),
+          `"${result.kind}" (from verdict ${verdict}) is not a valid SARIF 2.1.0 result kind`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
The judge emitted `kind: "false"` for a `false_positive` verdict. **That is not a member of the SARIF 2.1.0 `kind` enum** — the spec allows only `notApplicable`, `pass`, `fail`, `review`, `open`, `informational`. A validating consumer (GitHub Code Scanning among them) rejects the entire document, not just the offending result.

## The fix

`false_positive` now maps to `pass`, with the rationale in an external suppression:

```jsonc
{
  "ruleId": "aghast-sql-injection",
  "kind": "pass",
  "suppressions": [
    { "kind": "external", "justification": "Input is an allowlisted column name." }
  ]
  // no "level" — see below
}
```

This is **already how the formatter represents a dismissed finding** from a false-positive-validation check. Both paths now describe the same thing the same way, rather than one being valid and the other not.

`level` is dropped for these results: it is meaningless alongside `kind: "pass"` per the spec, and leaving the severity-derived value would tell a consumer the finding is both dismissed *and* an error.

`true_positive → open` and `uncertain → review` were already valid and are unchanged.

The result `kind` type is narrowed to the spec set, so an invalid value is now a compile error rather than something a reader has to catch.

## Why it shipped

The judge SARIF mapping had no coverage in the formatter tests, and the one CLI test that exercised it asserted the bug by name (`SARIF result for false_positive has kind:false`). That test is corrected, and now also checks the suppression and the absent level.

Added a per-verdict test block plus a **structural guard** that walks every emitted result and rejects any `kind` outside the enum — so adding a fourth verdict without checking the spec fails here rather than in a consumer. Verified by reintroducing the original bug: 2 tests fail.

`npm run build` clean; 53/53 across the two affected test files.