### PR TITLE
ci: add CodeQL SAST workflow running on all PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Static analysis (SAST) for the aghast repo itself, uploaded to GitHub code
+# scanning. Public-only, like scorecard.yml — it satisfies the OpenSSF
+# Scorecard "SAST" check, which looks for github/codeql-action running on the
+# project's commits. Excluded from the public/private sync (see .claude).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so the baseline stays fresh even in quiet weeks.
+    - cron: '27 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
## What

Adds `.github/workflows/codeql.yml` — a CodeQL static-analysis (SAST) workflow that runs on:

- pushes to `main`
- **all pull requests to `main`**
- a weekly schedule (keeps the baseline fresh)

## Why

OpenSSF Scorecard's **SAST** check (surfaced as code-scanning alert [#13](https://github.com/owasp-aghast/aghast/security/code-scanning/13)) was scoring **0** — *"SAST tool is not run on all commits"*. Scorecard looks for `github/codeql-action` in a workflow (or the `github-code-scanning` app on recent PRs); the repo had neither. The Semgrep/Opengrep steps in `ci.yml` are product integration tests, not SAST of this repo, so Scorecard can't count them.

This workflow is the standard, Scorecard-recognized remediation.

## Details

- Language: `javascript-typescript` (covers the TS/Node source)
- Query suite: `security-extended` (appropriate for a security tool)
- Actions pinned to SHAs with version comments, matching repo convention
- Minimal permissions (`security-events: write` on the job for the code-scanning upload)

## Notes

- The Scorecard score won't jump immediately — its message counts historical commits ("0 of 27"); the score climbs as new commits/PRs are analyzed.
- Public-only: excluded from the public/private sync (the private repo doesn't run Scorecard, so it doesn't need the SAST check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)