### PR TITLE
feat: document all discovery methods, harden reporting, and show cost and judge verdicts in reports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,7 @@
 - [Creating Checks](creating-checks.md) - scaffolding new security checks
 - [Configuration Reference](configuration.md) - check schemas, check types, runtime config
 - [Development](development.md) - setup, building, testing, releasing
+
+## Examples
+
+- [`examples/github-actions-pr-comments.yml`](examples/github-actions-pr-comments.yml) - runnable GitHub Actions workflow that scans a PR's changed code and posts findings as inline review comments

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,7 @@ configured criterion matches the target repo.
 ```json
 {
   "id": "aghast-typescript-only",
-  "repositories": [],
+  "repositories": ["org/payments-api"],
   "matchCriteria": {
     "hasFileTypes": [".ts", ".tsx"],
     "hasFiles": ["package.json"],
@@ -83,6 +83,17 @@ configured criterion matches the target repo.
   }
 }
 ```
+
+This check runs on `org/payments-api` because it is listed explicitly, **and** on
+any other repository satisfying every criterion: it contains at least one `.ts`
+or `.tsx` file, has a `package.json`, has files under `src/api/` or `src/routes/`,
+and is tagged both `backend` and `api-service`.
+
+> **Do not pair `matchCriteria` with `"repositories": []`.** An empty
+> `repositories` array already matches every repository, so the criteria can
+> never narrow anything and the check runs everywhere — the opposite of what the
+> config appears to say. Use a non-empty list, as above, or omit the explicit
+> repositories you don't need and let the criteria do the selecting.
 
 | Criterion       | Type       | Match when |
 |-----------------|------------|------------|
@@ -254,7 +265,7 @@ Diff filtering works identically for `openant` discovery: the filter narrows the
 | `model`            | `string`                      | No       | AI model override for this check (e.g. `claude-sonnet-4-20250514`). Takes precedence over CLI `--model` and runtime config |
 | `checkTarget`      | `object`                      | No       | Target configuration (omit for repository checks) |
 | `checkTarget.type` | `string`                      | Yes**    | `repository`, `targeted`, or `static` (**required if `checkTarget` present) |
-| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, or `glob` (***required for `targeted` and `static` types) |
+| `checkTarget.discovery` | `string`                 | Yes***   | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, `glob`, or `script` (***required for `targeted` and `static` types) |
 | `checkTarget.analysisMode` | `string`              | No       | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery`. Built-in modes use their own prompt template and don't require `instructionsFile`. See [How It Works](how-it-works.md) |
 | `checkTarget.rules`| `string` or `string[]`        | Yes****  | Rule file path(s) relative to check folder (****only for `semgrep` or `opengrep` discovery — both tools share the same rule syntax) |
 | `checkTarget.sarifFile` | `string`                 | Yes***** | Path to SARIF file relative to target repository (*****only for `sarif` discovery) |
@@ -452,7 +463,7 @@ The built-in `config/pricing.json` provides per-million-token rates for the defa
 | `agentProvider.model`           | `string`   | (provider default) | Model ID override. For `opencode`, use `providerID/modelID` format (e.g. `opencode/nemotron-3-super-free`) |
 | `reporting.outputDirectory`     | `string`   | (target repo) | Directory for result files |
 | `reporting.outputFormat`        | `string`   | `json` | Output format: `json`, `sarif`, `csv`, `html`, or `markdown` (see [Scanning › Output Formats](scanning.md#output-formats)) |
-| `reporting.includeIndividualIssueFiles` | `boolean` | `false` | When `true`, write one file per issue under `security_issues_<project>/<check-id>/` alongside the main report (Spec E.3.2). The directory is created in the same folder as the main report |
+| `reporting.includeIndividualIssueFiles` | `boolean` | `false` | When `true`, write one file per issue under `security_issues_<project>/<check-id>/` alongside the main report (Spec E.3.2). The directory is created in the same folder as the main report. Each run first removes `issue_<NNN>_*` files left by the previous run, so a scan with fewer findings does not leave stale ones behind; files you add yourself are not touched |
 | `reporting.individualIssueFormat` | `string` | `markdown` | Format for individual issue files: `markdown`, `json`, or `html`. Ignored unless `includeIndividualIssueFiles` is `true` |
 | `logging.logFile`               | `string`   | (none) | Path to log file. When set, all log output is written to this file |
 | `logging.logType`               | `string`   | `file` | Log file handler type. Pluggable; currently only `file` is supported |

--- a/docs/creating-checks.md
+++ b/docs/creating-checks.md
@@ -23,7 +23,7 @@ Scaffolds a new security check interactively. Any values not provided via flags 
 | `--id <id>` | Check ID (auto-prefixed with `aghast-` if needed) |
 | `--name <name>` | Human-readable check name |
 | `--check-type <type>` | `repository` (default), `targeted`, or `static` |
-| `--discovery <method>` | Discovery method: `semgrep`, `opengrep`, `sarif`, or `openant` (required for `targeted` and `static` types; `sarif` and `openant` are targeted-only) |
+| `--discovery <method>` | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, or `glob` (required for `targeted` and `static` types; `sarif`, `openant` and `glob` are targeted-only). `script` discovery is not scaffolded — write the check definition by hand, see [Configuration Reference → Discovery Methods](configuration.md#discovery-methods) |
 | `--analysis-mode <mode>` | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery` |
 | `--severity <level>` | `critical`, `high`, `medium`, `low`, or `informational` |
 | `--confidence <level>` | `high`, `medium`, or `low` |

