### PR TITLE
chore(deps): apply security dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1722,9 +1722,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,13 +763,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "overrides": {
     "minimatch@<10.2.3": ">=10.2.3",
-    "@anthropic-ai/sdk@<0.91.1": ">=0.91.1"
+    "@anthropic-ai/sdk@<0.91.1": ">=0.91.1",
+    "@hono/node-server@<2.0.5": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "picomatch": "^4.0.4"
   },
   "overrides": {
-    "minimatch@<10.2.3": ">=10.2.3",
-    "@anthropic-ai/sdk@<0.91.1": ">=0.91.1",
     "@hono/node-server@<2.0.5": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "picomatch": "^4.0.4"
   },
   "overrides": {
-    "@hono/node-server@<2.0.5": "^2.0.5"
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
## Summary

- Bump [hono from 4.12.25 to 4.12.31](https://github.com/owasp-aghast/aghast/pull/144).
- Bump [fast-uri from 3.1.2 to 3.1.4](https://github.com/owasp-aghast/aghast/pull/143).
- Override [@hono/node-server onto the patched 2.x line](https://github.com/owasp-aghast/aghast/security/dependabot/31), resolving to 2.0.11 while MCP remains constrained to vulnerable 1.x releases.
- Remove obsolete minimatch and @anthropic-ai/sdk security overrides now that upstream ranges resolve patched versions naturally.

## Verification

- npm 10.9.2 clean install
- npm audit: 0 vulnerabilities
- npm run lint
- npm run build
- npm test: 1,383 passed; 3 skipped