### PR TITLE
Scaffold script-discovery checks and matchCriteria/priority in new-check

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,6 +313,11 @@ Use `script` discovery when target selection is too custom for the other
 methods — parsing an OpenAPI spec, walking a build manifest, querying a schema
 artifact. aghast runs your script and turns its stdout into targets.
 
+> `aghast new-check --check-type targeted --discovery script` scaffolds a
+> script check and, unless you point `--script` at an existing file, writes a
+> starter script wired to the output format you pick. See
+> [Creating Checks](creating-checks.md).
+
 > **Trust model — read this before enabling a script check.**
 >
 > **Scripts run with the full privileges of the aghast process and are not

--- a/docs/creating-checks.md
+++ b/docs/creating-checks.md
@@ -23,12 +23,15 @@ Scaffolds a new security check interactively. Any values not provided via flags 
 | `--id <id>` | Check ID (auto-prefixed with `aghast-` if needed) |
 | `--name <name>` | Human-readable check name |
 | `--check-type <type>` | `repository` (default), `targeted`, or `static` |
-| `--discovery <method>` | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, or `glob` (required for `targeted` and `static` types; `sarif`, `openant` and `glob` are targeted-only). `script` discovery is not scaffolded — write the check definition by hand, see [Configuration Reference → Discovery Methods](configuration.md#discovery-methods) |
+| `--discovery <method>` | Discovery method: `semgrep`, `opengrep`, `sarif`, `openant`, `glob`, or `script` (required for `targeted` and `static` types; `sarif`, `openant`, `glob`, and `script` are targeted-only) |
 | `--analysis-mode <mode>` | Analysis mode for targeted checks: `custom` (default), `false-positive-validation`, or `general-vuln-discovery` |
+| `--script <path>` / `--script-type <type>` / `--output-format <format>` | For `script` discovery: the script path (relative to the check folder; omit to generate a starter script), the runtime (`node` or `bash`), and the stdout format (`lines`, `json-array`, or `json-object`). See [Script discovery](configuration.md#script-discovery) |
+| `--priority <n>` | Execution order (non-negative integer; lower runs first, unset runs last) |
+| `--match-file-types` / `--match-paths` / `--match-files` / `--match-tags` | `matchCriteria` sub-fields — dynamically match repositories in addition to the explicit `--repositories` list. See [Repository matching](configuration.md#dynamic-repository-matching) |
 | `--severity <level>` | `critical`, `high`, `medium`, `low`, or `informational` |
 | `--confidence <level>` | `high`, `medium`, or `low` |
 
-Run `aghast new-check --help` for the full list of flags including `--check-overview`, `--check-items`, `--pass-condition`, `--fail-condition`, `--flag-condition`, `--repositories`, `--semgrep-rules` / `--opengrep-rules` (aliases for the same flag — don't pass both in the same command), `--max-targets`, and `--language`.
+Run `aghast new-check --help` for the full list of flags including `--check-overview`, `--check-items`, `--pass-condition`, `--fail-condition`, `--flag-condition`, `--repositories`, `--semgrep-rules` / `--opengrep-rules` (aliases for the same flag — don't pass both in the same command), `--max-targets`, `--language`, `--cwd`, and `--timeout-ms`.
 
 ## What gets created
 
@@ -38,8 +41,9 @@ Running `new-check` creates a check folder in `<config-dir>/checks/<check-id>/` 
 - `<id>.md` - markdown instructions for AI analysis (not created for `static` checks or targeted checks using a built-in analysis mode)
 - `<id>.yaml` - Semgrep/Opengrep rule file (for checks with `semgrep` or `opengrep` discovery — both tools share the same rule syntax)
 - `tests/` - Semgrep/Opengrep rule test files (for checks with `semgrep` or `opengrep` discovery)
+- `<id>.js` / `<id>.sh` - starter discovery script (for `script` discovery, when you don't point `--script` at an existing file). It documents the output contract in comments and prints an empty target set — edit it before running. See [Script discovery](configuration.md#script-discovery) for the trust model and output formats
 
-The check is also registered in `checks-config.json`.
+The check is also registered in `checks-config.json`. When you provide `--priority` or any `--match-*` flag, the registry entry also gets `priority` / `matchCriteria` (both Layer 1 fields).
 
 ## Check definition schema
 
@@ -47,7 +51,7 @@ See the [Configuration Reference](configuration.md#layer-2-check-definition-idjs
 
 ## Diff filtering
 
-Every targeted/static check you create automatically participates in [diff filtering](configuration.md#diff-filtering) when the scan is invoked with a diff source (e.g. `--diff-ref`, `AGHAST_DIFF_REF` in a PR workflow). Nothing in the check JSON is required to opt in. If a specific check should stay full-repo even during a diff-scoped scan, set `"diffFilter": false` on its `checkTarget`. See the [Configuration Reference](configuration.md#diff-filtering) for details.
+Every targeted/static check whose discovery supports it (`semgrep`, `opengrep`, `sarif`, `openant`) automatically participates in [diff filtering](configuration.md#diff-filtering) when the scan is invoked with a diff source (e.g. `--diff-ref`, `AGHAST_DIFF_REF` in a PR workflow) — nothing in the check JSON is required to opt in. `glob` and `script` discovery do not support diff filtering (`checkTarget.diffFilter` has no effect for them) and always run full-repo. If a specific check with a supporting discovery should stay full-repo even during a diff-scoped scan, set `"diffFilter": false` on its `checkTarget`. See the [Configuration Reference](configuration.md#diff-filtering) for details.
 
 ---
 

--- a/src/new-check.ts
+++ b/src/new-check.ts
@@ -64,6 +64,16 @@ interface ParsedFlags {
   analysisMode?: string;
   maxTargets?: string;
   language?: string;
+  script?: string;
+  scriptType?: string;
+  outputFormat?: string;
+  cwd?: string;
+  timeoutMs?: string;
+  priority?: string;
+  matchFileTypes?: string;
+  matchPaths?: string;
+  matchFiles?: string;
+  matchTags?: string;
   configDir?: string;
 }
 
@@ -88,6 +98,16 @@ const CLI_FLAG_MAP: Record<string, keyof ParsedFlags> = {
   '--analysis-mode': 'analysisMode',
   '--max-targets': 'maxTargets',
   '--language': 'language',
+  '--script': 'script',
+  '--script-type': 'scriptType',
+  '--output-format': 'outputFormat',
+  '--cwd': 'cwd',
+  '--timeout-ms': 'timeoutMs',
+  '--priority': 'priority',
+  '--match-file-types': 'matchFileTypes',
+  '--match-paths': 'matchPaths',
+  '--match-files': 'matchFiles',
+  '--match-tags': 'matchTags',
   '--config-dir': 'configDir',
 };
 
@@ -173,6 +193,14 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
     process.exit(1);
   }
 
+  // Yes/no gate. Defaults to "no" on empty input. Non-interactive callers never
+  // reach this (they gate on whether flags were supplied instead).
+  async function askYesNo(label: string): Promise<boolean> {
+    if (!rl) return false;
+    const answer = await rl.question(`${label} (y/N): `);
+    return /^y(es)?$/i.test(answer.trim());
+  }
+
   // Phase 1: Basic identity
   const result = {
     id: await ask('Check ID (e.g. aghast-xss)', flags.id),
@@ -194,6 +222,16 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
     glob: '',
     maxTargets: '',
     language: '',
+    script: '',
+    scriptType: '',
+    outputFormat: '',
+    cwd: '',
+    timeoutMs: '',
+    priority: '',
+    matchFileTypes: '',
+    matchPaths: '',
+    matchFiles: '',
+    matchTags: '',
   };
 
   // Phase 2: Check type, discovery, and analysis mode (determines what other questions to ask)
@@ -201,7 +239,7 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
 
   if (result.checkType === 'targeted' || result.checkType === 'static') {
     const discoveryChoices = result.checkType === 'targeted'
-      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob']
+      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob', 'script']
       : ['semgrep', 'opengrep'];
     result.discovery = await askChoice('Discovery method', discoveryChoices, 'semgrep', flags.discovery);
     result.maxTargets = await askOptional('Max targets', flags.maxTargets);
@@ -210,9 +248,10 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
       let modeChoices: string[];
       if (result.discovery === 'openant') {
         modeChoices = ['custom', 'general-vuln-discovery'];
-      } else if (result.discovery === 'glob') {
-        // glob discovery does not support false-positive-validation (no per-target
-        // finding to validate); offer custom and general-vuln-discovery.
+      } else if (result.discovery === 'glob' || result.discovery === 'script') {
+        // glob/script discovery do not support false-positive-validation (no
+        // per-target tool finding to validate); offer custom and
+        // general-vuln-discovery.
         modeChoices = ['custom', 'general-vuln-discovery'];
       } else {
         modeChoices = ['custom', 'false-positive-validation', 'general-vuln-discovery'];
@@ -238,6 +277,18 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
       result.glob = flags.glob !== undefined
         ? flags.glob
         : await ask('Glob pattern (e.g. src/routes/**/*.ts)', flags.glob);
+    } else if (result.discovery === 'script') {
+      result.scriptType = await askChoice('Script runtime', ['node', 'bash'], 'node', flags.scriptType);
+      result.outputFormat = await askChoice(
+        'Script output format', ['lines', 'json-array', 'json-object'], 'json-array', flags.outputFormat,
+      );
+      // Empty script path means "generate a starter script" (mirrors the
+      // semgrep-rules empty→template behaviour above).
+      result.script = flags.script !== undefined
+        ? flags.script
+        : await askOptional('Script file path (relative to check folder, or Enter to generate a starter script)', undefined);
+      result.cwd = await askOptional('Working directory (relative to repo root, default: repo root)', flags.cwd);
+      result.timeoutMs = await askOptional('Script timeout in ms (default: 30000)', flags.timeoutMs);
     }
   }
 
@@ -246,6 +297,29 @@ async function promptForMissing(flags: ParsedFlags): Promise<Required<Omit<Parse
   result.confidence = await askChoice('Confidence', ['high', 'medium', 'low'], 'medium', flags.confidence);
   result.model = flags.model !== undefined ? flags.model : await askOptional(`AI model override (default: ${DEFAULT_MODEL})`, undefined);
   result.repositories = flags.repositories !== undefined ? flags.repositories : await askOptional('Repositories (comma-separated URLs, or empty for all)', undefined);
+
+  // Phase 3.5: Registry-level fields (Layer 1) — execution ordering and dynamic
+  // repository matching. Apply to every check type.
+  result.priority = flags.priority !== undefined
+    ? flags.priority
+    : await askOptional('Execution priority (non-negative integer, lower runs first)', undefined);
+
+  const matchFlagsProvided =
+    flags.matchFileTypes !== undefined || flags.matchPaths !== undefined ||
+    flags.matchFiles !== undefined || flags.matchTags !== undefined;
+  if (matchFlagsProvided) {
+    // Non-interactive / flag-driven: take whatever flags were supplied.
+    result.matchFileTypes = flags.matchFileTypes ?? '';
+    result.matchPaths = flags.matchPaths ?? '';
+    result.matchFiles = flags.matchFiles ?? '';
+    result.matchTags = flags.matchTags ?? '';
+  } else if (await askYesNo('Add repository match criteria?')) {
+    // Interactive gate said yes — prompt for each sub-field.
+    result.matchFileTypes = await askOptional('  Match file types (comma-separated extensions, e.g. .ts,.tsx)', undefined);
+    result.matchPaths = await askOptional('  Match paths (comma-separated glob patterns; any match)', undefined);
+    result.matchFiles = await askOptional('  Require files (comma-separated paths/globs; all must exist)', undefined);
+    result.matchTags = await askOptional('  Require tags (comma-separated; all must be present)', undefined);
+  }
 
   // Phase 4: Instructions (only for check types/modes that need custom instructions)
   const builtInAnalysisMode = result.analysisMode === 'false-positive-validation'
@@ -283,7 +357,7 @@ async function loadExistingRegistry(registryPath: string): Promise<RegistryFile>
 }
 
 function validateInputs(
-  inputs: { id: string; severity: string; confidence: string; checkType: string; discovery: string; analysisMode: string; maxTargets: string; language: string; sarifFile: string; glob: string },
+  inputs: { id: string; severity: string; confidence: string; checkType: string; discovery: string; analysisMode: string; maxTargets: string; language: string; sarifFile: string; glob: string; scriptType: string; outputFormat: string; timeoutMs: string; priority: string; matchFileTypes: string; matchPaths: string; matchFiles: string; matchTags: string },
 ): string[] {
   const errors: string[] = [];
 
@@ -313,9 +387,39 @@ function validateInputs(
     }
   }
 
+  if (inputs.timeoutMs) {
+    const parsed = parseInt(inputs.timeoutMs, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      errors.push(`Invalid timeoutMs "${inputs.timeoutMs}". Must be a positive integer`);
+    }
+  }
+
+  if (inputs.priority) {
+    const parsed = parseInt(inputs.priority, 10);
+    if (isNaN(parsed) || parsed < 0 || String(parsed) !== inputs.priority.trim()) {
+      errors.push(`Invalid priority "${inputs.priority}". Must be a non-negative integer`);
+    }
+  }
+
+  // A blank/whitespace/comma-only match-* value would otherwise scaffold an
+  // empty-array matchCriteria sub-field, which fails loadCheckRegistry's
+  // "at least one of ..." check for the *whole* registry, not just this
+  // check. Reject it here instead, at scaffold time.
+  const matchFieldChecks: Array<[label: string, raw: string, split: string[]]> = [
+    ['--match-file-types', inputs.matchFileTypes, splitList(inputs.matchFileTypes)],
+    ['--match-paths', inputs.matchPaths, splitGlobList(inputs.matchPaths)],
+    ['--match-files', inputs.matchFiles, splitGlobList(inputs.matchFiles)],
+    ['--match-tags', inputs.matchTags, splitList(inputs.matchTags)],
+  ];
+  for (const [label, raw, split] of matchFieldChecks) {
+    if (raw && split.length === 0) {
+      errors.push(`${label} "${raw}" contains no usable values after parsing; provide at least one non-empty, comma-separated value or omit the flag`);
+    }
+  }
+
   if ((inputs.checkType === 'targeted' || inputs.checkType === 'static') && inputs.checkType) {
     const validDiscoveries = inputs.checkType === 'targeted'
-      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob']
+      ? ['semgrep', 'opengrep', 'openant', 'sarif', 'glob', 'script']
       : ['semgrep', 'opengrep'];
     if (!inputs.discovery || !validDiscoveries.includes(inputs.discovery)) {
       errors.push(`Invalid discovery "${inputs.discovery}" for check type "${inputs.checkType}". Must be one of: ${validDiscoveries.join(', ')}`);
@@ -326,10 +430,20 @@ function validateInputs(
     if (inputs.discovery === 'glob' && !inputs.glob) {
       errors.push('glob pattern is required for glob discovery');
     }
+    if (inputs.discovery === 'script') {
+      const validScriptTypes = ['node', 'bash'];
+      if (!inputs.scriptType || !validScriptTypes.includes(inputs.scriptType)) {
+        errors.push(`Invalid scriptType "${inputs.scriptType}" for script discovery. Must be one of: ${validScriptTypes.join(', ')}`);
+      }
+      const validOutputFormats = ['lines', 'json-array', 'json-object'];
+      if (!inputs.outputFormat || !validOutputFormats.includes(inputs.outputFormat)) {
+        errors.push(`Invalid outputFormat "${inputs.outputFormat}" for script discovery. Must be one of: ${validOutputFormats.join(', ')}`);
+      }
+    }
 
     if (inputs.analysisMode) {
       let validModes: string[];
-      if (inputs.discovery === 'openant' || inputs.discovery === 'glob') {
+      if (inputs.discovery === 'openant' || inputs.discovery === 'glob' || inputs.discovery === 'script') {
         validModes = ['custom', 'general-vuln-discovery'];
       } else {
         validModes = ['custom', 'false-positive-validation', 'general-vuln-discovery'];
@@ -384,6 +498,94 @@ ${comment} TODO: Add code that should NOT be matched by the rule
 `;
 }
 
+// --- Script Discovery Template ---
+
+/** File extension for a generated starter discovery script. */
+function scriptExtension(scriptType: string): string {
+  return scriptType === 'bash' ? '.sh' : '.js';
+}
+
+/**
+ * Generate a starter discovery script for `script` discovery. The body matches
+ * the chosen `outputFormat` and the output contract is documented in comments
+ * (see docs/configuration.md#script-discovery).
+ */
+function generateDiscoveryScript(
+  checkId: string,
+  scriptType: 'node' | 'bash',
+  outputFormat: 'lines' | 'json-array' | 'json-object',
+): string {
+  if (scriptType === 'bash') {
+    // Runs in the target repo (cwd = repo root by default). Print targets to
+    // stdout; write diagnostics to stderr. A non-zero exit fails the check.
+    const header = `#!/usr/bin/env bash
+# Discovery script for ${checkId}.
+# Runs inside the target repo (cwd = repo root by default).
+# Output contract: print discovery targets to stdout in the "${outputFormat}" format.
+#   - Only the "file" field is required; it must be a repo-relative path that
+#     stays inside the repo (no absolute paths, no ".." escape).
+#   - Optional fields: startLine, endLine, message, snippet.
+# Write diagnostics to stderr. A non-zero exit status fails the check.
+# The environment is curated: API keys/tokens are NOT available to this script.
+set -euo pipefail
+`;
+    if (outputFormat === 'lines') {
+      return `${header}
+# TODO: replace with real discovery logic — one repo-relative file path per line.
+# printf '%s\\n' 'src/example.ts'
+`;
+    }
+    if (outputFormat === 'json-object') {
+      return `${header}
+# TODO: replace with real discovery logic — emit a JSON object with a "targets" array.
+echo '{ "targets": [] }'
+`;
+    }
+    return `${header}
+# TODO: replace with real discovery logic — emit a JSON array of target objects.
+# echo '[{ "file": "src/example.ts", "startLine": 1, "endLine": 20, "message": "example target" }]'
+echo '[]'
+`;
+  }
+
+  // node
+  const header = `#!/usr/bin/env node
+// Discovery script for ${checkId}.
+// Runs inside the target repo (cwd = repo root by default).
+// Output contract: print discovery targets to stdout in the "${outputFormat}" format.
+//   - Only the "file" field is required; it must be a repo-relative path that
+//     stays inside the repo (no absolute paths, no ".." escape).
+//   - Optional fields: startLine, endLine, message, snippet.
+// Write diagnostics to stderr (console.error). A non-zero exit fails the check.
+// The environment is curated: API keys/tokens are NOT available to this script.
+`;
+  if (outputFormat === 'lines') {
+    return `${header}
+// TODO: replace with real discovery logic — one repo-relative file path per line.
+const files = [
+  // 'src/example.ts',
+];
+process.stdout.write(files.join('\\n'));
+`;
+  }
+  if (outputFormat === 'json-object') {
+    return `${header}
+// TODO: replace with real discovery logic.
+const targets = [
+  // { file: 'src/example.ts', startLine: 1, endLine: 20, message: 'example target' },
+];
+process.stdout.write(JSON.stringify({ targets }));
+`;
+  }
+  return `${header}
+// TODO: replace with real discovery logic.
+const targets = [
+  // { file: 'src/example.ts', startLine: 1, endLine: 20, message: 'example target' },
+];
+process.stdout.write(JSON.stringify(targets));
+`;
+}
+
 // --- File Generation ---
 
 function generateMarkdown(inputs: {
@@ -431,6 +633,11 @@ function generateCheckDefinition(inputs: {
   semgrepRules: string;
   sarifFile: string;
   glob: string;
+  script: string;
+  scriptType: string;
+  outputFormat: string;
+  cwd: string;
+  timeoutMs: string;
   maxTargets: string;
 }): Record<string, unknown> {
   const def: Record<string, unknown> = {
@@ -472,6 +679,19 @@ function generateCheckDefinition(inputs: {
       checkTarget.sarifFile = inputs.sarifFile;
     } else if (inputs.discovery === 'glob') {
       checkTarget.glob = inputs.glob;
+    } else if (inputs.discovery === 'script') {
+      // When no explicit script path is given, a starter script named after the
+      // check id + runtime extension is generated (see runNewCheck).
+      const scriptType = (inputs.scriptType || 'node') as 'node' | 'bash';
+      checkTarget.script = inputs.script || `${inputs.id}${scriptExtension(scriptType)}`;
+      checkTarget.scriptType = scriptType;
+      checkTarget.outputFormat = inputs.outputFormat || 'json-array';
+      if (inputs.cwd) {
+        checkTarget.cwd = inputs.cwd;
+      }
+      if (inputs.timeoutMs) {
+        checkTarget.timeoutMs = parseInt(inputs.timeoutMs, 10);
+      }
     }
     if (inputs.analysisMode && inputs.analysisMode !== 'custom') {
       checkTarget.analysisMode = inputs.analysisMode;
@@ -485,17 +705,73 @@ function generateCheckDefinition(inputs: {
   return def;
 }
 
+/** Split a comma-separated flag value into a trimmed, non-empty list. */
+function splitList(value: string): string[] {
+  return value.split(',').map((v) => v.trim()).filter(Boolean);
+}
+
+/**
+ * Split a comma-separated list of glob patterns, brace-aware: commas inside
+ * `{...}` brace-expansion groups (e.g. `src/**\/*.{ts,tsx}`) are not treated
+ * as list separators, so a single pattern using brace expansion survives
+ * intact instead of being torn into two malformed patterns. Otherwise
+ * behaves like splitList (trims and drops empty segments).
+ */
+function splitGlobList(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of value) {
+    if (char === '{') depth++;
+    else if (char === '}') depth = Math.max(0, depth - 1);
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+  return parts.map((v) => v.trim()).filter(Boolean);
+}
+
 function generateRegistryEntry(inputs: {
   id: string;
   repositories: string;
+  priority: string;
+  matchFileTypes: string;
+  matchPaths: string;
+  matchFiles: string;
+  matchTags: string;
 }): Record<string, unknown> {
-  return {
+  const entry: Record<string, unknown> = {
     id: inputs.id,
-    repositories: inputs.repositories
-      ? inputs.repositories.split(',').map((r) => r.trim()).filter(Boolean)
-      : [],
+    repositories: inputs.repositories ? splitList(inputs.repositories) : [],
     enabled: true,
   };
+
+  if (inputs.priority) {
+    entry.priority = parseInt(inputs.priority, 10);
+  }
+
+  // matchCriteria (Layer 1) — include only the sub-fields that produced at
+  // least one item after splitting (a blank/whitespace/comma-only value must
+  // not scaffold an empty array — see validateInputs, which rejects that
+  // case before we get here).
+  const matchCriteria: Record<string, string[]> = {};
+  const fileTypes = splitList(inputs.matchFileTypes);
+  const paths = splitGlobList(inputs.matchPaths);
+  const files = splitGlobList(inputs.matchFiles);
+  const tags = splitList(inputs.matchTags);
+  if (fileTypes.length > 0) matchCriteria.hasFileTypes = fileTypes;
+  if (paths.length > 0) matchCriteria.hasPaths = paths;
+  if (files.length > 0) matchCriteria.hasFiles = files;
+  if (tags.length > 0) matchCriteria.tags = tags;
+  if (Object.keys(matchCriteria).length > 0) {
+    entry.matchCriteria = matchCriteria;
+  }
+
+  return entry;
 }
 
 // --- Main ---
@@ -527,9 +803,20 @@ Options:
   --opengrep-rules <paths>   Alias for --semgrep-rules; do not pass both (error)
   --sarif-file <path>        SARIF file path in check definition, relative to repo (for sarif discovery)
   --glob <pattern>           Glob pattern (for glob discovery, e.g. "src/routes/**/*.ts")
+  --script <path>            Script path relative to the check folder (for script
+                             discovery; omit to generate a starter script)
+  --script-type <type>       Script runtime: node or bash (for script discovery)
+  --output-format <format>   Script stdout format: lines, json-array, json-object
+  --cwd <path>               Working directory for the script, relative to repo root
+  --timeout-ms <n>           Script timeout in milliseconds (default: 30000)
   --analysis-mode <mode>     Analysis mode for targeted checks (default: custom). See below
   --max-targets <n>          Maximum number of targets to analyze
   --language <lang>          Language for Semgrep/Opengrep template: python, javascript, typescript
+  --priority <n>             Execution order (non-negative integer, lower runs first)
+  --match-file-types <exts>  matchCriteria: comma-separated file extensions (e.g. .ts,.tsx)
+  --match-paths <globs>      matchCriteria: comma-separated glob patterns (any match)
+  --match-files <paths>      matchCriteria: comma-separated paths/globs (all must exist)
+  --match-tags <tags>        matchCriteria: comma-separated repo tags (all must be present)
   -h, --help                 Show this help message
 
 Environment variables:
@@ -546,17 +833,24 @@ Discovery mechanisms:
   openant     OpenAnt code analysis finds units (targeted only)
   sarif       External SARIF file provides findings (targeted only)
   glob        File path glob pattern selects whole-file targets (targeted only)
+  script      User-provided node/bash script emits targets (targeted only)
 
 Analysis modes (targeted checks only):
   custom                      Use a custom instructions markdown file (default)
   false-positive-validation   AI validates each finding as true/false positive (semgrep, opengrep, sarif)
   general-vuln-discovery      AI scans each target for general security vulnerabilities (all)
 
+Repository matching / ordering (registry-level, all check types):
+  --priority                  Lower values run first; unset checks run last
+  --match-*                   Add repos dynamically via matchCriteria in addition to
+                              the explicit --repositories list
+
 Examples:
   aghast new-check --config-dir ./my-checks
   aghast new-check --config-dir ./my-checks --id xss --name "XSS Prevention"
   aghast new-check --config-dir ./my-checks --check-type targeted --discovery semgrep --language typescript
   aghast new-check --config-dir ./my-checks --check-type targeted --discovery sarif --sarif-file ./sast-results.sarif
+  aghast new-check --config-dir ./my-checks --check-type targeted --discovery script --script-type node --output-format json-array
 
 ${docsFooter('creating-checks.md')}`;
 
@@ -602,6 +896,15 @@ export async function runNewCheck(args: string[]): Promise<void> {
       console.error(formatError(ERROR_CODES.E2004, err));
     }
     process.exit(1);
+  }
+
+  // Script discovery with scriptType "bash" can never run on Windows
+  // (E7106) — warn now, at scaffold time, rather than let the author
+  // discover it only after a failed scan.
+  if (inputs.discovery === 'script' && (inputs.scriptType || 'node') === 'bash' && process.platform === 'win32') {
+    console.warn(
+      `Warning: --script-type bash is not supported on Windows (${ERROR_CODES.E7106.code}); this check will fail at scan time on this machine. Use --script-type node, or run scans from Linux/macOS/WSL.`,
+    );
   }
 
   // Create check folder
@@ -651,6 +954,16 @@ export async function runNewCheck(args: string[]): Promise<void> {
       await writeFile(testPath, generateSemgrepTestFile(inputs.id, inputs.language), 'utf-8');
       console.log(`Created: ${checkFolder}/tests/${testFileName} (test scaffold — edit before running)`);
     }
+  }
+
+  // Generate a starter discovery script when the author didn't supply their own.
+  if (inputs.discovery === 'script' && !inputs.script) {
+    const scriptType = (inputs.scriptType || 'node') as 'node' | 'bash';
+    const outputFormat = (inputs.outputFormat || 'json-array') as 'lines' | 'json-array' | 'json-object';
+    const scriptName = `${inputs.id}${scriptExtension(scriptType)}`;
+    const scriptPath = resolve(checkFolder, scriptName);
+    await writeFile(scriptPath, generateDiscoveryScript(inputs.id, scriptType, outputFormat), 'utf-8');
+    console.log(`Created: ${checkFolder}/${scriptName} (starter script — edit before running)`);
   }
 
   // Update registry (Layer 1)

--- a/tests/new-check.test.ts
+++ b/tests/new-check.test.ts
@@ -690,6 +690,8 @@ describe('new-check utility', () => {
         '',                     // Confidence (default: medium)
         '',                     // Model (optional, skip)
         '',                     // Repositories (optional, skip)
+        '',                     // Priority (optional, skip)
+        '',                     // Add repository match criteria? (y/N — skip)
         'Overview text',        // Check overview
         'Item A,Item B',        // Check items
         'All good',             // PASS condition
@@ -979,5 +981,325 @@ describe('new-check utility', () => {
     const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
     assert.equal(checkDef.checkTarget.discovery, 'glob');
     assert.equal(checkDef.checkTarget.maxTargets, 40);
+  });
+
+  // ─── Targeted script checks (issue #350) ─
+
+  it('targeted script (node/json-array) creates checkTarget and generates starter script', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'json-array',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.type, 'targeted');
+    assert.equal(checkDef.checkTarget.discovery, 'script');
+    assert.equal(checkDef.checkTarget.scriptType, 'node');
+    assert.equal(checkDef.checkTarget.outputFormat, 'json-array');
+    assert.equal(checkDef.checkTarget.script, 'aghast-test.js', 'script defaults to <id>.js');
+    assert.equal(checkDef.instructionsFile, 'aghast-test.md', 'script discovery requires instructionsFile by default');
+    assert.equal(checkDef.checkTarget.rules, undefined, 'script should not have rules');
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(resolve(checksDir, 'aghast-test'));
+    assert.ok(files.includes('aghast-test.js'), 'should generate starter script');
+    assert.ok(files.includes('aghast-test.md'), 'should generate instructions .md');
+    assert.ok(!files.includes('aghast-test.yaml'), 'script should not generate Semgrep yaml');
+
+    // The generated node script runs and emits an empty json-array.
+    const scriptOut = await new Promise<string>((res) => {
+      execFile(process.execPath, [resolve(checksDir, 'aghast-test', 'aghast-test.js')], (_e, stdout) => res(stdout));
+    });
+    assert.equal(scriptOut.trim(), '[]', 'starter json-array script should print []');
+  });
+
+  it('targeted script (node/lines) starter script emits repo-relative paths, one per line', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'lines',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const scriptPath = resolve(checksDir, 'aghast-test', 'aghast-test.js');
+    const scriptOut = await new Promise<string>((res) => {
+      execFile(process.execPath, [scriptPath], (_e, stdout) => res(stdout));
+    });
+    assert.equal(scriptOut.trim(), '', 'starter lines script should print nothing for the empty starter file list');
+
+    const content = await readFile(scriptPath, 'utf-8');
+    assert.match(content, /files\.join\('\\n'\)/, 'lines template should join the file list with newlines');
+  });
+
+  it('targeted script (node/json-object) starter script emits an empty targets object', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'json-object',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const scriptPath = resolve(checksDir, 'aghast-test', 'aghast-test.js');
+    const scriptOut = await new Promise<string>((res) => {
+      execFile(process.execPath, [scriptPath], (_e, stdout) => res(stdout));
+    });
+    assert.equal(scriptOut.trim(), '{"targets":[]}', 'starter json-object script should print { targets: [] }');
+  });
+
+  // bash scriptType can't be executed on Windows CI runners (E7106), so these
+  // assert the generated file *content* directly instead of running it —
+  // mirroring how the Semgrep-rule template tests check file contents
+  // without invoking Semgrep.
+
+  it('targeted script (bash/lines) generates a starter script with the lines output contract', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'bash',
+      '--output-format': 'lines',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.script, 'aghast-test.sh', 'bash script defaults to <id>.sh');
+
+    const content = await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.sh'), 'utf-8');
+    assert.match(content, /^#!\/usr\/bin\/env bash/, 'bash script should have a bash shebang');
+    assert.match(content, /set -euo pipefail/, 'bash script should fail fast on errors');
+    assert.match(content, /one repo-relative file path per line/, 'lines template should describe the lines contract');
+  });
+
+  it('targeted script (bash/json-array) generates a starter script that echoes an empty array', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'bash',
+      '--output-format': 'json-array',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const content = await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.sh'), 'utf-8');
+    assert.match(content, /echo '\[\]'/, 'json-array bash template should echo an empty array');
+  });
+
+  it('targeted script (bash/json-object) generates a starter script that echoes an empty targets object', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'bash',
+      '--output-format': 'json-object',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const content = await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.sh'), 'utf-8');
+    assert.match(content, /echo '\{ "targets": \[\] \}'/, 'json-object bash template should echo an empty targets object');
+  });
+
+  it('warns when scaffolding a bash script check on Windows, since it will fail at scan time (E7106)', async (t) => {
+    if (process.platform !== 'win32') {
+      t.skip('Windows-only warning; not applicable on this platform');
+      return;
+    }
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'bash',
+      '--output-format': 'json-array',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+    assert.ok(
+      result.stderr.includes('bash') && result.stderr.includes('Windows') && result.stderr.includes('E7106'),
+      `Expected a bash-on-Windows warning referencing E7106, got: ${result.stderr}`,
+    );
+  });
+
+  it('targeted script with general-vuln-discovery skips instructionsFile and .md', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'json-array',
+      '--analysis-mode': 'general-vuln-discovery',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.analysisMode, 'general-vuln-discovery');
+    assert.equal(checkDef.instructionsFile, undefined, 'built-in mode does not need instructionsFile');
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(resolve(checksDir, 'aghast-test'));
+    assert.ok(!files.includes('aghast-test.md'), 'built-in mode should not generate .md file');
+    assert.ok(files.includes('aghast-test.js'), 'should still generate starter script');
+  });
+
+  it('targeted script with explicit --script does not generate a starter script', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'lines',
+      '--script': 'find-targets.js',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.script, 'find-targets.js', 'should use the supplied script path');
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(resolve(checksDir, 'aghast-test'));
+    assert.ok(!files.includes('aghast-test.js'), 'should not generate a template when --script is supplied');
+  });
+
+  it('targeted script includes cwd and timeoutMs when provided', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'json-object',
+      '--cwd': 'server',
+      '--timeout-ms': '60000',
+    }));
+
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const checkDef = JSON.parse(await readFile(resolve(checksDir, 'aghast-test', 'aghast-test.json'), 'utf-8'));
+    assert.equal(checkDef.checkTarget.outputFormat, 'json-object');
+    assert.equal(checkDef.checkTarget.cwd, 'server');
+    assert.equal(checkDef.checkTarget.timeoutMs, 60000);
+  });
+
+  it('targeted script rejects false-positive-validation analysis mode', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'json-array',
+      '--analysis-mode': 'false-positive-validation',
+    }));
+
+    assert.notEqual(result.exitCode, 0, 'Should reject false-positive-validation for script discovery');
+    assert.ok(
+      result.stderr.includes('Invalid analysis mode'),
+      `Expected analysis mode error, got: ${result.stderr}`,
+    );
+  });
+
+  it('targeted script rejects an invalid output format', async () => {
+    const result = await runNewCheck(allFlags({
+      '--check-type': 'targeted',
+      '--discovery': 'script',
+      '--script-type': 'node',
+      '--output-format': 'yaml',
+    }));
+
+    assert.notEqual(result.exitCode, 0, 'Should reject an unknown output format');
+    assert.ok(
+      result.stderr.includes('Invalid outputFormat'),
+      `Expected outputFormat error, got: ${result.stderr}`,
+    );
+  });
+
+  // ─── priority / matchCriteria (registry-level, issue #350) ─
+
+  it('writes priority into the registry entry', async () => {
+    const result = await runNewCheck(allFlags({ '--priority': '5' }));
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    const entry = registry.checks.find((c: { id: string }) => c.id === 'aghast-test');
+    assert.equal(entry.priority, 5);
+  });
+
+  it('rejects a negative priority', async () => {
+    const result = await runNewCheck(allFlags({ '--priority': '-1' }));
+    assert.notEqual(result.exitCode, 0, 'Should reject a negative priority');
+    assert.ok(result.stderr.includes('Invalid priority'), `Expected priority error, got: ${result.stderr}`);
+  });
+
+  it('rejects a non-integer priority', async () => {
+    const result = await runNewCheck(allFlags({ '--priority': 'abc' }));
+    assert.notEqual(result.exitCode, 0, 'Should reject a non-integer priority');
+    assert.ok(result.stderr.includes('Invalid priority'), `Expected priority error, got: ${result.stderr}`);
+  });
+
+  it('writes matchCriteria with only the provided sub-fields', async () => {
+    const result = await runNewCheck(allFlags({
+      '--match-file-types': '.ts,.tsx',
+      '--match-tags': 'backend,api',
+    }));
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    const entry = registry.checks.find((c: { id: string }) => c.id === 'aghast-test');
+    assert.deepEqual(entry.matchCriteria.hasFileTypes, ['.ts', '.tsx']);
+    assert.deepEqual(entry.matchCriteria.tags, ['backend', 'api']);
+    assert.equal(entry.matchCriteria.hasPaths, undefined, 'absent sub-fields are omitted');
+    assert.equal(entry.matchCriteria.hasFiles, undefined, 'absent sub-fields are omitted');
+  });
+
+  it('rejects a blank/comma-only --match-file-types value instead of scaffolding an empty matchCriteria array', async () => {
+    const result = await runNewCheck(allFlags({
+      '--match-file-types': ' , ',
+    }));
+    assert.notEqual(result.exitCode, 0, 'Should reject a match-file-types value with no usable entries after parsing');
+    assert.ok(
+      result.stderr.includes('--match-file-types') && result.stderr.includes('no usable values'),
+      `Expected a match-file-types parsing error, got: ${result.stderr}`,
+    );
+
+    // The registry must be left untouched — no bad entry written that would
+    // later crash loadCheckRegistry for the entire config directory.
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    assert.equal(registry.checks.length, 0, 'no registry entry should be written when validation fails');
+  });
+
+  it('rejects a comma-only --match-paths / --match-tags value the same way', async () => {
+    const result = await runNewCheck(allFlags({
+      '--match-paths': ',,',
+      '--match-tags': ' ',
+    }));
+    assert.notEqual(result.exitCode, 0, 'Should reject match-paths/match-tags values with no usable entries');
+    assert.ok(result.stderr.includes('--match-paths'), `Expected a match-paths error, got: ${result.stderr}`);
+    assert.ok(result.stderr.includes('--match-tags'), `Expected a match-tags error, got: ${result.stderr}`);
+  });
+
+  it('preserves brace-expansion glob patterns in --match-paths instead of splitting on the internal comma', async () => {
+    const result = await runNewCheck(allFlags({
+      '--match-paths': 'src/**/*.{ts,tsx},docs/**/*.md',
+    }));
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    const entry = registry.checks.find((c: { id: string }) => c.id === 'aghast-test');
+    assert.deepEqual(
+      entry.matchCriteria.hasPaths,
+      ['src/**/*.{ts,tsx}', 'docs/**/*.md'],
+      'the brace-expansion pattern should survive as one entry, not be torn apart at the internal comma',
+    );
+  });
+
+  it('omits matchCriteria and priority when not provided', async () => {
+    const result = await runNewCheck(allFlags());
+    assert.equal(result.exitCode, 0, `CLI failed: ${result.stderr}`);
+
+    const registry = JSON.parse(await readFile(registryPath, 'utf-8'));
+    const entry = registry.checks.find((c: { id: string }) => c.id === 'aghast-test');
+    assert.equal(entry.matchCriteria, undefined, 'no matchCriteria key when unset');
+    assert.equal(entry.priority, undefined, 'no priority key when unset');
   });
 });


### PR DESCRIPTION
Extends `aghast new-check` so more of a check's configuration can be scaffolded from the CLI instead of hand-editing JSON.

## What's new

- **Script discovery scaffolding.** `new-check --check-type targeted --discovery script` now generates a starter discovery script (Node.js or bash) wired to the output format you choose (`lines`, `json-array`, or `json-object`). The starter documents the output contract in comments and prints an empty target set, so you edit it before running. If `--script` points at an existing file, no starter is generated.
- **New script flags:** `--script`, `--script-type`, `--output-format`, `--cwd`, `--timeout-ms`.
- **Layer 1 registry fields.** `--priority <n>` sets execution order (lower runs first), and `--match-file-types` / `--match-paths` / `--match-files` / `--match-tags` populate `matchCriteria` for dynamic repository matching. When provided, these are written into the `checks-config.json` registry entry.
- **Docs** updated across Creating Checks and Configuration Reference to cover the new flags, the generated starter script, and which discoveries participate in diff filtering.

## Testing

- `npm test` in the public repo: 1349 passing, 3 skipped (integration tests), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)