--- a/docs/examples/github-actions-pr-comments.yml
+++ b/docs/examples/github-actions-pr-comments.yml
@@ -1,0 +1,81 @@
+# Example: post aghast findings as inline review comments on a pull request.
+#
+# Copy into .github/workflows/ and adjust the config-dir path. Referenced from
+# docs/scanning.md → "Posting Findings to GitHub Pull Requests".
+#
+# What this demonstrates:
+#   - the `pull-requests: write` permission that inline comments require
+#   - diff-scoped scanning, so only code the PR touched is analysed
+#   - fetch-depth: 0, without which the base ref is unreachable and the diff
+#     filter silently has nothing to compare against
+#   - confining --pr to a single job, since comment dedup is per-run
+
+name: Security scan (PR comments)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  # Required to post review comments. Without it `gh` fails and aghast reports
+  # [E7201] — the scan still completes and the report is still written, but no
+  # comments appear.
+  pull-requests: write
+
+jobs:
+  aghast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The default shallow clone (depth 1) cannot see the base branch, so
+          # `git diff` finds nothing and diff filtering has no effect.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install aghast
+        run: npm install -g @owasp-aghast/aghast
+
+      # Your check definitions live in their own repository.
+      - name: Fetch check definitions
+        run: git clone --depth=1 https://github.com/your-org/your-aghast-checks.git checks-config
+
+      - name: Run scan and post findings to the PR
+        env:
+          # Auth for the `gh` CLI. GITHUB_TOKEN is provided automatically.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Scope the scan to code this PR touched.
+          AGHAST_DIFF_REF: origin/${{ github.base_ref }}
+          # Retry is off by default; unattended runs benefit from it, since a
+          # transient provider failure would otherwise mean re-running the job.
+          AGHAST_RETRY_MAX_ATTEMPTS: '3'
+        run: |
+          aghast scan . \
+            --config-dir ./checks-config \
+            --pr ${{ github.event.pull_request.number }} \
+            --output-format sarif \
+            --output aghast.sarif
+          # --repo, --base-sha and --head-sha are omitted deliberately: aghast
+          # reads $GITHUB_REPOSITORY / $GITHUB_BASE_SHA / $GITHUB_HEAD_SHA.
+
+      # Keep the machine-readable report even when the step above fails, so a
+      # failed scan is still diagnosable.
+      - name: Upload SARIF report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aghast-sarif
+          path: aghast.sarif
+
+# Notes
+#
+# Exit codes: by default aghast exits 0 even when checks FAIL, so findings do
+# not block the PR — the comments are the signal. Add --fail-on-check-failure
+# to turn findings into a red build once you trust the checks.
+#
+# Parallel shards: comment dedup is per-run, so two jobs posting to the same PR
+# concurrently can each produce comments. Keep --pr in one job.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -183,6 +183,10 @@ Discovery methods are deterministic: they use static analysis or pre-existing re
 - **Opengrep**: identical to Semgrep discovery but runs the Opengrep binary (a Semgrep fork). Use this when you prefer Opengrep for licensing or tooling reasons — the rule syntax and SARIF output are the same.
 - **OpenAnt**: runs [OpenAnt](https://github.com/knostic/OpenAnt/) to extract individual code units (functions, classes) with call graph context (who calls this function, what does it call).
 - **SARIF**: reads findings from an external SARIF file (e.g., output from another SAST scanner) and feeds each finding to the AI.
+- **Glob**: selects whole files by path pattern (e.g. `src/routes/**/*.ts`), with no scanner required. Use it when "every file in this directory" is the right unit of review — route handlers, migrations, IaC templates.
+- **Script**: runs a `node` or `bash` script you supply and turns its stdout into targets. The escape hatch for enumeration that none of the above express — parsing an OpenAPI spec, walking a build manifest, querying a schema artifact.
+
+Glob and Script select code directly rather than producing findings to narrow, so neither supports diff filtering; checks using them run over their full target set even during a diff-scoped scan.
 
 #### Diff filtering: narrowing a discovery to changed code
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -75,6 +75,17 @@ the PR comment phase is non-fatal.
 > the same PR can each pass the marker check and produce duplicate comments.
 > Confine `--pr` to a single matrix job (or run after the matrix completes).
 
+At most 50 inline comments are posted per review. A noisy check against a large
+diff would otherwise be unreviewable, and a request that large risks being
+rejected outright — losing every comment rather than some. Any findings beyond
+the cap are named in the review summary and remain in full in the scan report.
+
+A complete, runnable workflow is in
+[`docs/examples/github-actions-pr-comments.yml`](examples/github-actions-pr-comments.yml).
+It covers the two settings most easily missed: the `pull-requests: write`
+permission, without which posting fails with `[E7201]`, and `fetch-depth: 0`,
+without which the base ref is unreachable and diff scoping silently does nothing.
+
 > **Phase 1 only.** Issue tracker creation, AI-assisted remediation, IDE/LSP
 > integration, and Slack/email notifications listed in Spec E.7 are deferred
 > to future iterations.
@@ -139,8 +150,31 @@ Results are written to `security_checks_results.<ext>` in the target repo by def
 - **JSON** (default) - structured results with summary, per-check details, issues, and token usage
 - **SARIF** - SARIF 2.1.0 output compatible with GitHub Code Scanning and other SARIF viewers
 - **CSV** - one row per issue (plus one row per `ERROR` check) for spreadsheet analysis. UTF-8 encoded, no BOM, RFC 4180 quoting, CRLF line endings. Descriptions are flattened to a single line and truncated to 500 chars. The structured `dataFlow` taint trace is omitted; use SARIF or JSON for the full trace.
-- **Markdown** - human-readable report for pasting into a PR, ticket or wiki. Sections: header, executive summary, per-check status table, detailed findings with fenced code snippets (language tag inferred from file extension), flagged items, errors, statistics, and CI metadata when the scan ran in CI. All user-controlled text is escaped so findings cannot break out of tables or inject markup.
-- **HTML** - self-contained interactive report with inline CSS/JS and the full `ScanResults` embedded as a JSON island. Includes filterable issues table, severity/status badges, expandable per-check sections, and code snippets. No external resources, so the file can be emailed or hosted as-is.
+- **Markdown** - human-readable report for pasting into a PR, ticket or wiki. Sections: header, executive summary, per-check status table, detailed findings with fenced code snippets (language tag inferred from file extension), flagged items, errors, judge verdicts, statistics (including estimated cost), and CI metadata when the scan ran in CI. All user-controlled text is escaped so findings cannot break out of tables or inject markup.
+- **HTML** - self-contained interactive report with inline CSS/JS and the full `ScanResults` embedded as a JSON island. Includes filterable issues table, severity/status badges, expandable per-check sections, code snippets, and stat tiles for estimated cost and judge verdicts when available. No external resources, so the file can be emailed or hosted as-is.
+
+### Cost and judge verdicts in reports
+
+Estimated scan cost appears in the JSON, Markdown and HTML reports (in Markdown
+under **Statistics**, in HTML as a stat tile). It is **not** a CSV column: cost is
+a single value for the whole run, so repeating it on every row would invite
+summing it and getting cost × issue-count.
+
+Judge verdicts, being per-issue, appear in every format:
+
+| Format | Where |
+|--------|-------|
+| JSON / SARIF | `issue.judge` object / result `kind` and `properties.judge` |
+| Markdown | a **Judge Verdicts** summary section, plus a verdict block per issue |
+| HTML | stat tiles, and a **Verdict** column added to the issues table |
+| CSV | `judgeVerdict`, `judgeConfidence`, `judgeRationale` columns |
+
+> **CSV consumers:** the three judge columns were appended to the end of the row
+> and are **always present**, empty when the judge did not run. Appending keeps
+> existing column indices valid; keeping them unconditional means the header
+> shape does not change with runtime configuration, which matters more for a
+> parser than a few empty cells. A consumer that asserts an exact column count
+> will need updating.
 
 ## CI/CD Metadata
 
@@ -180,6 +214,14 @@ Discovery methods for `targeted` and `static` checks:
 | `opengrep` | Opengrep installed | Runs Opengrep (a Semgrep fork with identical rule syntax and SARIF output) | Yes |
 | `sarif` | SARIF file in check definition | Reads findings from an external SARIF file | Yes |
 | `openant` | OpenAnt + Python 3.11+ | Runs `openant parse` on the target repo to extract code units with call graph context | Yes |
+| `glob` | Nothing | Walks the repository and selects whole-file targets matching a glob pattern | No |
+| `script` | A `node` or `bash` script in the check folder | Runs a user-provided script and parses its stdout into targets | No |
+
+`glob` and `script` produce targets that carry no SARIF findings to narrow, so
+they do not support the diff filter: a check using either runs over its full
+target set even during a `--diff-ref` scan. See
+[Configuration Reference → Discovery Methods](configuration.md#discovery-methods)
+for the full field reference for each.
 
 Diff filtering narrows findings to code touched by a git diff (plus call-graph flow). It activates automatically on all supporting discoveries whenever you provide a diff source (`--diff-ref`, `--diff-file`, `AGHAST_DIFF_REF`, or a check-level `diffRef`). OpenAnt (used for the call graph) is optional: if it isn't installed and no `AGHAST_OPENANT_DATASET` is provided, the filter falls back to **depth-0 mode** — file and line overlap only, no call-graph flow. A warning is logged when the fallback triggers. Set `checkTarget.diffFilter: false` on a specific check to exempt it. See [How It Works](how-it-works.md#diff-filtering-narrowing-a-discovery-to-changed-code) for details.
 

--- a/src/formatters/csv-formatter.ts
+++ b/src/formatters/csv-formatter.ts
@@ -24,6 +24,25 @@ import type { OutputFormatter } from './types.js';
 /** Maximum length of the description field in CSV output (longer values are truncated with an ellipsis). */
 const DESCRIPTION_MAX_LENGTH = 500;
 
+/**
+ * Judge columns are appended at the end and are ALWAYS present, even when the
+ * judge did not run (in which case they are empty).
+ *
+ * Two deliberate choices, both different from the HTML formatter:
+ *
+ *   - Appended, not inserted: a consumer reading by column index keeps working
+ *     for every column it already knew about.
+ *   - Unconditional, not "only when the judge ran": CSV is the format most
+ *     likely to be machine-parsed, and a header row that changes shape
+ *     depending on runtime configuration is far more hostile to a script than
+ *     a couple of empty columns. HTML can afford to hide an empty column
+ *     because a human reads it; a parser cannot.
+ *
+ * Scan-level cost is deliberately NOT a column. It is a single value for the
+ * whole run, so repeating it on every row would invite summing it — yielding
+ * cost × issue-count, silently and wrongly. It stays in the JSON, Markdown and
+ * HTML reports, where it can be shown once.
+ */
 const CSV_HEADERS = [
   'checkId',
   'checkName',
@@ -35,6 +54,9 @@ const CSV_HEADERS = [
   'confidence',
   'description',
   'recommendation',
+  'judgeVerdict',
+  'judgeConfidence',
+  'judgeRationale',
 ] as const;
 
 /** Escapes a single CSV field per RFC 4180. */
@@ -78,6 +100,13 @@ function issueRow(issue: SecurityIssue, checkStatus: string): string {
     escapeCsvField(issue.confidence),
     escapeCsvField(normalizeDescription(issue.description)),
     escapeCsvField(issue.recommendation),
+    escapeCsvField(issue.judge?.verdict),
+    // Confidence as a plain 0–1 number: spreadsheets can format or threshold it,
+    // which a "85%" string would prevent.
+    escapeCsvField(issue.judge?.confidence),
+    // Model-authored free text — flattened and truncated like description, so a
+    // multi-paragraph rationale cannot blow up the row.
+    escapeCsvField(issue.judge?.rationale ? normalizeDescription(issue.judge.rationale) : undefined),
   ].join(',');
 }
 
@@ -96,6 +125,9 @@ function errorCheckRow(check: CheckExecutionSummary): string {
     '', // confidence
     escapeCsvField(description),
     '', // recommendation
+    '', // judgeVerdict — an ERROR check produced no issue to judge
+    '', // judgeConfidence
+    '', // judgeRationale
   ].join(',');
 }
 

--- a/src/formatters/html-formatter.ts
+++ b/src/formatters/html-formatter.ts
@@ -18,7 +18,6 @@ import type {
   SecurityIssue,
   CheckExecutionSummary,
   RepositoryInfo,
-  ScanSummary,
 } from '../types.js';
 import type { OutputFormatter } from './types.js';
 
@@ -255,7 +254,47 @@ function renderHeader(results: ScanResults): string {
   `;
 }
 
-function renderSummary(summary: ScanSummary, _repo: RepositoryInfo): string {
+/**
+ * Format a cost for display. Sub-cent runs are common with cheap models, and
+ * rounding them to "$0.00" reads as "free" rather than "very small".
+ */
+function formatCost(amount: number, currency: string): string {
+  const decimals = amount > 0 && amount < 0.01 ? 4 : 2;
+  const value = amount.toFixed(decimals);
+  return currency === 'USD' ? `$${value}` : `${value} ${escapeHtml(currency)}`;
+}
+
+function renderSummary(results: ScanResults, _repo: RepositoryInfo): string {
+  const { summary } = results;
+  const extra: string[] = [];
+
+  // Judge tiles appear only when the stage ran. `judgedIssues` is the marker:
+  // every other counter is legitimately zero on a clean scan and cannot
+  // distinguish "judge ran and found nothing" from "judge never ran".
+  if (summary.judgedIssues !== undefined) {
+    extra.push(
+      `<div class="stat"><div class="num">${summary.judgedIssues}</div><div class="label">Judged</div></div>`,
+    );
+    if (summary.falsePositives !== undefined) {
+      extra.push(
+        `<div class="stat"><div class="num">${summary.falsePositives}</div><div class="label">False positives</div></div>`,
+      );
+    }
+    if (summary.uncertainJudgements !== undefined) {
+      extra.push(
+        `<div class="stat"><div class="num">${summary.uncertainJudgements}</div><div class="label">Uncertain</div></div>`,
+      );
+    }
+  }
+
+  const cost = results.metadata?.cost;
+  if (cost) {
+    extra.push(
+      `<div class="stat"><div class="num">${escapeHtml(formatCost(cost.totalCostUsd, cost.currency))}</div>`
+      + `<div class="label">Est. cost</div></div>`,
+    );
+  }
+
   return `
     <section class="summary-grid">
       <div class="stat"><div class="num">${summary.totalChecks}</div><div class="label">Checks</div></div>
@@ -264,6 +303,7 @@ function renderSummary(summary: ScanSummary, _repo: RepositoryInfo): string {
       <div class="stat"><div class="num">${summary.flaggedChecks}</div><div class="label">Flagged</div></div>
       <div class="stat"><div class="num">${summary.errorChecks}</div><div class="label">Errors</div></div>
       <div class="stat"><div class="num">${summary.totalIssues}</div><div class="label">Issues</div></div>
+      ${extra.join('\n      ')}
     </section>
   `;
 }
@@ -272,10 +312,20 @@ function renderIssuesTable(issues: SecurityIssue[], statusByCheck: Map<string, s
   if (issues.length === 0) {
     return `<section class="card"><h2>Issues</h2><p class="empty">No issues detected.</p></section>`;
   }
+  // Only carry a Verdict column when the judge actually annotated something.
+  // A permanently empty column on every non-judged scan is worse than none.
+  const hasVerdicts = issues.some((i) => i.judge);
   const rows = issues.map((issue) => {
     const sev = issue.severity ?? '';
     const sevCls = severityClass(issue.severity);
     const sevBadge = `<span class="badge ${sevCls}">${escapeHtml(sev || 'unknown')}</span>`;
+    const verdictCell = hasVerdicts
+      ? `<td>${issue.judge
+          ? `<span class="badge">${escapeHtml(issue.judge.verdict)}</span> `
+            + `<span title="${escapeHtml(issue.judge.rationale ?? '')}">`
+            + `${Math.round(issue.judge.confidence * 100)}%</span>`
+          : ''}</td>`
+      : '';
     // Fall back to 'UNKNOWN' (not 'FAIL') for orphaned issues so the row's
     // status badge and the data-status filter don't lie when an issue
     // references a checkId that isn't in the checks list.
@@ -291,6 +341,7 @@ function renderIssuesTable(issues: SecurityIssue[], statusByCheck: Map<string, s
         <td>${sevBadge}</td>
         <td><code>${escapeHtml(issue.file)}</code>:${escapeHtml(issue.startLine)}-${escapeHtml(issue.endLine)}</td>
         <td>${escapeHtml(issue.description)}</td>
+        ${verdictCell}
       </tr>
     `;
   }).join('');
@@ -317,7 +368,7 @@ function renderIssuesTable(issues: SecurityIssue[], statusByCheck: Map<string, s
       </div>
       <table id="issues-table" aria-label="Security issues">
         <thead>
-          <tr><th>Check ID</th><th>Check</th><th>Status</th><th>Severity</th><th>Location</th><th>Description</th></tr>
+          <tr><th>Check ID</th><th>Check</th><th>Status</th><th>Severity</th><th>Location</th><th>Description</th>${hasVerdicts ? '<th>Verdict</th>' : ''}</tr>
         </thead>
         <tbody>${rows}</tbody>
       </table>
@@ -397,7 +448,7 @@ export class HtmlFormatter implements OutputFormatter {
 <body>
   <div class="container">
     ${renderHeader(results)}
-    ${renderSummary(results.summary, results.repository)}
+    ${renderSummary(results, results.repository)}
     ${renderIssuesTable(results.issues, statusByCheck)}
     ${renderCheckDetails(results.checks, issuesByCheck)}
     <footer>Generated by aghast v${escapeHtml(results.version)}</footer>

--- a/src/formatters/markdown-formatter.ts
+++ b/src/formatters/markdown-formatter.ts
@@ -298,6 +298,19 @@ function renderIssue(issue: SecurityIssue, ordinal: number): string[] {
     lines.push('');
     lines.push(issue.recommendation);
   }
+  if (issue.judge) {
+    lines.push('');
+    lines.push('**Judge verdict:**');
+    lines.push('');
+    const confidence = `${Math.round(issue.judge.confidence * 100)}% confidence`;
+    lines.push(`- **Verdict:** ${issue.judge.verdict} (${confidence})`);
+    lines.push(`- **Model:** ${inlineCode(issue.judge.model)}`);
+    if (issue.judge.rationale) {
+      // Rationale is model-authored free text; escape it so a stray backtick or
+      // pipe cannot break out of the bullet and corrupt the rest of the report.
+      lines.push(`- **Rationale:** ${escapeInlineText(issue.judge.rationale)}`);
+    }
+  }
   return lines;
 }
 
@@ -374,6 +387,51 @@ function renderStatistics(results: ScanResults): string {
       + `output ${results.tokenUsage.outputTokens.toLocaleString('en-US')})`,
     );
   }
+  // Cost sits with tokens rather than under its own heading: it is the same
+  // question ("what did this run consume?") and the reader is already here.
+  const cost = results.metadata?.cost;
+  if (cost) {
+    lines.push(`- **Estimated cost:** ${formatCost(cost.totalCostUsd, cost.currency)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format a cost for display. Sub-cent runs are common with cheap models, and
+ * rounding them to "$0.00" reads as "free" rather than "very small", so those
+ * get four decimal places instead of two.
+ */
+function formatCost(amount: number, currency: string): string {
+  const decimals = amount > 0 && amount < 0.01 ? 4 : 2;
+  const value = amount.toFixed(decimals);
+  return currency === 'USD' ? `$${value}` : `${value} ${escapeInlineText(currency)}`;
+}
+
+/**
+ * Judge verdict counts. Rendered only when the judge stage ran — `judgedIssues`
+ * is the marker, since every other counter is legitimately zero on a clean scan
+ * and cannot distinguish "judge ran and found nothing" from "judge never ran".
+ */
+function renderJudgeSummary(results: ScanResults): string | null {
+  const { summary } = results;
+  if (summary.judgedIssues === undefined) return null;
+
+  const lines: string[] = [];
+  lines.push('## Judge Verdicts');
+  lines.push('');
+  lines.push(`- **Issues judged:** ${summary.judgedIssues}`);
+  if (summary.falsePositives !== undefined) {
+    lines.push(`- **Judged false positive:** ${summary.falsePositives}`);
+  }
+  if (summary.uncertainJudgements !== undefined) {
+    lines.push(`- **Uncertain:** ${summary.uncertainJudgements}`);
+  }
+  if (summary.flaggedByCheck !== undefined) {
+    lines.push(`- **Flagged by check:** ${summary.flaggedByCheck}`);
+  }
+  if (summary.flaggedByJudge !== undefined) {
+    lines.push(`- **Flagged by judge:** ${summary.flaggedByJudge}`);
+  }
   return lines.join('\n');
 }
 
@@ -444,6 +502,8 @@ export class MarkdownFormatter implements OutputFormatter {
     if (flagged) sections.push(flagged);
     const errors = renderErrors(results);
     if (errors) sections.push(errors);
+    const judge = renderJudgeSummary(results);
+    if (judge) sections.push(judge);
     sections.push(renderStatistics(results));
     const ci = renderCIMetadata(results);
     if (ci) sections.push(ci);

--- a/src/issue-file-writer.ts
+++ b/src/issue-file-writer.ts
@@ -10,13 +10,16 @@
  * markup in AI responses or source code snippets.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, readdir, unlink } from 'node:fs/promises';
 import { basename, resolve, sep } from 'node:path';
 import type { ScanResults, SecurityIssue, DataFlowStep } from './types.js';
 // Reuse the shared escaper from the HTML report formatter rather than keeping a
 // second copy — it also handles null/undefined, which a local `string`-only
 // version did not.
 import { escapeHtml } from './formatters/html-formatter.js';
+import { logDebug } from './logging.js';
+
+const TAG = 'issue-files';
 
 export type IndividualIssueFormat = 'markdown' | 'json' | 'html';
 
@@ -226,6 +229,59 @@ export interface WriteIndividualIssueFilesResult {
  * @param format Output format (`markdown` | `json` | `html`).
  * @returns Root directory and the list of files written.
  */
+/**
+ * Matches only the files this module generates: `issue_<NNN>_<slug>.<ext>` with
+ * one of the three known extensions.
+ *
+ * Deliberately strict. The output directory is a normal directory a user may
+ * keep other things in — notes, a README, a previous run they copied aside — and
+ * a loose glob would delete them. Anything not matching this exact shape is
+ * left alone, and directories are never removed.
+ */
+const GENERATED_ISSUE_FILE = /^issue_\d{3,}_.*\.(?:md|json|html)$/;
+
+/**
+ * Remove issue files left by a previous run.
+ *
+ * Without this, a run that produces fewer findings than the last one leaves the
+ * surplus behind: the writer numbers from 1 each time, so old `issue_004_*`
+ * files survive and read as current findings. Stale results in a security
+ * report are worse than no results.
+ *
+ * Best-effort by design — a directory that cannot be read is skipped rather
+ * than failing the scan, since the report itself has already been written.
+ */
+async function clearStaleIssueFiles(rootDir: string): Promise<number> {
+  let removed = 0;
+  let entries;
+  try {
+    entries = await readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return 0; // First run: nothing to clear.
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const checkDir = resolve(rootDir, entry.name);
+    let files;
+    try {
+      files = await readdir(checkDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.isFile() || !GENERATED_ISSUE_FILE.test(file.name)) continue;
+      try {
+        await unlink(resolve(checkDir, file.name));
+        removed++;
+      } catch {
+        // Locked or already gone — the write below will overwrite what it can.
+      }
+    }
+  }
+  return removed;
+}
+
 export async function writeIndividualIssueFiles(
   results: ScanResults,
   outputDir: string,
@@ -234,6 +290,13 @@ export async function writeIndividualIssueFiles(
   const projectName = deriveProjectName(results);
   const rootDir = resolve(outputDir, `security_issues_${projectName}`);
   await mkdir(rootDir, { recursive: true });
+
+  // Clear before writing, so a run with fewer findings than the last one does
+  // not leave the surplus behind looking current.
+  const removed = await clearStaleIssueFiles(rootDir);
+  if (removed > 0) {
+    logDebug(TAG, `Removed ${removed} issue file(s) from a previous run in ${rootDir}`);
+  }
 
   // Group issues by checkId, preserving order (the order issues were collected).
   const grouped = new Map<string, SecurityIssue[]>();

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -6,7 +6,7 @@
 
 import { logProgress, logDebug, logWarn, createTimer } from './logging.js';
 import { type AgentProvider, type AgentResponse, type SecurityIssue, type JudgeVerdict } from './types.js';
-import { withRetry, defaultIsRetryable, DEFAULT_RETRY, type RetryOptions, type CircuitBreaker } from './retry.js';
+import { withRetry, defaultIsRetryable, DEFAULT_RETRY, AgentTimeoutError, type RetryOptions, type CircuitBreaker } from './retry.js';
 import { BudgetExceededError } from './budget.js';
 import { type ScanCostTracker, preflightBudget, recordUsage } from './cost-tracker.js';
 import { type AbortHandle, mapWithConcurrency } from './concurrency.js';
@@ -20,9 +20,12 @@ const DEFAULT_JUDGE_TIMEOUT_MS = 5 * 60 * 1000;
  * DEFAULT_JUDGE_TIMEOUT_MS. Module-private: callers distinguish it via
  * `instanceof JudgeTimeoutError` inside this module only.
  */
-class JudgeTimeoutError extends Error {
+class JudgeTimeoutError extends AgentTimeoutError {
   constructor(timeoutSeconds: number) {
     super(`Judge provider timed out after ${timeoutSeconds}s`);
+    // Deliberately does NOT override `name`: the retry classifier matches on
+    // `AgentTimeoutError` by name (so it survives a serialization boundary),
+    // and callers in this module distinguish it with `instanceof` anyway.
   }
 }
 

--- a/src/result-handlers/pr-comment-handler.ts
+++ b/src/result-handlers/pr-comment-handler.ts
@@ -76,6 +76,12 @@ export interface PRCommentContext {
 export interface PRCommentResult {
   posted: number;
   skipped: number;
+  /**
+   * Findings that were eligible to post but exceeded the per-review cap. They
+   * are named in the review summary and remain in the scan report; they are not
+   * counted as `skipped`, which means "deliberately not applicable".
+   */
+  omitted?: number;
 }
 
 /**
@@ -373,15 +379,30 @@ async function listExistingReviewComments(
   });
 }
 
+/**
+ * Upper bound on inline comments in a single review.
+ *
+ * A noisy check against a large diff could otherwise post hundreds of comments
+ * in one API call — unreviewable for the author, and large enough to risk the
+ * request being rejected outright, which loses every comment rather than some.
+ * Truncating is the lesser harm, and it is surfaced in the review body rather
+ * than dropped silently. Mirrors `limitTargets` in the SARIF parser.
+ */
+const DEFAULT_MAX_INLINE_COMMENTS = 50;
+
 async function postReview(
   executor: CommandExecutor,
   ctx: PRCommentContext,
   comments: ReviewComment[],
+  omitted = 0,
 ): Promise<void> {
   const path = `repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.prNumber}/reviews`;
+  const summary = `aghast posted ${comments.length} finding${comments.length === 1 ? '' : 's'}.`;
   const body: Record<string, unknown> = {
     event: 'COMMENT',
-    body: `aghast posted ${comments.length} finding${comments.length === 1 ? '' : 's'}.`,
+    body: omitted > 0
+      ? `${summary} ${omitted} further finding${omitted === 1 ? '' : 's'} ${omitted === 1 ? 'was' : 'were'} not posted inline (capped at ${comments.length} per review) — see the full scan report for the complete list.`
+      : summary,
     comments,
   };
   if (ctx.headSha) body.commit_id = ctx.headSha;
@@ -398,6 +419,11 @@ async function postReview(
 export interface PostPRCommentsOptions {
   /** Inject a custom executor for testing. Defaults to spawning `gh`. */
   executor?: CommandExecutor;
+  /**
+   * Maximum inline comments in one review (default 50). Findings beyond the cap
+   * are reported in the review summary rather than dropped silently.
+   */
+  maxComments?: number;
 }
 
 /**
@@ -495,11 +521,27 @@ export async function postPRComments(
     return { posted: 0, skipped: totalSkipped };
   }
 
-  await postReview(executor, ctx, toPost);
+  const maxComments = options.maxComments ?? DEFAULT_MAX_INLINE_COMMENTS;
+  const capped = toPost.slice(0, maxComments);
+  const omitted = toPost.length - capped.length;
+  if (omitted > 0) {
+    logWarn(
+      TAG,
+      `${toPost.length} comments to post exceeds the cap of ${maxComments}; ` +
+        `posting the first ${capped.length} and noting the remaining ${omitted} in the review summary. ` +
+        'All findings remain in the scan report.',
+    );
+  }
+
+  await postReview(executor, ctx, capped, omitted);
   logProgress(
     TAG,
-    `Posted ${toPost.length} comment(s); skipped ${totalSkipped} (${skippedOutsideDiff} outside diff, ${skippedDuplicate} duplicate)`,
+    `Posted ${capped.length} comment(s); skipped ${totalSkipped} (${skippedOutsideDiff} outside diff, ${skippedDuplicate} duplicate)`,
   );
 
-  return { posted: toPost.length, skipped: totalSkipped };
+  // Only present when something was actually omitted, so the result shape is
+  // unchanged for the overwhelmingly common case (and for existing consumers).
+  return omitted > 0
+    ? { posted: capped.length, skipped: totalSkipped, omitted }
+    : { posted: capped.length, skipped: totalSkipped };
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -110,6 +110,12 @@ export function defaultIsRetryable(err: unknown): boolean {
   //    crossed a serialization boundary and lost their prototype.
   if (e.name === 'FatalProviderError' || e.name === 'BudgetExceededError') return false;
 
+  // 0b. aghast's own timeout guard. Classified explicitly rather than falling
+  //     through to the message fallback below, so the decision is deliberate and
+  //     testable rather than a side effect of the word "timeout" appearing in
+  //     the text. Retryable: a hung stream often succeeds on a fresh call.
+  if (e.name === 'AgentTimeoutError') return true;
+
   // 1. Status code (authoritative). If present, this short-circuits message inspection.
   const status = e.status ?? e.statusCode;
   if (typeof status === 'number') {
@@ -154,6 +160,27 @@ export function defaultIsRetryable(err: unknown): boolean {
 export interface CircuitBreakerOptions {
   /** Maximum consecutive total failures before tripping. Must be >= 1. */
   threshold: number;
+}
+
+/**
+ * Thrown when aghast's own per-call guard fires because a provider call did not
+ * return in time. Distinct from a provider-reported network timeout.
+ *
+ * Named rather than message-matched so the retry decision is deliberate: before
+ * this existed, the classification depended on the word "timeout" appearing in
+ * a free-text message, which is exactly the incidental matching the classifier
+ * warns against elsewhere.
+ *
+ * It IS retryable — a hung stream frequently succeeds on a fresh call — but the
+ * cost is visible: with `maxAttempts: n` a genuinely wedged provider takes up to
+ * n × the timeout to give up. That trade is documented in
+ * docs/configuration.md so anyone enabling retry knows what they are buying.
+ */
+export class AgentTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentTimeoutError';
+  }
 }
 
 /** Thrown by `withRetry` when the breaker is open (failing fast). */

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -155,6 +155,36 @@ export async function loadRuntimeConfig(configDir?: string, explicitPath?: strin
       }
     }
   }
+  if (obj.retry !== undefined) {
+    if (typeof obj.retry !== 'object' || obj.retry === null || Array.isArray(obj.retry)) {
+      throw new Error(`Runtime config "${pathToLoad}": "retry" must be an object`);
+    }
+    const retry = obj.retry as Record<string, unknown>;
+    // Validated at load rather than at first use: an invalid retry setting
+    // otherwise surfaces mid-scan, after AI calls have already been paid for.
+    const positiveInt = (key: string, min: number): void => {
+      const value = retry[key];
+      if (value === undefined) return;
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < min) {
+        throw new Error(
+          `Runtime config "${pathToLoad}": "retry.${key}" must be an integer >= ${min}`,
+        );
+      }
+    };
+    // maxAttempts counts the first attempt, so 1 is valid and means no retry.
+    positiveInt('maxAttempts', 1);
+    positiveInt('baseDelayMs', 0);
+    positiveInt('maxDelayMs', 0);
+    positiveInt('circuitBreakerThreshold', 1);
+
+    const base = retry.baseDelayMs;
+    const max = retry.maxDelayMs;
+    if (typeof base === 'number' && typeof max === 'number' && max < base) {
+      throw new Error(
+        `Runtime config "${pathToLoad}": "retry.maxDelayMs" (${max}) must be >= "retry.baseDelayMs" (${base})`,
+      );
+    }
+  }
   if (obj.pricing !== undefined) {
     if (typeof obj.pricing !== 'object' || obj.pricing === null || Array.isArray(obj.pricing)) {
       throw new Error(`Runtime config "${pathToLoad}": "pricing" must be an object`);

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -48,7 +48,7 @@ import type { ScanRecord } from './scan-history.js';
 import { collectCIMetadata } from './ci-metadata.js';
 import { type ScanCostTracker, createCostTracker, recordUsage, preflightBudget } from './cost-tracker.js';
 import { type AbortHandle, mapWithConcurrency } from './concurrency.js';
-import { withRetry, defaultIsRetryable, CircuitBreaker, DEFAULT_RETRY, isRetryEnabled, type RetryOptions } from './retry.js';
+import { withRetry, defaultIsRetryable, CircuitBreaker, DEFAULT_RETRY, isRetryEnabled, AgentTimeoutError, type RetryOptions } from './retry.js';
 import { type JudgeOptions, runJudge, applyJudgeResults } from './judge.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -754,7 +754,7 @@ async function executeTargetedCheck(
               ),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(
-                  () => reject(new Error(
+                  () => reject(new AgentTimeoutError(
                     `Agent provider timed out after ${DEFAULT_TARGET_TIMEOUT_MS / 1000}s on target ${target.label}`,
                   )),
                   DEFAULT_TARGET_TIMEOUT_MS,

--- a/tests/csv-formatter.test.ts
+++ b/tests/csv-formatter.test.ts
@@ -41,7 +41,7 @@ describe('CsvFormatter', () => {
     assert.equal(lines.length, 1);
     assert.equal(
       lines[0],
-      'checkId,checkName,status,file,startLine,endLine,severity,confidence,description,recommendation',
+      'checkId,checkName,status,file,startLine,endLine,severity,confidence,description,recommendation,judgeVerdict,judgeConfidence,judgeRationale',
     );
   });
 
@@ -73,7 +73,9 @@ describe('CsvFormatter', () => {
     assert.equal(lines.length, 2);
     assert.equal(
       lines[1],
-      'c1,C1,FAIL,src/app.ts,10,15,high,medium,SQL injection,Use parameterized queries',
+      // Trailing empty cells are the judge columns, which are always present so
+      // the header shape does not change with runtime configuration.
+      'c1,C1,FAIL,src/app.ts,10,15,high,medium,SQL injection,Use parameterized queries,,,',
     );
   });
 
@@ -186,7 +188,7 @@ describe('CsvFormatter', () => {
     });
     const out = formatter.format(results);
     const lines = out.split('\r\n').filter((l) => l.length > 0);
-    assert.equal(lines[1], 'c1,C1,FAIL,a.ts,1,1,,,x,');
+    assert.equal(lines[1], 'c1,C1,FAIL,a.ts,1,1,,,x,,,,');
   });
 
   it('orphaned issue (no matching checks entry) gets status UNKNOWN', () => {
@@ -251,5 +253,61 @@ describe('normalizeDescription', () => {
     const out = normalizeDescription('x'.repeat(600));
     assert.equal(out.length, 500);
     assert.ok(out.endsWith('…'));
+  });
+});
+
+describe('CsvFormatter: judge verdict columns', () => {
+  const formatter = new CsvFormatter();
+
+  it('emits verdict, confidence and rationale for a judged issue', () => {
+    const out = formatter.format(makeResults({
+      issues: [{
+        checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'x',
+        judge: {
+          verdict: 'false_positive',
+          confidence: 0.92,
+          rationale: 'Input is validated upstream.',
+          model: 'claude-opus-4-7',
+          provider: 'claude-code',
+        },
+      }],
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issueCount: 1, executionTime: 1 }],
+    }));
+    const row = out.split('\r\n')[1]!;
+    assert.ok(row.endsWith('false_positive,0.92,Input is validated upstream.'), `unexpected row: ${row}`);
+  });
+
+  it('flattens and quotes a multi-line rationale so the row stays intact', () => {
+    const out = formatter.format(makeResults({
+      issues: [{
+        checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'x',
+        judge: {
+          verdict: 'uncertain',
+          confidence: 0.4,
+          rationale: 'Line one,\nline two\r\nline three',
+          model: 'm', provider: 'p',
+        },
+      }],
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issueCount: 1, executionTime: 1 }],
+    }));
+    const lines = out.split('\r\n').filter((l) => l.length > 0);
+    // The embedded newlines must not split the row, and the comma must be quoted.
+    assert.equal(lines.length, 2, `rationale newlines leaked into new rows: ${JSON.stringify(lines)}`);
+    assert.ok(lines[1]!.includes('"Line one, line two line three"'), `unexpected row: ${lines[1]}`);
+  });
+
+  it('scan-level cost is deliberately absent — summing a repeated scalar would mislead', () => {
+    const out = formatter.format(makeResults({
+      metadata: { cost: { totalCostUsd: 1.23, currency: 'USD' } },
+      issues: [
+        { checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x' },
+        { checkId: 'c1', checkName: 'C1', file: 'b.ts', startLine: 2, endLine: 2, description: 'y' },
+      ],
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issueCount: 2, executionTime: 1 }],
+    }));
+    assert.ok(!out.includes('1.23'), 'cost must not appear per-row in CSV');
+    assert.ok(!out.toLowerCase().includes('cost'), 'no cost column should exist');
   });
 });

--- a/tests/docs-discovery-consistency.test.ts
+++ b/tests/docs-discovery-consistency.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Guards the documentation tables that enumerate discovery methods.
+ *
+ * Adding a discovery method touches the registry plus several independent docs
+ * locations, and nothing forced them to agree. In practice they drifted: `glob`
+ * and `script` each landed in some tables and not others, at different times.
+ * This test makes the registry the single source of truth — add a discovery and
+ * the suite tells you exactly which docs still need it.
+ *
+ * It deliberately asserts only that each method is *mentioned* in the right
+ * region of each file. Asserting on wording would make every copy-edit a test
+ * failure, which is how consistency tests get deleted.
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Importing the scan runner registers the built-in discoveries as a side effect.
+import '../src/scan-runner.js';
+import { getRegisteredDiscoveries } from '../src/discovery.js';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const docsDir = resolve(testDir, '..', 'docs');
+
+/**
+ * Each entry names a docs file and the section that enumerates discoveries.
+ * `section` is matched from its heading to the next heading of the same or
+ * higher level, so an unrelated mention elsewhere in the file cannot satisfy
+ * the assertion.
+ */
+const DOC_TARGETS = [
+  // `table` requires a real row (`| \`glob\` | ...`). Plain "is it mentioned
+  // somewhere nearby" is not enough: surrounding prose that explains a
+  // discovery would satisfy it, and the check would pass with the row deleted.
+  { file: 'scanning.md', heading: '| Discovery | Requires |', mode: 'table' },
+  { file: 'configuration.md', heading: '| Discovery | Requires |', mode: 'table' },
+  // `prose` is a bullet list, so a mention in the block is the right assertion.
+  { file: 'how-it-works.md', heading: 'Discovery methods are deterministic', mode: 'prose' },
+] as const;
+
+/** Extract the table or paragraph block starting at `heading`. */
+function sectionFrom(content: string, heading: string): string {
+  const start = content.indexOf(heading);
+  if (start === -1) return '';
+  // Take a generous window: the enumerations are contiguous blocks, and a
+  // fixed line budget is more robust than guessing the next heading level.
+  return content.slice(start).split('\n').slice(0, 40).join('\n');
+}
+
+describe('docs: discovery method tables match the registry', () => {
+  let registered: string[];
+
+  before(() => {
+    registered = getRegisteredDiscoveries();
+  });
+
+  it('registry is non-empty (guards against the import side effect breaking)', () => {
+    assert.ok(
+      registered.length >= 6,
+      `expected the built-in discoveries to be registered, got: ${registered.join(', ') || '(none)'}`,
+    );
+  });
+
+  for (const { file, heading, mode } of DOC_TARGETS) {
+    it(`${file} enumerates every registered discovery`, async () => {
+      const content = await readFile(resolve(docsDir, file), 'utf-8');
+      const section = sectionFrom(content, heading);
+      assert.notEqual(
+        section,
+        '',
+        `could not locate the discovery section in ${file} (looked for "${heading}") — ` +
+          'if the docs were restructured, update DOC_TARGETS in this test',
+      );
+
+      // Case-insensitive: tables use the literal id (`opengrep`) while prose
+      // uses a display form (**Opengrep**). Both count as documenting it.
+      const haystack = section.toLowerCase();
+      const missing = registered.filter((name) => {
+        const id = name.toLowerCase();
+        return mode === 'table'
+          // Must be its own row, not merely named in nearby prose.
+          ? !new RegExp(`^\\|\\s*\`${id}\`\\s*\\|`, 'm').test(haystack)
+          : !haystack.includes(id);
+      });
+      assert.deepEqual(
+        missing,
+        [],
+        `${file} is missing ${mode === 'table' ? 'table rows' : 'mentions'} for: ${missing.join(', ')}`,
+      );
+    });
+  }
+
+  it('the checkTarget.discovery field reference lists every registered discovery', async () => {
+    const content = await readFile(resolve(docsDir, 'configuration.md'), 'utf-8');
+    const line = content
+      .split('\n')
+      .find((l) => l.includes('`checkTarget.discovery`'));
+    assert.ok(line, 'configuration.md should document the checkTarget.discovery field');
+
+    const missing = registered.filter((name) => !line.includes(`\`${name}\``));
+    assert.deepEqual(
+      missing,
+      [],
+      `the checkTarget.discovery row omits: ${missing.join(', ')}`,
+    );
+  });
+});

