### PR TITLE
fix: eliminate CodeQL filesystem race findings

### DIFF
--- a/src/repo-scan.ts
+++ b/src/repo-scan.ts
@@ -12,7 +12,7 @@
  * checks run, not to enumerate the whole repo.
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 import picomatch from 'picomatch';
 import type { MatchCriteria } from './types.js';
@@ -151,13 +151,10 @@ async function loadTags(repoPath: string): Promise<Set<string>> {
   // .aghast-tags
   try {
     const tagsFile = join(repoPath, '.aghast-tags');
-    const st = await stat(tagsFile);
-    if (st.isFile()) {
-      const raw = await readFile(tagsFile, 'utf-8');
-      for (const line of raw.split(/\r?\n/)) {
-        const t = line.trim();
-        if (t && !t.startsWith('#')) tags.add(t);
-      }
+    const raw = await readFile(tagsFile, 'utf-8');
+    for (const line of raw.split(/\r?\n/)) {
+      const t = line.trim();
+      if (t && !t.startsWith('#')) tags.add(t);
     }
   } catch {
     // Missing or unreadable; ignore.
@@ -166,18 +163,15 @@ async function loadTags(repoPath: string): Promise<Set<string>> {
   // .aghast.json -> tags array
   try {
     const cfgFile = join(repoPath, '.aghast.json');
-    const st = await stat(cfgFile);
-    if (st.isFile()) {
-      const raw = await readFile(cfgFile, 'utf-8');
-      const parsed = JSON.parse(raw) as unknown;
-      if (
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        Array.isArray((parsed as Record<string, unknown>).tags)
-      ) {
-        for (const t of (parsed as Record<string, unknown>).tags as unknown[]) {
-          if (typeof t === 'string' && t.trim() !== '') tags.add(t.trim());
-        }
+    const raw = await readFile(cfgFile, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      Array.isArray((parsed as Record<string, unknown>).tags)
+    ) {
+      for (const t of (parsed as Record<string, unknown>).tags as unknown[]) {
+        if (typeof t === 'string' && t.trim() !== '') tags.add(t.trim());
       }
     }
   } catch {

--- a/src/semgrep-runner.ts
+++ b/src/semgrep-runner.ts
@@ -10,7 +10,7 @@
  */
 
 import { execFile } from 'node:child_process';
-import { readFile, mkdtemp, rm, access } from 'node:fs/promises';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { logProgress, logDebug } from './logging.js';
@@ -182,12 +182,12 @@ export async function runSarifScanner(
       );
     }
 
-    const outputFileExists = await access(outputFile).then(() => true, () => false);
-    if (!outputFileExists) {
+    let sarifContent: string;
+    try {
+      sarifContent = await readFile(outputFile, 'utf-8');
+    } catch {
       throw new Error(`${tool.displayName} did not produce output`);
     }
-
-    const sarifContent = await readFile(outputFile, 'utf-8');
     logDebug(tool.tag, `SARIF output: ${sarifContent.length} chars`);
     return sarifContent;
   } finally {

--- a/tests/build-config.test.ts
+++ b/tests/build-config.test.ts
@@ -17,9 +17,8 @@ import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliEntry = resolve(__dirname, '..', 'src', 'cli.ts');
@@ -71,8 +70,7 @@ describe('build-config CLI', () => {
   let tempDir: string;
 
   beforeEach(async () => {
-    tempDir = join(tmpdir(), `aghast-build-config-${randomUUID()}`);
-    await mkdir(tempDir, { recursive: true });
+    tempDir = await mkdtemp(join(tmpdir(), 'aghast-build-config-'));
   });
 
   afterEach(async () => {

--- a/tests/cli-mock-mode.test.ts
+++ b/tests/cli-mock-mode.test.ts
@@ -158,7 +158,7 @@ describe('CLI mock mode: ScanResults output structure', () => {
 
   it('writes security_checks_results.json to the repository directory', async () => {
     await runCLI({ AGHAST_MOCK_AI: 'true' });
-    await access(outputFile); // throws if missing
+    await readFile(outputFile, 'utf-8'); // throws if missing
   });
 
   it('output has all required top-level ScanResults fields', async () => {
@@ -682,7 +682,6 @@ describe('CLI mock mode: output format', () => {
   it('default (no flag) writes .json file', async () => {
     const { exitCode } = await runCLI({ AGHAST_MOCK_AI: 'true' });
     assert.equal(exitCode, 0);
-    await access(outputFile); // throws if missing
     const raw = await readFile(outputFile, 'utf-8');
     const results = JSON.parse(raw) as Record<string, unknown>;
     assert.ok(results.scanId, 'Should be valid ScanResults JSON');
@@ -694,7 +693,6 @@ describe('CLI mock mode: output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'json'],
     );
     assert.equal(exitCode, 0);
-    await access(outputFile);
     const raw = await readFile(outputFile, 'utf-8');
     const results = JSON.parse(raw) as Record<string, unknown>;
     assert.ok(results.scanId, 'Should be valid ScanResults JSON');
@@ -706,8 +704,6 @@ describe('CLI mock mode: output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'sarif'],
     );
     assert.equal(exitCode, 0);
-    await access(sarifOutputFile);
-
     const raw = await readFile(sarifOutputFile, 'utf-8');
     const sarif = JSON.parse(raw) as Record<string, unknown>;
     assert.equal(sarif.version, '2.1.0');
@@ -770,8 +766,6 @@ describe('CLI mock mode: output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'markdown'],
     );
     assert.equal(exitCode, 0);
-    await access(markdownOutputFile);
-
     const md = await readFile(markdownOutputFile, 'utf-8');
     assert.ok(md.startsWith('# Security Scan Report'), 'Should start with the H1 title');
     assert.ok(md.includes('## Executive Summary'));
@@ -857,8 +851,6 @@ describe('CLI mock mode: CSV output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
     );
     assert.equal(exitCode, 0);
-    await access(csvOutputFile);
-
     const raw = await readFile(csvOutputFile, 'utf-8');
     const lines = raw.split('\r\n').filter((l) => l.length > 0);
     assert.equal(lines.length, 1, 'PASS scan should have header row only');
@@ -871,8 +863,6 @@ describe('CLI mock mode: CSV output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'csv'],
     );
     assert.equal(exitCode, 0);
-    await access(csvOutputFile);
-
     const raw = await readFile(csvOutputFile, 'utf-8');
     const lines = raw.split('\r\n').filter((l) => l.length > 0);
     assert.equal(lines.length, 2, 'FAIL scan with 1 issue: header + 1 issue row');
@@ -912,8 +902,6 @@ describe('CLI mock mode: HTML output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
     );
     assert.equal(exitCode, 0);
-    await access(htmlOutputFile);
-
     const raw = await readFile(htmlOutputFile, 'utf-8');
     assert.ok(raw.startsWith('<!DOCTYPE html>'), 'should start with DOCTYPE');
     assert.ok(raw.includes('<style>'), 'should include inline CSS');
@@ -927,8 +915,6 @@ describe('CLI mock mode: HTML output format', () => {
       [repoDir, '--config-dir', singleCheckConfigDir, '--output-format', 'html'],
     );
     assert.equal(exitCode, 0);
-    await access(htmlOutputFile);
-
     const raw = await readFile(htmlOutputFile, 'utf-8');
     assert.ok(raw.includes('aghast-sql-injection'));
     assert.ok(raw.includes('SQL Injection Prevention'));

--- a/tests/markdown-formatter.test.ts
+++ b/tests/markdown-formatter.test.ts
@@ -172,7 +172,7 @@ describe('MarkdownFormatter — mixed scan', () => {
 
   it('Header includes repository remote/branch/commit', () => {
     const md = formatter.format(mixed);
-    assert.ok(md.includes('https://github.com/example/repo'));
+    assert.match(md, /https:\/\/github\.com\/example\/repo/);
     assert.ok(md.includes('`main`'));
     assert.ok(md.includes('`abc1234`'));
   });
@@ -236,7 +236,7 @@ describe('MarkdownFormatter — mixed scan', () => {
     const triggerIdx = md.indexOf('**Trigger:**');
     assert.ok(jobIdx > 0 && triggerIdx > 0);
     assert.ok(jobIdx < triggerIdx, 'Job URL should precede Trigger');
-    assert.ok(md.includes('https://ci.example.com/jobs/123'));
+    assert.match(md, /https:\/\/ci\.example\.com\/jobs\/123/);
     assert.ok(md.includes('github-actions'));
   });
 

--- a/tests/markdown-formatter.test.ts
+++ b/tests/markdown-formatter.test.ts
@@ -172,7 +172,7 @@ describe('MarkdownFormatter — mixed scan', () => {
 
   it('Header includes repository remote/branch/commit', () => {
     const md = formatter.format(mixed);
-    assert.match(md, /https:\/\/github\.com\/example\/repo/);
+    assert.match(md, /^- \*\*Remote URL:\*\* <https:\/\/github\.com\/example\/repo>$/m);
     assert.ok(md.includes('`main`'));
     assert.ok(md.includes('`abc1234`'));
   });
@@ -236,7 +236,7 @@ describe('MarkdownFormatter — mixed scan', () => {
     const triggerIdx = md.indexOf('**Trigger:**');
     assert.ok(jobIdx > 0 && triggerIdx > 0);
     assert.ok(jobIdx < triggerIdx, 'Job URL should precede Trigger');
-    assert.match(md, /https:\/\/ci\.example\.com\/jobs\/123/);
+    assert.match(md, /^- \*\*Job URL:\*\* https:\/\/ci\.example\.com\/jobs\/123$/m);
     assert.ok(md.includes('github-actions'));
   });
 


### PR DESCRIPTION
## Summary

- remove check-then-use filesystem patterns from repository tag loading and SARIF output handling
- use OS-created private temporary directories in build-config CLI tests
- make output and URL assertions direct, eliminating the remaining CodeQL findings

## Verification

- npm run build
- npm run lint
- npm test