### PR TITLE
docs: document the script discovery contract and trust model, judge cost, and per-issue files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,104 @@ The `discovery` field on `checkTarget` specifies how targets are found for `targ
 | `glob` | None | Walks the repository and selects whole-file targets matching a glob pattern (e.g. `src/routes/**/*.ts`). Targeted checks only. Always skips: `.git`, `node_modules`, `.venv`, `venv`, `__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`, `dist`, `build`, `.next`, `.nuxt`, `.cache`, `.idea`, `.vscode`. Files larger than 10 MiB and symlinks are also skipped | No |
 | `script` | None (script must be node or bash) | Runs a user-provided discovery script in the repo and parses its stdout into targets. Runs with `shell: false`, a curated environment with secrets stripped, a hard timeout and a bounded stdout. Script and output paths must resolve inside the repo, symlinks included | No |
 
+### Script discovery
+
+Use `script` discovery when target selection is too custom for the other
+methods — parsing an OpenAPI spec, walking a build manifest, querying a schema
+artifact. aghast runs your script and turns its stdout into targets.
+
+> **Trust model — read this before enabling a script check.**
+>
+> **Scripts run with the full privileges of the aghast process and are not
+> sandboxed.** Treat any script referenced by a check definition as trusted
+> code: only enable script-discovery checks whose script you or your team have
+> read and audited. The measures below are defence-in-depth against mistakes and
+> against a compromised *check definition* — they are not a sandbox, and they do
+> not make an untrusted script safe to run.
+>
+> What aghast does enforce:
+>
+> - **Path containment.** The script path must resolve inside the check folder
+>   (or the repo). Both it and `cwd` are `realpath`'d and re-checked, so a
+>   symlink pointing outside cannot be used to execute external code.
+> - **No shell.** Spawned with `shell: false` and array arguments, so no field
+>   in a check definition can inject a command.
+> - **Curated environment.** Only a small allow-list of neutral variables is
+>   forwarded (`PATH`, `HOME`, locale, temp dirs, Windows essentials). Anything
+>   matching a secret pattern is dropped as well — `*_KEY`, `*_TOKEN`,
+>   `*_SECRET`, `*_PASSWORD`, and the `ANTHROPIC_`, `OPENAI_`, `GITHUB_`,
+>   `AGHAST_`, `AWS_`, `GCP_`, `AZURE_` prefixes. **Your script will not see the
+>   API key**, by design.
+> - **Bounded.** Hard timeout (default 30s), stdout capped at 8 MiB, stderr at
+>   1 MiB, and at most 100,000 parsed targets.
+> - **Output is data.** Parsed as lines or JSON, never `eval`-ed. File paths the
+>   script returns are validated as relative and inside the repo before reaching
+>   the AI prompt or the snippet extractor.
+
+#### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `checkTarget.script` | `string` | Yes | Path to the script, relative to the check folder. Must resolve inside it |
+| `checkTarget.scriptType` | `string` | Yes | `node` or `bash`. `bash` is **not supported on Windows** — aghast raises a clear error rather than silently falling back |
+| `checkTarget.outputFormat` | `string` | Yes | `lines`, `json-array`, or `json-object` — see below |
+| `checkTarget.cwd` | `string` | No | Working directory for the script, relative to the repo root (default: the repo root). Must resolve inside the repo |
+| `checkTarget.timeoutMs` | `number` | No | Kill the script after this many milliseconds (default: `30000`) |
+
+#### Output formats
+
+**`lines`** — one repo-relative file path per line. Blank lines are ignored.
+The simplest option when you only need to select whole files:
+
+```
+src/routes/users.ts
+src/routes/orders.ts
+```
+
+**`json-array`** — a JSON array of target objects at the root:
+
+```json
+[
+  { "file": "src/routes/users.ts", "startLine": 10, "endLine": 42, "message": "POST handler" }
+]
+```
+
+**`json-object`** — the same objects under a `targets` key, for scripts that
+want to emit metadata alongside:
+
+```json
+{ "targets": [ { "file": "src/routes/users.ts", "startLine": 10, "endLine": 42 } ] }
+```
+
+Target object fields — only `file` is required:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `string` | Repo-relative path. Must not be absolute or escape the repo |
+| `startLine` | `number` | Start of the region of interest (default: whole file) |
+| `endLine` | `number` | End of the region |
+| `message` | `string` | Passed to the AI as context for why this target was selected |
+| `snippet` | `string` | Code to show the AI instead of reading the file |
+
+A non-zero exit status fails the check. Write diagnostics to stderr — stdout is
+parsed as target output.
+
+#### Example
+
+```json
+{
+  "name": "API route review",
+  "checkType": "targeted",
+  "checkTarget": {
+    "discovery": "script",
+    "script": "find-routes.js",
+    "scriptType": "node",
+    "outputFormat": "json-array",
+    "timeoutMs": 60000
+  }
+}
+```
+
 ### Diff filtering
 
 Diff filtering narrows a SARIF-producing discovery's output to findings touching code in a git diff. A finding is "in scope" if it overlaps a code unit directly changed by the diff, or is a direct caller or callee of a changed unit (using OpenAnt's call graph). Findings in files OpenAnt can't parse (config files, templates) are kept if the file itself appears in the diff.

--- a/docs/cost-tracking.md
+++ b/docs/cost-tracking.md
@@ -196,6 +196,34 @@ merge blocker.
 
 ---
 
+## The judge stage costs extra
+
+The [LLM judge](scanning.md#llm-judge-stage) makes **one additional AI call per
+issue found**, and those calls go through the same accounting as check analysis:
+they count towards the scan total, appear in `aghast stats`, and are checked
+against your budget limits before each call.
+
+Two consequences worth planning for:
+
+- **Judge cost scales with findings, not with checks.** A scan producing 3 issues
+  adds 3 judge calls; one producing 200 adds 200. A noisy check set is
+  disproportionately more expensive to judge than a quiet one.
+- **Use a cheaper judge model if cost matters.** `--judge-model` is independent
+  of `--model`, so the judge can run on a smaller model than the scan. Judging is
+  a narrower task than discovery — it re-evaluates a single finding with its
+  snippet and the check's instructions.
+
+To exclude a specific check's findings from judging entirely, set
+`"judge": false` on its Layer 1 entry — useful for a high-volume check whose
+findings you already trust.
+
+A budget abort during judging stops the stage but still writes the report;
+issues judged before the abort keep their verdicts, and the rest have no `judge`
+field.
+
+Retry, when [enabled](configuration.md#retry-and-resilience), covers judge calls
+too — so a retried judge call spends more than one call's worth of tokens.
+
 ## What is *not* counted
 
 - Semgrep and OpenAnt compute time (CPU / CI minutes)

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -153,6 +153,42 @@ Results are written to `security_checks_results.<ext>` in the target repo by def
 - **Markdown** - human-readable report for pasting into a PR, ticket or wiki. Sections: header, executive summary, per-check status table, detailed findings with fenced code snippets (language tag inferred from file extension), flagged items, errors, judge verdicts, statistics (including estimated cost), and CI metadata when the scan ran in CI. All user-controlled text is escaped so findings cannot break out of tables or inject markup.
 - **HTML** - self-contained interactive report with inline CSS/JS and the full `ScanResults` embedded as a JSON island. Includes filterable issues table, severity/status badges, expandable per-check sections, code snippets, and stat tiles for estimated cost and judge verdicts when available. No external resources, so the file can be emailed or hosted as-is.
 
+### One file per finding
+
+Alongside the main report, aghast can write a separate file for each issue —
+useful when findings are handed to different owners, tracked individually, or
+fed into a system that expects one document per item.
+
+Enable it in `runtime-config.json` (there is no CLI flag):
+
+```jsonc
+{
+  "reporting": {
+    "includeIndividualIssueFiles": true,
+    "individualIssueFormat": "markdown"   // or "json" / "html"
+  }
+}
+```
+
+Files are written next to the main report, grouped by check:
+
+```
+security_issues_<project>/
+  aghast-sql-injection/
+    issue_001_users.ts.md
+    issue_002_orders.ts.md
+  aghast-xss/
+    issue_001_render.tsx.md
+```
+
+Numbering restarts at `001` within each check. Each run first removes
+`issue_<NNN>_*` files left by the previous run, so a scan with fewer findings
+does not leave stale ones behind looking current — anything else you keep in
+those directories is left alone.
+
+The main report is unaffected: this is purely additional output, and the feature
+is off unless you switch it on.
+
 ### Cost and judge verdicts in reports
 
 Estimated scan cost appears in the JSON, Markdown and HTML reports (in Markdown

--- a/docs/trying-it-out.md
+++ b/docs/trying-it-out.md
@@ -427,6 +427,30 @@ If OpenAnt is not installed, the diff filter falls back to file/line overlap onl
 
 The checks in `checks-config.json` include a `repositories` field that limits which repos each check runs against. To run the example checks against your own repository, add your repo's path or remote URL to the `repositories` array for the relevant check, or set it to an empty array `[]` to match all repositories. See the [Configuration Reference](configuration.md) for details.
 
+### Second-guessing the results: the LLM judge
+
+Any of the scans above can be re-run with a second model reviewing the findings.
+Add `--judge-model` to the same command:
+
+```bash
+node --import tsx src/cli.ts scan <repo-path> --config-dir checks-config \
+  --judge-model claude-opus-4-7
+```
+
+Each issue gains a verdict — `true_positive`, `false_positive` or `uncertain` —
+with a confidence score and the judge's reasoning. Nothing is removed by
+default, so you can compare the verdicts against your own read of the findings
+before deciding to trust them.
+
+Once you do trust them, `--judge-drop-false-positives` removes the dismissed
+findings from the report, which can flip a check from FAIL to PASS. `uncertain`
+verdicts escalate the check to FLAG rather than being silently accepted.
+
+This is the highest-leverage option to try on a check that produces findings you
+suspect are noise. It is not free — it costs one extra AI call per issue, so see
+[Cost Tracking](cost-tracking.md#the-judge-stage-costs-extra) before turning it
+on for a large scan.
+
 ## What's next
 
 - [Scanning](scanning.md) - all scan options, output formats, and environment variables


### PR DESCRIPTION
Three documentation gaps. Docs only — no source changes.

## Script discovery had no public documentation

`script` discovery **executes user-supplied scripts**, and until now a check
author had no field reference (`script`, `scriptType`, `outputFormat`, `cwd`,
`timeoutMs` were all undocumented), no description of the output formats, and
**no statement of the trust model** — despite the implementation having a
thorough one that had never left the source file.

`docs/configuration.md` now covers the fields, all three output formats with
examples, the target object shape, and the trust model.

The trust model section is deliberately blunt about what aghast does **not**
provide — scripts are not sandboxed and run with the full privileges of the
process, so a script must be treated as trusted code — before listing what *is*
enforced: symlink-aware path containment, `shell: false` spawning, a curated
environment, bounds (30s timeout, 8 MiB stdout, 100k targets), and output parsed
as data rather than evaluated.

The point most likely to surprise someone writing their first script is called
out explicitly: **the script does not receive the API key**, because
secret-shaped variables are stripped from its environment by design.

## The judge stage was missing from cost documentation

It makes **one extra AI call per issue** and shares the budget machinery, but
`docs/cost-tracking.md` did not mention it. Now records:

- judge cost scales with **findings, not checks** — a scan producing 200 issues
  adds 200 judge calls
- `--judge-model` is independent of `--model`, so the judge can run cheaper
- retry, when enabled, covers judge calls too
- how a budget abort mid-judging behaves (report still written; issues judged
  before the abort keep their verdicts)
- `"judge": false` as the per-check cost lever

## Per-issue files had no narrative

Two config-table rows, no explanation. `docs/scanning.md` now shows the directory
layout, the three formats, and the stale-file clearing behaviour.

## Also

The judge is now mentioned in `docs/trying-it-out.md`, so a reader working
through the tutorial discovers the feature exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)