--- a/tests/html-formatter.test.ts
+++ b/tests/html-formatter.test.ts
@@ -310,3 +310,73 @@ describe('escapeJsonForScriptTag', () => {
     assert.equal(parsed.x, original);
   });
 });
+
+describe('HtmlFormatter: cost and judge verdicts', () => {
+  const formatter = new HtmlFormatter();
+
+  it('renders an estimated-cost stat tile when cost metadata exists', () => {
+    const out = formatter.format(makeResults({
+      metadata: { cost: { totalCostUsd: 2.5, currency: 'USD' } },
+    }));
+    assert.ok(out.includes('Est. cost'), 'cost tile should be present');
+    assert.ok(out.includes('$2.50'), 'cost value should be rendered');
+  });
+
+  it('omits the cost tile when there is no cost metadata', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(!out.includes('Est. cost'), 'no cost tile without cost metadata');
+  });
+
+  it('renders judge tiles only when the judge stage ran', () => {
+    const without = formatter.format(makeResults());
+    assert.ok(!without.includes('>Judged<'), 'no judge tile when the stage did not run');
+
+    const withJudge = formatter.format(makeResults({
+      summary: {
+        totalChecks: 1, passedChecks: 0, failedChecks: 1, flaggedChecks: 0,
+        errorChecks: 0, totalIssues: 2,
+        judgedIssues: 2, falsePositives: 1, uncertainJudgements: 0,
+      },
+    }));
+    assert.ok(withJudge.includes('>Judged<'), 'judge tile should appear');
+    assert.ok(withJudge.includes('False positives'), 'false-positive tile should appear');
+  });
+
+  it('adds a Verdict column only when at least one issue was judged', () => {
+    const unjudged = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 1 }],
+      issues: [{ checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x' }],
+    }));
+    assert.ok(!unjudged.includes('<th>Verdict</th>'), 'no empty Verdict column on an unjudged scan');
+
+    const judged = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 1 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+        judge: {
+          verdict: 'false_positive', confidence: 0.9,
+          rationale: 'Validated upstream', model: 'm', provider: 'p',
+        },
+      }],
+    }));
+    assert.ok(judged.includes('<th>Verdict</th>'), 'Verdict column should appear');
+    assert.ok(judged.includes('false_positive'), 'verdict value should render');
+    assert.ok(judged.includes('90%'), 'confidence should render as a percentage');
+  });
+
+  it('escapes a malicious rationale in the verdict tooltip (XSS safety)', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 1 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1, description: 'x',
+        judge: {
+          verdict: 'uncertain', confidence: 0.5,
+          rationale: '"><script>alert(1)</script>',
+          model: 'm', provider: 'p',
+        },
+      }],
+    }));
+    assert.ok(!out.includes('<script>alert(1)</script>'), 'rationale must not inject raw script markup');
+    assert.ok(out.includes('&lt;script&gt;'), 'rationale should be HTML-escaped');
+  });
+});

