### PR TITLE
feat: link to the documentation from CLI --help output

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -24,6 +24,7 @@ import { getAvailableFormats } from './formatters/index.js';
 import { getAvailableLogTypes, isValidLogLevel, getLogLevel, setLogLevel } from './logging.js';
 import { DEFAULT_MODEL } from './types.js';
 import type { RuntimeConfig, ProviderModelInfo } from './types.js';
+import { DOCS_HELP_FOOTER } from './docs-url.js';
 import {
   DEFAULT_OUTPUT_FORMAT,
   DEFAULT_LOG_LEVEL,
@@ -178,7 +179,9 @@ Examples:
   aghast build-config --config-dir ./my-checks
   aghast build-config --config-dir ./my-checks --provider claude-code --model sonnet --non-interactive
   aghast build-config --runtime-config ./prod.json --output-format sarif --fail-on-check-failure true
-  aghast build-config --config-dir ./my-checks --clear logFile --clear genericPrompt`;
+  aghast build-config --config-dir ./my-checks --clear logFile --clear genericPrompt
+
+${DOCS_HELP_FOOTER}`;
 
 const CLEARABLE_FIELDS = new Set([
   'provider',

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -24,7 +24,7 @@ import { getAvailableFormats } from './formatters/index.js';
 import { getAvailableLogTypes, isValidLogLevel, getLogLevel, setLogLevel } from './logging.js';
 import { DEFAULT_MODEL } from './types.js';
 import type { RuntimeConfig, ProviderModelInfo } from './types.js';
-import { DOCS_HELP_FOOTER } from './docs-url.js';
+import { docsFooter } from './docs-url.js';
 import {
   DEFAULT_OUTPUT_FORMAT,
   DEFAULT_LOG_LEVEL,
@@ -181,7 +181,7 @@ Examples:
   aghast build-config --runtime-config ./prod.json --output-format sarif --fail-on-check-failure true
   aghast build-config --config-dir ./my-checks --clear logFile --clear genericPrompt
 
-${DOCS_HELP_FOOTER}`;
+${docsFooter('configuration.md')}`;
 
 const CLEARABLE_FIELDS = new Set([
   'provider',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
+import { DOCS_HELP_FOOTER } from './docs-url.js';
 
 // Signal to subcommand modules that they're being imported, not run directly
 process.env._AGHAST_CLI = '1';
@@ -32,7 +33,9 @@ Options:
   --help      Show this help message
   --version   Show version number
 
-Run 'aghast <command> --help' for more information on a command.`;
+Run 'aghast <command> --help' for more information on a command.
+
+${DOCS_HELP_FOOTER}`;
 
 function getVersion(): string {
   const require = createRequire(import.meta.url);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
-import { DOCS_HELP_FOOTER } from './docs-url.js';
+import { docsFooter } from './docs-url.js';
 
 // Signal to subcommand modules that they're being imported, not run directly
 process.env._AGHAST_CLI = '1';
@@ -35,7 +35,7 @@ Options:
 
 Run 'aghast <command> --help' for more information on a command.
 
-${DOCS_HELP_FOOTER}`;
+${docsFooter()}`;
 
 function getVersion(): string {
   const require = createRequire(import.meta.url);

--- a/src/docs-url.ts
+++ b/src/docs-url.ts
@@ -1,0 +1,9 @@
+/**
+ * Canonical documentation URL, surfaced in CLI --help output so users who
+ * install aghast via npm can discover the docs for configuration, check types
+ * and examples. Single source of truth — do not duplicate this literal.
+ */
+export const DOCS_URL = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
+
+/** Ready-to-append help footer pointing at the documentation. */
+export const DOCS_HELP_FOOTER = `Documentation:\n  ${DOCS_URL}`;

--- a/src/docs-url.ts
+++ b/src/docs-url.ts
@@ -1,9 +1,17 @@
 /**
- * Canonical documentation URL, surfaced in CLI --help output so users who
+ * Canonical documentation location, surfaced in CLI --help output so users who
  * install aghast via npm can discover the docs for configuration, check types
- * and examples. Single source of truth — do not duplicate this literal.
+ * and examples. Single source of truth — do not duplicate these literals.
  */
-export const DOCS_URL = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
+export const DOCS_BASE = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
 
-/** Ready-to-append help footer pointing at the documentation. */
-export const DOCS_HELP_FOOTER = `Documentation:\n  ${DOCS_URL}`;
+/**
+ * Build a help footer that links to a specific documentation page (e.g.
+ * `scanning.md`), or to the docs index when no page is given. The page names
+ * are asserted to exist on disk by tests/docs-links.test.ts, so a renamed or
+ * removed page fails CI rather than shipping a dead link.
+ */
+export function docsFooter(page?: string): string {
+  const url = page ? `${DOCS_BASE}/${page}` : DOCS_BASE;
+  return `Documentation:\n  ${url}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { verifyOpenAntInstalled } from './openant-runner.js';
 import { MockAgentProvider } from './mock-agent-provider.js';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { DEFAULT_OUTPUT_FORMAT, DEFAULT_LOG_LEVEL, DEFAULT_LOG_TYPE } from './defaults.js';
+import { DOCS_HELP_FOOTER } from './docs-url.js';
 import { colorStatus } from './colors.js';
 import { getCheckType } from './check-types.js';
 import { getDiscovery, getRegisteredDiscoveries } from './discovery.js';
@@ -205,7 +206,9 @@ Examples:
   aghast scan ./my-repo --config-dir ./my-checks --output results.sarif --output-format sarif
   aghast scan ./my-repo --config-dir ./my-checks --fail-on-check-failure --debug
   aghast scan ./my-repo --config-dir ./my-checks --log-file scan.log --log-level warn
-  aghast scan ./my-repo --config-dir ./my-checks --model claude-sonnet-4-20250514`;
+  aghast scan ./my-repo --config-dir ./my-checks --model claude-sonnet-4-20250514
+
+${DOCS_HELP_FOOTER}`;
 
 function parseArgs(args: string[]): {
   repositoryPath?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import { verifyOpenAntInstalled } from './openant-runner.js';
 import { MockAgentProvider } from './mock-agent-provider.js';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { DEFAULT_OUTPUT_FORMAT, DEFAULT_LOG_LEVEL, DEFAULT_LOG_TYPE } from './defaults.js';
-import { DOCS_HELP_FOOTER } from './docs-url.js';
+import { docsFooter } from './docs-url.js';
 import { colorStatus } from './colors.js';
 import { getCheckType } from './check-types.js';
 import { getDiscovery, getRegisteredDiscoveries } from './discovery.js';
@@ -208,7 +208,7 @@ Examples:
   aghast scan ./my-repo --config-dir ./my-checks --log-file scan.log --log-level warn
   aghast scan ./my-repo --config-dir ./my-checks --model claude-sonnet-4-20250514
 
-${DOCS_HELP_FOOTER}`;
+${docsFooter('scanning.md')}`;
 
 function parseArgs(args: string[]): {
   repositoryPath?: string;

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -18,6 +18,7 @@ import { createRequire } from 'node:module';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { getCheckType, getValidCheckTypes } from './check-types.js';
 import { DEFAULT_MODEL } from './types.js';
+import { DOCS_HELP_FOOTER } from './docs-url.js';
 
 const ID_PREFIX = 'aghast-';
 
@@ -555,7 +556,9 @@ Examples:
   aghast new-check --config-dir ./my-checks
   aghast new-check --config-dir ./my-checks --id xss --name "XSS Prevention"
   aghast new-check --config-dir ./my-checks --check-type targeted --discovery semgrep --language typescript
-  aghast new-check --config-dir ./my-checks --check-type targeted --discovery sarif --sarif-file ./sast-results.sarif`;
+  aghast new-check --config-dir ./my-checks --check-type targeted --discovery sarif --sarif-file ./sast-results.sarif
+
+${DOCS_HELP_FOOTER}`;
 
 export async function runNewCheck(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -18,7 +18,7 @@ import { createRequire } from 'node:module';
 import { ERROR_CODES, formatError, formatFatalError } from './error-codes.js';
 import { getCheckType, getValidCheckTypes } from './check-types.js';
 import { DEFAULT_MODEL } from './types.js';
-import { DOCS_HELP_FOOTER } from './docs-url.js';
+import { docsFooter } from './docs-url.js';
 
 const ID_PREFIX = 'aghast-';
 
@@ -558,7 +558,7 @@ Examples:
   aghast new-check --config-dir ./my-checks --check-type targeted --discovery semgrep --language typescript
   aghast new-check --config-dir ./my-checks --check-type targeted --discovery sarif --sarif-file ./sast-results.sarif
 
-${DOCS_HELP_FOOTER}`;
+${docsFooter('creating-checks.md')}`;
 
 export async function runNewCheck(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -11,6 +11,7 @@ import 'dotenv/config';
 import { ERROR_CODES, formatError } from './error-codes.js';
 import { queryScanHistory, type ScanRecord, type HistoryFilters } from './scan-history.js';
 import { formatCostSourceLabel } from './cost-calculator.js';
+import { DOCS_HELP_FOOTER } from './docs-url.js';
 
 const STATS_HELP = `Usage: aghast stats [options]
 
@@ -31,7 +32,9 @@ Options:
 Examples:
   aghast stats
   aghast stats --repo my-org/my-repo --since 2026-01-01
-  aghast stats --model claude-sonnet --json`;
+  aghast stats --model claude-sonnet --json
+
+${DOCS_HELP_FOOTER}`;
 
 interface StatsArgs {
   repo?: string;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -11,7 +11,7 @@ import 'dotenv/config';
 import { ERROR_CODES, formatError } from './error-codes.js';
 import { queryScanHistory, type ScanRecord, type HistoryFilters } from './scan-history.js';
 import { formatCostSourceLabel } from './cost-calculator.js';
-import { DOCS_HELP_FOOTER } from './docs-url.js';
+import { docsFooter } from './docs-url.js';
 
 const STATS_HELP = `Usage: aghast stats [options]
 
@@ -34,7 +34,7 @@ Examples:
   aghast stats --repo my-org/my-repo --since 2026-01-01
   aghast stats --model claude-sonnet --json
 
-${DOCS_HELP_FOOTER}`;
+${docsFooter('cost-tracking.md')}`;
 
 interface StatsArgs {
   repo?: string;

--- a/tests/cli-subcommands.test.ts
+++ b/tests/cli-subcommands.test.ts
@@ -147,34 +147,45 @@ describe('CLI subcommands: help and version', () => {
 describe('CLI subcommands: documentation links', () => {
   const DOCS_BASE = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
 
+  // Extract the URL printed on the line after the "Documentation:" footer header.
+  // We assert on the exact line (not a substring match of the URL against stdout)
+  // so the check can't be fooled by the URL appearing elsewhere — and so it does
+  // not read as the bypassable url.includes(host) sanitization anti-pattern.
+  function docsFooterUrl(stdout: string): string {
+    const lines = stdout.split('\n');
+    const idx = lines.findIndex((line) => line.trim() === 'Documentation:');
+    assert.ok(idx >= 0 && idx + 1 < lines.length, 'help should print a Documentation: footer');
+    return lines[idx + 1].trim();
+  }
+
   it('top-level --help links to the docs index', async () => {
     const { exitCode, stdout } = await runCLI(['--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_BASE), 'Top-level help should link to the docs index');
+    assert.equal(docsFooterUrl(stdout), DOCS_BASE, 'Top-level help should link to the docs index');
   });
 
   it('scan --help links to the scanning page', async () => {
     const { exitCode, stdout } = await runCLI(['scan', '--help'], { AGHAST_MOCK_AI: 'true' });
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(`${DOCS_BASE}/scanning.md`), 'scan help should link to scanning.md');
+    assert.equal(docsFooterUrl(stdout), `${DOCS_BASE}/scanning.md`, 'scan help should link to scanning.md');
   });
 
   it('new-check --help links to the creating-checks page', async () => {
     const { exitCode, stdout } = await runCLI(['new-check', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(`${DOCS_BASE}/creating-checks.md`), 'new-check help should link to creating-checks.md');
+    assert.equal(docsFooterUrl(stdout), `${DOCS_BASE}/creating-checks.md`, 'new-check help should link to creating-checks.md');
   });
 
   it('build-config --help links to the configuration page', async () => {
     const { exitCode, stdout } = await runCLI(['build-config', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(`${DOCS_BASE}/configuration.md`), 'build-config help should link to configuration.md');
+    assert.equal(docsFooterUrl(stdout), `${DOCS_BASE}/configuration.md`, 'build-config help should link to configuration.md');
   });
 
   it('stats --help links to the cost-tracking page', async () => {
     const { exitCode, stdout } = await runCLI(['stats', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(`${DOCS_BASE}/cost-tracking.md`), 'stats help should link to cost-tracking.md');
+    assert.equal(docsFooterUrl(stdout), `${DOCS_BASE}/cost-tracking.md`, 'stats help should link to cost-tracking.md');
   });
 });
 

--- a/tests/cli-subcommands.test.ts
+++ b/tests/cli-subcommands.test.ts
@@ -145,36 +145,36 @@ describe('CLI subcommands: help and version', () => {
 // ─── Documentation links in help output ──────────────────────────────────────
 
 describe('CLI subcommands: documentation links', () => {
-  const DOCS_URL = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
+  const DOCS_BASE = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
 
-  it('top-level --help links to the documentation', async () => {
+  it('top-level --help links to the docs index', async () => {
     const { exitCode, stdout } = await runCLI(['--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_URL), 'Top-level help should include the docs URL');
+    assert.ok(stdout.includes(DOCS_BASE), 'Top-level help should link to the docs index');
   });
 
-  it('scan --help links to the documentation', async () => {
+  it('scan --help links to the scanning page', async () => {
     const { exitCode, stdout } = await runCLI(['scan', '--help'], { AGHAST_MOCK_AI: 'true' });
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_URL), 'scan help should include the docs URL');
+    assert.ok(stdout.includes(`${DOCS_BASE}/scanning.md`), 'scan help should link to scanning.md');
   });
 
-  it('new-check --help links to the documentation', async () => {
+  it('new-check --help links to the creating-checks page', async () => {
     const { exitCode, stdout } = await runCLI(['new-check', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_URL), 'new-check help should include the docs URL');
+    assert.ok(stdout.includes(`${DOCS_BASE}/creating-checks.md`), 'new-check help should link to creating-checks.md');
   });
 
-  it('build-config --help links to the documentation', async () => {
+  it('build-config --help links to the configuration page', async () => {
     const { exitCode, stdout } = await runCLI(['build-config', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_URL), 'build-config help should include the docs URL');
+    assert.ok(stdout.includes(`${DOCS_BASE}/configuration.md`), 'build-config help should link to configuration.md');
   });
 
-  it('stats --help links to the documentation', async () => {
+  it('stats --help links to the cost-tracking page', async () => {
     const { exitCode, stdout } = await runCLI(['stats', '--help']);
     assert.equal(exitCode, 0);
-    assert.ok(stdout.includes(DOCS_URL), 'stats help should include the docs URL');
+    assert.ok(stdout.includes(`${DOCS_BASE}/cost-tracking.md`), 'stats help should link to cost-tracking.md');
   });
 });
 

--- a/tests/cli-subcommands.test.ts
+++ b/tests/cli-subcommands.test.ts
@@ -142,6 +142,42 @@ describe('CLI subcommands: help and version', () => {
   });
 });
 
+// ─── Documentation links in help output ──────────────────────────────────────
+
+describe('CLI subcommands: documentation links', () => {
+  const DOCS_URL = 'https://github.com/owasp-aghast/aghast/tree/main/docs';
+
+  it('top-level --help links to the documentation', async () => {
+    const { exitCode, stdout } = await runCLI(['--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes(DOCS_URL), 'Top-level help should include the docs URL');
+  });
+
+  it('scan --help links to the documentation', async () => {
+    const { exitCode, stdout } = await runCLI(['scan', '--help'], { AGHAST_MOCK_AI: 'true' });
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes(DOCS_URL), 'scan help should include the docs URL');
+  });
+
+  it('new-check --help links to the documentation', async () => {
+    const { exitCode, stdout } = await runCLI(['new-check', '--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes(DOCS_URL), 'new-check help should include the docs URL');
+  });
+
+  it('build-config --help links to the documentation', async () => {
+    const { exitCode, stdout } = await runCLI(['build-config', '--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes(DOCS_URL), 'build-config help should include the docs URL');
+  });
+
+  it('stats --help links to the documentation', async () => {
+    const { exitCode, stdout } = await runCLI(['stats', '--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes(DOCS_URL), 'stats help should include the docs URL');
+  });
+});
+
 // ─── Unknown command ──────────────────────────────────────────────────────────
 
 describe('CLI subcommands: unknown command', () => {

--- a/tests/docs-links.test.ts
+++ b/tests/docs-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const srcDir = resolve(repoRoot, 'src');
+const docsDir = resolve(repoRoot, 'docs');
+
+/**
+ * The CLI help footers deep-link to individual documentation pages via
+ * docsFooter('<page>.md'). A renamed or deleted page would silently ship a dead
+ * link, so assert every page referenced from source actually exists under docs/.
+ */
+describe('documentation help links', () => {
+  it('every docsFooter(...) page exists under docs/', () => {
+    const files = readdirSync(srcDir).filter((f) => f.endsWith('.ts'));
+    const pattern = /docsFooter\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+    const referenced = new Set<string>();
+    for (const file of files) {
+      const contents = readFileSync(resolve(srcDir, file), 'utf-8');
+      for (const match of contents.matchAll(pattern)) {
+        referenced.add(match[1]);
+      }
+    }
+
+    // The feature wires up five help screens; four of them deep-link a page
+    // (the top-level help uses docsFooter() with no argument).
+    assert.ok(referenced.size >= 4, `Expected several deep-linked docs pages, found ${referenced.size}`);
+
+    for (const page of referenced) {
+      assert.ok(
+        existsSync(resolve(docsDir, page)),
+        `Help links to docs/${page} but that file does not exist`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #16. Every `--help` screen now ends with a link to the project documentation, so users who install via npm can discover the docs. Each subcommand deep-links to the page most relevant to it; the top-level help links to the docs index.

```
Documentation:
  https://github.com/owasp-aghast/aghast/tree/main/docs/scanning.md
```

| Help screen | Links to |
|---|---|
| top-level `--help` | docs index (`/docs`) |
| `scan --help` | `docs/scanning.md` |
| `new-check --help` | `docs/creating-checks.md` |
| `build-config --help` | `docs/configuration.md` |
| `stats --help` | `docs/cost-tracking.md` |

## Changes

- New `src/docs-url.ts` — single source of truth exporting `DOCS_BASE` and a `docsFooter(page?)` helper (a page name deep-links; omitting it links the index), so the URL can't drift across help screens.
- Wired into all five help outputs: top-level, `scan`, `new-check`, `build-config`, and `stats`. The issue named the first three; extending to the other two keeps the CLI consistent.
- Uses the canonical `owasp-aghast/aghast` docs URL.

## Tests

- `tests/cli-subcommands.test.ts` — a `documentation links` block spawns the real CLI for each of the five `--help` variants and asserts the footer's URL line equals the expected page URL exactly (exact-line comparison rather than a URL substring match, which also keeps CodeQL's `js/incomplete-url-substring-sanitization` rule happy).
- `tests/docs-links.test.ts` — a drift guard that scans the `docsFooter('…')` call sites in `src/` and asserts every referenced page exists under `docs/`, so a renamed or removed page fails CI instead of shipping a dead link.

`npm run build` and `npm run lint` are clean; the two affected suites pass 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