--- a/tests/issue-file-writer.test.ts
+++ b/tests/issue-file-writer.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import { writeIndividualIssueFiles } from '../src/issue-file-writer.js';
@@ -268,6 +268,47 @@ describe('writeIndividualIssueFiles', () => {
       () => writeIndividualIssueFiles(makeResults([makeIssue()]), out, 'pdf'),
       /Unsupported individual issue format: pdf/,
     );
+  });
+
+  it('clears issue files from a previous run with more findings', async () => {
+    const out = resolve(tmp, 'case-stale');
+    // First run: three findings.
+    await writeIndividualIssueFiles(
+      makeResults([makeIssue(), makeIssue({ file: 'src/b.ts' }), makeIssue({ file: 'src/c.ts' })]),
+      out,
+      'markdown',
+    );
+    const checkDir = join(out, 'security_issues_my-app', 'aghast-sqli');
+    assert.equal((await readdir(checkDir)).length, 3, 'first run should write 3 files');
+
+    // Second run: one finding. Without clearing, issue_002 and issue_003 survive
+    // and read as current findings — stale results in a security report.
+    await writeIndividualIssueFiles(makeResults([makeIssue()]), out, 'markdown');
+    const after = await readdir(checkDir);
+    assert.deepEqual(
+      after.sort(),
+      ['issue_001_example.ts.md'],
+      `stale files were left behind: ${after.join(', ')}`,
+    );
+  });
+
+  it('leaves files it did not generate alone when clearing', async () => {
+    const out = resolve(tmp, 'case-foreign');
+    await writeIndividualIssueFiles(makeResults([makeIssue(), makeIssue({ file: 'src/b.ts' })]), out, 'markdown');
+    const checkDir = join(out, 'security_issues_my-app', 'aghast-sqli');
+
+    // Things a user might legitimately keep alongside the output.
+    await writeFile(join(checkDir, 'NOTES.md'), 'my triage notes', 'utf-8');
+    await writeFile(join(checkDir, 'issue_summary.md'), 'not a generated file', 'utf-8');
+
+    await writeIndividualIssueFiles(makeResults([makeIssue()]), out, 'markdown');
+    const after = (await readdir(checkDir)).sort();
+    assert.ok(after.includes('NOTES.md'), 'unrelated file must survive');
+    assert.ok(
+      after.includes('issue_summary.md'),
+      'a file that only looks like a generated name (no NNN_) must survive',
+    );
+    assert.ok(!after.includes('issue_002_b.ts.md'), 'stale generated file should be gone');
   });
 
   it('derives project name from remoteUrl when path is missing', async () => {

--- a/tests/markdown-formatter.test.ts
+++ b/tests/markdown-formatter.test.ts
@@ -579,3 +579,66 @@ describe('MarkdownFormatter — escape edge cases', () => {
     assert.ok(md.includes('\\`code\\`'), 'backticks must be escaped');
   });
 });
+
+describe('MarkdownFormatter: cost and judge verdicts', () => {
+  const formatter = new MarkdownFormatter();
+
+  it('renders estimated cost in Statistics', () => {
+    const out = formatter.format(makeResults({
+      metadata: { cost: { totalCostUsd: 1.5, currency: 'USD' } },
+    }));
+    assert.match(out, /- \*\*Estimated cost:\*\* \$1\.50/);
+  });
+
+  it('shows sub-cent cost at four decimals rather than rounding to $0.00', () => {
+    const out = formatter.format(makeResults({
+      metadata: { cost: { totalCostUsd: 0.0023, currency: 'USD' } },
+    }));
+    assert.match(out, /\$0\.0023/, 'a tiny cost must not read as free');
+    assert.ok(!out.includes('$0.00 '), 'must not round a real cost to zero');
+  });
+
+  it('omits cost entirely when no pricing was available', () => {
+    const out = formatter.format(makeResults());
+    assert.ok(!out.includes('Estimated cost'), 'no cost section without cost metadata');
+  });
+
+  it('renders a Judge Verdicts section only when the judge ran', () => {
+    const without = formatter.format(makeResults());
+    assert.ok(!without.includes('## Judge Verdicts'), 'no judge section when the stage did not run');
+
+    const withJudge = formatter.format(makeResults({
+      summary: {
+        totalChecks: 1, passedChecks: 0, failedChecks: 1, flaggedChecks: 0,
+        errorChecks: 0, totalIssues: 3,
+        judgedIssues: 3, falsePositives: 1, uncertainJudgements: 1,
+      },
+    }));
+    assert.match(withJudge, /## Judge Verdicts/);
+    assert.match(withJudge, /- \*\*Issues judged:\*\* 3/);
+    assert.match(withJudge, /- \*\*Judged false positive:\*\* 1/);
+  });
+
+  it('renders a per-issue verdict and escapes the model-authored rationale', () => {
+    const out = formatter.format(makeResults({
+      checks: [{ checkId: 'c1', checkName: 'C1', status: 'FAIL', issuesFound: 1, executionTime: 1 }],
+      issues: [{
+        checkId: 'c1', checkName: 'C1', file: 'a.ts', startLine: 1, endLine: 1,
+        description: 'x',
+        judge: {
+          verdict: 'true_positive', confidence: 0.85,
+          // Pipes and backticks would otherwise corrupt surrounding markdown.
+          rationale: 'Sees `raw` input | unsanitised',
+          model: 'claude-opus-4-7', provider: 'claude-code',
+        },
+      }],
+    }));
+    assert.match(out, /\*\*Verdict:\*\* true_positive \(85% confidence\)/);
+    // Built by concatenation so the backslash-backtick pair is unambiguous in
+    // source: the formatter emits \` for a backtick and \| for a pipe.
+    const bs = String.fromCharCode(92); // backslash
+    const tick = String.fromCharCode(96); // backtick
+    assert.ok(out.includes(bs + tick + 'raw' + bs + tick), 'backticks in rationale must be escaped');
+    assert.ok(out.includes(bs + '|'), 'pipes in rationale must be escaped');
+  });
+});

--- a/tests/pr-comment-handler.test.ts
+++ b/tests/pr-comment-handler.test.ts
@@ -383,3 +383,48 @@ describe('postPRComments', () => {
     assert.ok(postCall, 'should still post the review when dedup listing fails');
   });
 });
+
+// ─── Inline comment cap ──────────────────────────────────────────────────────
+
+describe('postPRComments: caps inline comments per review', () => {
+  const ctx = { owner: 'octo', repo: 'demo', prNumber: 42 };
+
+  // One file with a large added hunk, so every issue lands inside the diff.
+  const bigPatch = ['@@ -1,1 +1,60 @@', ' a', ...Array.from({ length: 59 }, (_, i) => `+line ${i + 2}`)].join('\n');
+  const filesPayload: PullRequestFile[] = [
+    { filename: 'src/db.ts', status: 'modified', patch: bigPatch },
+  ];
+
+  it('posts at most maxComments and reports the remainder in the review body', async () => {
+    const { executor, calls } = makeFakeExecutor({
+      responses: [{ match: /pulls\/42\/files/, body: filesPayload }],
+    });
+    // 10 in-diff findings, cap of 4.
+    const issues = Array.from({ length: 10 }, (_, i) =>
+      makeIssue({ file: 'src/db.ts', startLine: i + 2, description: `finding ${i}` }),
+    );
+
+    const result = await postPRComments(makeResults(issues), ctx, { executor, maxComments: 4 });
+
+    assert.equal(result.posted, 4, 'should post exactly the cap');
+    assert.equal(result.omitted, 6, 'should report the rest as omitted, not skipped');
+    assert.equal(result.skipped, 0, 'omitted findings are not "skipped" — they were eligible');
+
+    const postCall = calls.find((c) => c.args.includes('--method'));
+    assert.ok(postCall, 'should post a review');
+    const payload = JSON.parse(postCall.input as string) as { body: string; comments: unknown[] };
+    assert.equal(payload.comments.length, 4, 'payload must carry only the capped comments');
+    // The omission must be visible to a human reading the PR, not just in logs.
+    assert.match(payload.body, /6 further findings were not posted inline/);
+    assert.match(payload.body, /full scan report/);
+  });
+
+  it('omits the field entirely when nothing was capped', async () => {
+    const { executor } = makeFakeExecutor({
+      responses: [{ match: /pulls\/42\/files/, body: filesPayload }],
+    });
+    const issues = [makeIssue({ file: 'src/db.ts', startLine: 2 })];
+    const result = await postPRComments(makeResults(issues), ctx, { executor, maxComments: 50 });
+    assert.deepEqual(result, { posted: 1, skipped: 0 }, 'result shape must be unchanged when nothing is capped');
+  });
+});

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -292,3 +292,54 @@ test('loadRuntimeConfig: rejects non-object root (e.g., array)', async () => {
     await unlinkSync(tmpPath);
   }
 });
+
+// Retry config was previously unvalidated, unlike budget: a bad value surfaced
+// mid-scan, after AI calls had already been paid for, rather than at load.
+test('loadRuntimeConfig: rejects invalid retry settings', async () => {
+  const { writeFile, unlink } = await import('node:fs/promises');
+  const cases: Array<{ config: unknown; expect: string }> = [
+    { config: { retry: [] }, expect: '"retry" must be an object' },
+    { config: { retry: { maxAttempts: 0 } }, expect: '"retry.maxAttempts" must be an integer >= 1' },
+    { config: { retry: { maxAttempts: 2.5 } }, expect: '"retry.maxAttempts" must be an integer >= 1' },
+    { config: { retry: { baseDelayMs: -1 } }, expect: '"retry.baseDelayMs" must be an integer >= 0' },
+    { config: { retry: { circuitBreakerThreshold: 0 } }, expect: '"retry.circuitBreakerThreshold" must be an integer >= 1' },
+    {
+      config: { retry: { baseDelayMs: 5000, maxDelayMs: 1000 } },
+      expect: '"retry.maxDelayMs" (1000) must be >= "retry.baseDelayMs" (5000)',
+    },
+  ];
+
+  for (const { config, expect } of cases) {
+    const tmpPath = resolve(__dirname, 'fixtures', 'runtime-config', 'bad-retry.json');
+    await writeFile(tmpPath, JSON.stringify(config), 'utf-8');
+    try {
+      await assert.rejects(
+        async () => {
+          await loadRuntimeConfig('/unused', tmpPath);
+        },
+        (err: unknown) => (err as Error).message.includes(expect),
+        `expected rejection containing: ${expect}`,
+      );
+    } finally {
+      await unlink(tmpPath);
+    }
+  }
+});
+
+test('loadRuntimeConfig: accepts valid retry settings', async () => {
+  const { writeFile, unlink } = await import('node:fs/promises');
+  const tmpPath = resolve(__dirname, 'fixtures', 'runtime-config', 'good-retry.json');
+  // maxAttempts: 1 is valid and means "no retry" — it counts the first attempt.
+  await writeFile(
+    tmpPath,
+    JSON.stringify({ retry: { maxAttempts: 1, baseDelayMs: 0, maxDelayMs: 0, circuitBreakerThreshold: 5 } }),
+    'utf-8',
+  );
+  try {
+    const cfg = await loadRuntimeConfig('/unused', tmpPath);
+    assert.equal(cfg.retry?.maxAttempts, 1);
+    assert.equal(cfg.retry?.circuitBreakerThreshold, 5);
+  } finally {
+    await unlink(tmpPath);
+  }
+});


### PR DESCRIPTION
Three independent changes from a post-merge review of the recently integrated
stretch features.

## Documentation

`glob` and `script` discovery were each documented in some places and not
others. Both now appear in `scanning.md`, `how-it-works.md` and
`creating-checks.md` alongside the configuration reference, together with
something previously unstated: neither supports the diff filter, because they
select code directly rather than producing findings to narrow — so a check using
either runs its full target set even in a `--diff-ref` scan.

A new test makes the discovery registry the source of truth for those tables, so
a future discovery method cannot land half-documented.

The `matchCriteria` example was **dead as written**: it paired the criteria with
`"repositories": []`, and an empty array already matches every repository, so the
criteria could never narrow anything. Now uses a real repository entry, with a
warning against the empty-array pairing.

New: **`docs/examples/github-actions-pr-comments.yml`**, a runnable workflow for
posting findings as inline PR review comments. It covers the two settings most
easily missed — `pull-requests: write`, without which posting fails with
`[E7201]`, and `fetch-depth: 0`, without which the base ref is unreachable and
diff scoping silently does nothing.

## Robustness

- **`retry` config is validated at load**, as `budget` already was. An invalid
  value previously surfaced mid-scan, after AI calls had been paid for.
- **Stale individual issue files are cleared.** The writer numbers from `001`
  each run, so a scan producing *fewer* findings left the surplus behind, and
  those files read as current findings. Only files matching the generated shape
  are removed — anything you keep in that directory is untouched.
- **Inline PR comments are capped at 50 per review.** A noisy check against a
  large diff would otherwise post hundreds in one API call, which is
  unreviewable and risks the request being rejected outright — losing every
  comment rather than some. The remainder is named in the review summary and all
  findings stay in the scan report.

## Cost and judge verdicts in reports

Both existed only in JSON and SARIF. Now:

| Format | Cost | Judge verdicts |
|--------|------|----------------|
| Markdown | in **Statistics** | a **Judge Verdicts** section, plus a per-issue verdict block |
| HTML | a stat tile | stat tiles, and a **Verdict** column on the issues table |
| CSV | *not a column — see below* | `judgeVerdict`, `judgeConfidence`, `judgeRationale` |

**Cost is deliberately not a CSV column.** It is a single value for the whole
run, so a per-row column would invite summing it and getting cost × issue-count.

### ⚠️ Note for CSV consumers

The three judge columns are **appended to the end of the row** and are **always
present**, empty when the judge did not run. Appending keeps existing column
indices valid, and keeping them unconditional means the header shape does not
change with runtime configuration — which matters more to a parser than a few
empty cells. **A consumer that asserts an exact column count will need
updating.**

## Verification

Lint, build and full suite clean: 1323 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)